### PR TITLE
Add EIP-2930 (type 0x01) transaction signing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Add Bitcoin PSBT signing support
 - Add Bitget multi-account export via crypto-multi-accounts UR
+- Add EIP-2930 (type 0x01) transaction signing support
 
 ### Fixed
 

--- a/__tests__/SecretsMenuScreen.test.tsx
+++ b/__tests__/SecretsMenuScreen.test.tsx
@@ -86,8 +86,12 @@ describe('SecretsMenuScreen', () => {
       const entry = getActivePressables(renderer).find(p =>
         extractText(p).includes('Change PIN'),
       );
-      await act(async () => { entry!.props.onPress(); });
-      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', { secretType: 'pin' });
+      await act(async () => {
+        entry!.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', {
+        secretType: 'pin',
+      });
     });
 
     it('navigates to ChangeSecret with puk secretType', async () => {
@@ -95,8 +99,12 @@ describe('SecretsMenuScreen', () => {
       const entry = getActivePressables(renderer).find(p =>
         extractText(p).includes('Change PUK'),
       );
-      await act(async () => { entry!.props.onPress(); });
-      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', { secretType: 'puk' });
+      await act(async () => {
+        entry!.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', {
+        secretType: 'puk',
+      });
     });
 
     it('navigates to ChangeSecret with pairing secretType', async () => {
@@ -104,8 +112,12 @@ describe('SecretsMenuScreen', () => {
       const entry = getActivePressables(renderer).find(p =>
         extractText(p).includes('Change Pairing Secret'),
       );
-      await act(async () => { entry!.props.onPress(); });
-      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', { secretType: 'pairing' });
+      await act(async () => {
+        entry!.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('ChangeSecret', {
+        secretType: 'pairing',
+      });
     });
   });
 

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -8,15 +8,20 @@ const VALID_PSBT_HEX = (() => {
   const { Psbt, payments, networks } = require('bitcoinjs-lib');
   const psbt = new Psbt({ network: networks.testnet });
   const fakePubkey = Buffer.alloc(33, 0x02);
-  const { output } = payments.p2wpkh({ pubkey: fakePubkey, network: networks.testnet });
+  const { output } = payments.p2wpkh({
+    pubkey: fakePubkey,
+    network: networks.testnet,
+  });
   psbt.addInput({
     hash: Buffer.alloc(32, 0xaa),
     index: 0,
-    bip32Derivation: [{
-      masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
-      path: "m/84'/1'/0'/0/0",
-      pubkey: fakePubkey,
-    }],
+    bip32Derivation: [
+      {
+        masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+        path: "m/84'/1'/0'/0/0",
+        pubkey: fakePubkey,
+      },
+    ],
   });
   psbt.addOutput({ script: output!, value: 90_000 });
   return psbt.toBuffer().toString('hex');
@@ -203,7 +208,10 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
 describe('TransactionDetailScreen – crypto-psbt result', () => {
   it('renders without crashing', async () => {
     await expect(
-      renderScreen({ kind: 'crypto-psbt', request: { psbtHex: VALID_PSBT_HEX } }),
+      renderScreen({
+        kind: 'crypto-psbt',
+        request: { psbtHex: VALID_PSBT_HEX },
+      }),
     ).resolves.toBeDefined();
   });
 

--- a/__tests__/btcPsbt.test.ts
+++ b/__tests__/btcPsbt.test.ts
@@ -22,7 +22,10 @@ const TESTNET_WPKH_PSBT_HEX = (() => {
   const psbt = new Psbt({ network: networks.testnet });
 
   const fakePubkey = Buffer.alloc(33, 0x02);
-  const { output } = payments.p2wpkh({ pubkey: fakePubkey, network: networks.testnet });
+  const { output } = payments.p2wpkh({
+    pubkey: fakePubkey,
+    network: networks.testnet,
+  });
 
   psbt.addInput({
     hash: Buffer.alloc(32, 0xaa),

--- a/__tests__/cryptoAccount.test.ts
+++ b/__tests__/cryptoAccount.test.ts
@@ -86,7 +86,9 @@ describe('buildCryptoAccountUR', () => {
     expect(decoder.isSuccess()).toBe(true);
 
     const cryptoAccount = decoder.resultRegistryType() as any;
-    expect(cryptoAccount.getMasterFingerprint().toString('hex')).toBe('aabbccdd');
+    expect(cryptoAccount.getMasterFingerprint().toString('hex')).toBe(
+      'aabbccdd',
+    );
 
     const descriptors = cryptoAccount.getOutputDescriptors();
     expect(descriptors).toHaveLength(3);

--- a/__tests__/ethSignature.test.ts
+++ b/__tests__/ethSignature.test.ts
@@ -140,6 +140,14 @@ describe('buildEthSignatureUR', () => {
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig[sig.length - 1]).toBe(27 + recId);
     });
+
+    it('EIP-2930 (txType=0x01, dataType=1): v equals recId, not EIP-155', () => {
+      // Without txType, dataType=1 chainId=1 would give v = 37 + recId
+      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 1, undefined, 0x01);
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig[sig.length - 1]).toBe(recId);
+      expect(sig[sig.length - 1]).not.toBe(37 + recId);
+    });
   });
 
   describe('CBOR map structure', () => {

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -1,0 +1,167 @@
+import { RLP } from '@ethereumjs/rlp';
+
+import { getTxLabel, parseTx } from '../src/utils/txParser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hexToBytes(hex: string): Buffer {
+  return Buffer.from(hex.replace(/^0x/, ''), 'hex');
+}
+
+function bigIntToMinBytes(n: bigint): Uint8Array {
+  if (n === 0n) return new Uint8Array(0);
+  const hex = n.toString(16).padStart(2, '0');
+  const padded = hex.length % 2 === 0 ? hex : '0' + hex;
+  return Buffer.from(padded, 'hex');
+}
+
+/** Build a legacy unsigned tx: RLP([nonce, gasPrice, gasLimit, to, value, data]) */
+function buildLegacyTxHex({
+  nonce = 1n,
+  gasPrice = 20_000_000_000n, // 20 Gwei
+  gasLimit = 21000n,
+  to = '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
+  value = 1_000_000_000_000_000_000n, // 1 ETH
+  data = new Uint8Array(0),
+} = {}): string {
+  const encoded = RLP.encode([
+    bigIntToMinBytes(nonce),
+    bigIntToMinBytes(gasPrice),
+    bigIntToMinBytes(gasLimit),
+    hexToBytes(to),
+    bigIntToMinBytes(value),
+    data,
+  ]);
+  return Buffer.from(encoded).toString('hex');
+}
+
+/** Build an EIP-2930 tx: 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]) */
+function buildEIP2930TxHex({
+  chainId = 1n,
+  nonce = 2n,
+  gasPrice = 15_000_000_000n, // 15 Gwei
+  gasLimit = 30000n,
+  to = '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
+  value = 500_000_000_000_000_000n, // 0.5 ETH
+  data = new Uint8Array(0),
+  accessList = [],
+} = {}): string {
+  const rlp = RLP.encode([
+    bigIntToMinBytes(chainId),
+    bigIntToMinBytes(nonce),
+    bigIntToMinBytes(gasPrice),
+    bigIntToMinBytes(gasLimit),
+    hexToBytes(to),
+    bigIntToMinBytes(value),
+    data,
+    accessList,
+  ]);
+  const bytes = new Uint8Array(1 + rlp.length);
+  bytes[0] = 0x01;
+  bytes.set(rlp, 1);
+  return Buffer.from(bytes).toString('hex');
+}
+
+// ---------------------------------------------------------------------------
+// parseTx
+// ---------------------------------------------------------------------------
+
+describe('parseTx', () => {
+  describe('legacy (dataType=1, no type prefix)', () => {
+    it('parses to address', () => {
+      const hex = buildLegacyTxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.to?.toLowerCase()).toBe(
+        '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
+      );
+    });
+
+    it('parses value as ETH string', () => {
+      const hex = buildLegacyTxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.value).toBe('1 ETH');
+    });
+
+    it('parses fees as legacy kind', () => {
+      const hex = buildLegacyTxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.fees.kind).toBe('legacy');
+      if (tx?.fees.kind === 'legacy') {
+        expect(tx.fees.gasPrice).toMatch(/Gwei/);
+        expect(tx.fees.gasLimit).toBe('21000');
+      }
+    });
+  });
+
+  describe('EIP-2930 (dataType=1, 0x01 prefix)', () => {
+    it('parses to address', () => {
+      const hex = buildEIP2930TxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.to?.toLowerCase()).toBe(
+        '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
+      );
+    });
+
+    it('parses value as ETH string', () => {
+      const hex = buildEIP2930TxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.value).toMatch(/ETH/);
+    });
+
+    it('parses fees as legacy kind (gasPrice)', () => {
+      const hex = buildEIP2930TxHex();
+      const tx = parseTx(hex, 1);
+      expect(tx?.fees.kind).toBe('legacy');
+      if (tx?.fees.kind === 'legacy') {
+        expect(tx.fees.gasPrice).toMatch(/Gwei/);
+        expect(tx.fees.gasLimit).toBe('30000');
+      }
+    });
+
+    it('parses nonce correctly', () => {
+      const hex = buildEIP2930TxHex({ nonce: 7n });
+      const tx = parseTx(hex, 1);
+      expect(tx?.nonce).toBe(7);
+    });
+  });
+
+  it('returns null for non-transaction dataType (EIP-712)', () => {
+    expect(parseTx('deadbeef', 2)).toBeNull();
+  });
+
+  it('returns null for malformed hex', () => {
+    expect(parseTx('zzzz', 1)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTxLabel
+// ---------------------------------------------------------------------------
+
+describe('getTxLabel', () => {
+  it('returns "EIP-2930 Transaction" for 0x01-prefixed dataType=1', () => {
+    expect(getTxLabel(buildEIP2930TxHex(), 1)).toBe('EIP-2930 Transaction');
+  });
+
+  it('returns "Legacy Transaction" for plain dataType=1', () => {
+    expect(getTxLabel(buildLegacyTxHex(), 1)).toBe('Legacy Transaction');
+  });
+
+  it('returns "EIP-1559 Transaction" for dataType=4', () => {
+    expect(getTxLabel('02' + 'deadbeef', 4)).toBe('EIP-1559 Transaction');
+  });
+
+  it('returns "EIP-712 Typed Data" for dataType=2', () => {
+    expect(getTxLabel('deadbeef', 2)).toBe('EIP-712 Typed Data');
+  });
+
+  it('returns "Personal Message" for dataType=3', () => {
+    expect(getTxLabel('deadbeef', 3)).toBe('Personal Message');
+  });
+
+  it('returns fallback for unknown dataType', () => {
+    expect(getTxLabel('deadbeef', 99)).toBe('Unknown (99)');
+  });
+});

--- a/__tests__/ur.test.ts
+++ b/__tests__/ur.test.ts
@@ -140,7 +140,10 @@ describe('parseEthSignRequest – derivation paths', () => {
 describe('handleUR – crypto-psbt', () => {
   function buildPsbtCbor(): Buffer {
     // Minimal valid PSBT: magic + empty global map
-    const psbtBytes = Buffer.from('70736274ff01000a0200000000000000000000', 'hex');
+    const psbtBytes = Buffer.from(
+      '70736274ff01000a0200000000000000000000',
+      'hex',
+    );
     return new CryptoPSBT(psbtBytes).toCBOR();
   }
 

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -1,8 +1,8 @@
 import { View, StyleSheet } from 'react-native';
 import { Icon, Text } from 'react-native-paper';
 import theme from '../theme';
-import { DATA_TYPE_LABELS, type EthSignRequest } from '../types';
-import { parseTx } from '../utils/txParser';
+import type { EthSignRequest } from '../types';
+import { getTxLabel, parseTx } from '../utils/txParser';
 import InfoRow from './InfoRow';
 
 const CHAIN_NAMES: Record<number, string> = {
@@ -33,8 +33,7 @@ export default function EthSignRequestDetail({
 }: {
   request: EthSignRequest;
 }) {
-  const typeLabel =
-    DATA_TYPE_LABELS[request.dataType] || `Unknown (${request.dataType})`;
+  const typeLabel = getTxLabel(request.signData, request.dataType);
   const tx = parseTx(request.signData, request.dataType);
 
   return (

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -23,8 +23,13 @@ function buildEthResultUR(
     dataType?: number;
     chainId?: number;
     requestId?: string;
+    signData?: string;
   },
 ): string {
+  const firstByte = params.signData
+    ? parseInt(params.signData.slice(0, 2), 16)
+    : undefined;
+  const txType = firstByte === 0x01 ? 0x01 : undefined;
   return buildEthSignatureUR(
     Array.from(result)
       .map(b => b.toString(16).padStart(2, '0'))
@@ -33,6 +38,7 @@ function buildEthResultUR(
     params.dataType,
     params.chainId,
     params.requestId,
+    txType,
   );
 }
 
@@ -150,6 +156,7 @@ export default function KeycardScreen({
         dataType?: number;
         chainId?: number;
         requestId?: string;
+        signData?: string;
       },
     );
     navigateToSignResult(urString);

--- a/src/utils/ethSignature.ts
+++ b/src/utils/ethSignature.ts
@@ -97,6 +97,7 @@ function concat(...arrays: Uint8Array[]): Uint8Array {
  * @param dataType        - eth-sign-request dataType (1=legacy, 2=typed, 3=personal, 4=EIP-1559)
  * @param chainId         - chain ID (used for legacy tx v calculation)
  * @param requestId       - optional UUID hex from the original eth-sign-request
+ * @param txType          - optional EIP-2718 transaction type byte (e.g. 0x01 for EIP-2930)
  */
 export function buildEthSignatureUR(
   signRespDataHex: string,
@@ -104,6 +105,7 @@ export function buildEthSignatureUR(
   dataType: number | undefined,
   chainId: number | undefined,
   requestId: string | undefined,
+  txType?: number,
 ): string {
   const tlv = new Keycard.BERTLV(hexToBytes(signRespDataHex));
   tlv.enterConstructed(TLV_SIGNATURE_TEMPLATE);
@@ -135,15 +137,20 @@ export function buildEthSignatureUR(
   }
 
   let v: number;
-  switch (dataType) {
-    case 1: // legacy transaction (EIP-155)
-      v = V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
-      break;
-    case 4: // EIP-1559
-      v = recId;
-      break;
-    default: // EIP-712 (2), personal_sign (3), unknown
-      v = V_BASE_LEGACY + recId;
+  if (txType === 0x01) {
+    // EIP-2930: v = recId (same as EIP-1559, no chain ID encoding)
+    v = recId;
+  } else {
+    switch (dataType) {
+      case 1: // legacy transaction (EIP-155)
+        v = V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
+        break;
+      case 4: // EIP-1559
+        v = recId;
+        break;
+      default: // EIP-712 (2), personal_sign (3), unknown
+        v = V_BASE_LEGACY + recId;
+    }
   }
 
   const sig = concat(r, s, encodeV(v));

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -1,5 +1,7 @@
 import { RLP } from '@ethereumjs/rlp';
 
+import { DATA_TYPE_LABELS } from '../types';
+
 export type ParsedTx = {
   to?: string;
   value?: string; // in ETH, e.g. "0.01"
@@ -92,8 +94,26 @@ function parseEIP1559(bytes: Buffer): ParsedTx {
   };
 }
 
+/** EIP-2930 (type 0x01): 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]) */
+function parseEIP2930(bytes: Buffer): ParsedTx {
+  const rlpBytes = bytes.slice(1);
+  const decoded = RLP.decode(rlpBytes) as Uint8Array[];
+  const [, nonce, gasPrice, gasLimit, to, value, data] = decoded;
+  return {
+    nonce: Number(bufToBigInt(nonce)),
+    to: toAddress(to),
+    value: weiToEth(bufToBigInt(value)),
+    data: data.length > 0 ? bufToHex(data) : undefined,
+    fees: {
+      kind: 'legacy',
+      gasPrice: weiToGwei(bufToBigInt(gasPrice)),
+      gasLimit: bufToBigInt(gasLimit).toString(),
+    },
+  };
+}
+
 /**
- * dataType 1 = Legacy transaction
+ * dataType 1 = Legacy transaction (or EIP-2930 if first byte is 0x01)
  * dataType 4 = EIP-1559 transaction
  * Others (EIP-712, personal sign) are not transactions — return null.
  */
@@ -103,10 +123,24 @@ export function parseTx(
 ): ParsedTx | null {
   try {
     const bytes = Buffer.from(signDataHex, 'hex');
+    if (dataType === 1 && bytes[0] === 0x01) return parseEIP2930(bytes);
     if (dataType === 1) return parseLegacy(bytes);
     if (dataType === 4) return parseEIP1559(bytes);
     return null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns a human-readable label for the transaction type.
+ * Distinguishes EIP-2930 from legacy even though both arrive with dataType=1.
+ */
+export function getTxLabel(signDataHex: string, dataType: number): string {
+  if (dataType === 1) {
+    const bytes = Buffer.from(signDataHex, 'hex');
+    if (bytes[0] === 0x01) return 'EIP-2930 Transaction';
+    return 'Legacy Transaction';
+  }
+  return DATA_TYPE_LABELS[dataType] ?? `Unknown (${dataType})`;
 }


### PR DESCRIPTION
Adds EIP-2930 (`0x01`) Ethereum transaction support across parsing, review, and signing.

- parse `0x01` transactions in `txParser`
- show `EIP-2930 Transaction` in the review UI
- recover signatures with `v = recId` for EIP-2930
- add Jest coverage for parsing and signature behavior