### PR TITLE
feat: add bitcoin message signing via BIP-322 QR flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Add Bitcoin PSBT signing support
+- Add Bitcoin message signing support via BIP-322, including crypto-psbt detection and btc-sign-request / btc-signature QR flows
 - Add Bitget multi-account export via crypto-multi-accounts UR
 - Add EIP-2930 (type 0x01) transaction signing support
 

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -38,6 +38,20 @@ jest.mock('../src/utils/btcPsbt', () => ({
   inspectBtcPsbt: jest.fn(),
 }));
 
+jest.mock('../src/utils/btcMessage', () => ({
+  buildBtcSignatureUR: jest.fn(() => 'ur:btc-signature/mock'),
+  hashBitcoinMessage: jest.fn(() => new Uint8Array(32)),
+  inspectBtcSignRequest: jest.fn(() => ({
+    message: 'hello btc',
+    isUtf8: true,
+  })),
+  parseBtcSignRequest: jest.fn(),
+  parseKeycardBtcMessageSignature: jest.fn(() => ({
+    signature: Buffer.alloc(65, 0x11),
+    publicKey: Buffer.alloc(33, 0x02),
+  })),
+}));
+
 const mockSubmitPin = jest.fn();
 const mockCancel = jest.fn();
 const mockExecute = jest.fn();
@@ -72,6 +86,20 @@ const btcSignRoute = {
     operation: 'sign',
     signMode: 'btc',
     psbtHex: 'deadbeef',
+  },
+  key: 'Keycard',
+  name: 'Keycard',
+} as any;
+
+const btcMessageSignRoute = {
+  params: {
+    operation: 'sign',
+    signMode: 'btc-message',
+    requestId: '00112233445566778899aabbccddeeff',
+    signDataHex: Buffer.from('hello btc', 'utf8').toString('hex'),
+    derivationPath: "m/84'/0'/0'/0/3",
+    address: 'bc1qexampleaddress',
+    origin: 'Sparrow',
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -341,6 +369,32 @@ describe('KeycardScreen', () => {
         jest.advanceTimersByTime(800);
       });
       expect(navigation.reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('BTC message sign navigation', () => {
+    it('calls execute for a btc message sign operation', async () => {
+      await renderScreen('pin_entry', btcMessageSignRoute);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('navigates to QRResult after btc message sign completes', async () => {
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: new Uint8Array([1, 2, 3]),
+      });
+      await act(async () => {
+        ReactTestRenderer.create(
+          <KeycardScreen route={btcMessageSignRoute} navigation={navigation} />,
+        );
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+      expect(navigation.reset).toHaveBeenCalledTimes(1);
+      const resetCall = navigation.reset.mock.calls[0][0];
+      expect(resetCall.routes[1].name).toBe('QRResult');
+      expect(resetCall.routes[1].params.urString).toBe('ur:btc-signature/mock');
     });
   });
 });

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -27,6 +27,55 @@ const VALID_PSBT_HEX = (() => {
   return psbt.toBuffer().toString('hex');
 })();
 
+const BIP322_PSBT_HEX = (() => {
+  const {
+    Psbt,
+    Transaction,
+    payments,
+    networks,
+    script,
+    opcodes,
+  } = require('bitcoinjs-lib');
+
+  const fakePubkey = Buffer.alloc(33, 0x02);
+  const { output } = payments.p2wpkh({
+    pubkey: fakePubkey,
+    network: networks.testnet,
+  });
+
+  const toSpend = new Transaction();
+  toSpend.version = 0;
+  toSpend.addInput(
+    Buffer.alloc(32, 0x00),
+    0xffffffff,
+    0,
+    script.compile([opcodes.OP_0, Buffer.alloc(32, 0x11)]),
+  );
+  toSpend.addOutput(output!, 0);
+
+  const psbt = new Psbt({ network: networks.testnet });
+  psbt.setVersion(0);
+  psbt.addInput({
+    hash: toSpend.getHash(),
+    index: 0,
+    sequence: 0,
+    witnessUtxo: {
+      script: output!,
+      value: 0,
+    },
+    bip32Derivation: [
+      {
+        masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+        path: "m/84'/1'/0'/0/0",
+        pubkey: fakePubkey,
+      },
+    ],
+  });
+  psbt.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+
+  return psbt.toBuffer().toString('hex');
+})();
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -245,5 +294,37 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       request: { psbtHex: 'deadbeef' },
     });
     expect(toJson(renderer)).toContain('Sign transaction');
+  });
+
+  it('shows BIP-322 requests as message signing', async () => {
+    const renderer = await renderScreen({
+      kind: 'crypto-psbt',
+      request: { psbtHex: BIP322_PSBT_HEX },
+    });
+    const json = toJson(renderer);
+    expect(json).toContain('Bitcoin Message');
+    expect(json).toContain('BIP-322 Message');
+    expect(json).toContain('Sign message');
+  });
+});
+
+describe('TransactionDetailScreen – btc-sign-request result', () => {
+  it('shows message signing details and CTA', async () => {
+    const renderer = await renderScreen({
+      kind: 'btc-sign-request',
+      request: {
+        requestId: '00112233445566778899aabbccddeeff',
+        signDataHex: Buffer.from('hello btc', 'utf8').toString('hex'),
+        dataType: 1,
+        derivationPath: "m/84'/0'/0'/0/3",
+        address: 'bc1qexampleaddress',
+        origin: 'Sparrow',
+      },
+    });
+    const json = toJson(renderer);
+    expect(json).toContain('Bitcoin Message');
+    expect(json).toContain('btc-sign-request');
+    expect(json).toContain('hello btc');
+    expect(json).toContain('Sign message');
   });
 });

--- a/__tests__/btcPsbt.test.ts
+++ b/__tests__/btcPsbt.test.ts
@@ -1,5 +1,6 @@
-import { inspectBtcPsbt, parseCryptoPsbtRequest } from '../src/utils/btcPsbt';
 import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
+
+import { inspectBtcPsbt, parseCryptoPsbtRequest } from '../src/utils/btcPsbt';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -51,6 +52,55 @@ const TESTNET_WPKH_PSBT_HEX = (() => {
       },
     ],
   });
+
+  return psbt.toBuffer().toString('hex');
+})();
+
+const BIP322_PSBT_HEX = (() => {
+  const {
+    Psbt,
+    Transaction,
+    payments,
+    networks,
+    script,
+    opcodes,
+  } = require('bitcoinjs-lib');
+
+  const fakePubkey = Buffer.alloc(33, 0x02);
+  const { output } = payments.p2wpkh({
+    pubkey: fakePubkey,
+    network: networks.testnet,
+  });
+
+  const toSpend = new Transaction();
+  toSpend.version = 0;
+  toSpend.addInput(
+    Buffer.alloc(32, 0x00),
+    0xffffffff,
+    0,
+    script.compile([opcodes.OP_0, Buffer.alloc(32, 0x11)]),
+  );
+  toSpend.addOutput(output!, 0);
+
+  const psbt = new Psbt({ network: networks.testnet });
+  psbt.setVersion(0);
+  psbt.addInput({
+    hash: toSpend.getHash(),
+    index: 0,
+    sequence: 0,
+    witnessUtxo: {
+      script: output!,
+      value: 0,
+    },
+    bip32Derivation: [
+      {
+        masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+        path: "m/84'/1'/0'/0/0",
+        pubkey: fakePubkey,
+      },
+    ],
+  });
+  psbt.addOutput({ script: Buffer.from([0x6a]), value: 0 });
 
   return psbt.toBuffer().toString('hex');
 })();
@@ -109,5 +159,11 @@ describe('inspectBtcPsbt', () => {
   it('reports totalOutputSats as sum of all outputs', () => {
     const summary = inspectBtcPsbt(TESTNET_WPKH_PSBT_HEX);
     expect(summary.totalOutputSats).toBe(99_000);
+  });
+
+  it('detects shell-style BIP-322 message signing PSBTs', () => {
+    const summary = inspectBtcPsbt(BIP322_PSBT_HEX);
+    expect(summary.requestType).toBe('bip322-message');
+    expect(summary.bip322Address).toMatch(/^tb1/);
   });
 });

--- a/__tests__/ur.test.ts
+++ b/__tests__/ur.test.ts
@@ -1,6 +1,14 @@
-import { URDecoder } from '@ngraveio/bc-ur';
 import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
+import {
+  CryptoKeypath,
+  DataItem,
+  PathComponent,
+  RegistryTypes,
+  encodeDataItem,
+} from '@keystonehq/bc-ur-registry';
 import { EthSignRequest } from '@keystonehq/bc-ur-registry-eth';
+import { URDecoder } from '@ngraveio/bc-ur';
+
 import { handleUR } from '../src/utils/ur';
 import { DATA_TYPE_LABELS } from '../src/types';
 
@@ -33,6 +41,54 @@ function buildCbor(
   const decoder = new URDecoder();
   decoder.receivePart(req.toUREncoder(1000).nextPart());
   return decoder.resultUR().cbor;
+}
+
+function buildBtcSignRequestCbor(
+  message: string,
+  hdPath: string,
+  opts: {
+    xfp?: string;
+    uuid?: string;
+    address?: string;
+    origin?: string;
+  } = {},
+): Buffer {
+  const components = hdPath
+    .replace(/^m\//, '')
+    .split('/')
+    .map(component => {
+      const hardened = component.endsWith("'");
+      const index = Number.parseInt(component.replace("'", ''), 10);
+      return new PathComponent({ index, hardened });
+    });
+  const keypath = new CryptoKeypath(
+    components,
+    Buffer.from(opts.xfp ?? 'deadbeef', 'hex'),
+  );
+  const keypathItem = keypath.toDataItem();
+  keypathItem.setTag(RegistryTypes.CRYPTO_KEYPATH.getTag());
+  const map: Record<number, any> = {
+    1: new DataItem(
+      Buffer.from(
+        (opts.uuid ?? '00112233-4455-6677-8899-aabbccddeeff').replace(/-/g, ''),
+        'hex',
+      ),
+      RegistryTypes.UUID.getTag(),
+    ),
+    2: Buffer.from(message, 'utf8'),
+    3: 1,
+    4: [keypathItem],
+  };
+
+  if (opts.address) {
+    map[5] = [opts.address];
+  }
+
+  if (opts.origin) {
+    map[6] = opts.origin;
+  }
+
+  return encodeDataItem(new DataItem(map));
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +216,35 @@ describe('handleUR – crypto-psbt', () => {
   it('returns unsupported for unrecognised type (not crypto-psbt)', () => {
     const result = handleUR('unknown-type', Buffer.alloc(0));
     expect(result.kind).toBe('unsupported');
+  });
+});
+
+describe('handleUR – btc-sign-request', () => {
+  it('parses a valid btc-sign-request', () => {
+    const cbor = buildBtcSignRequestCbor('hello btc', "m/84'/0'/0'/0/3", {
+      address: 'bc1qexampleaddress',
+      origin: 'Sparrow',
+    });
+    const result = handleUR('btc-sign-request', cbor);
+
+    expect(result.kind).toBe('btc-sign-request');
+    if (result.kind === 'btc-sign-request') {
+      expect(result.request.requestId).toBe('00112233445566778899aabbccddeeff');
+      expect(result.request.signDataHex).toBe(
+        Buffer.from('hello btc', 'utf8').toString('hex'),
+      );
+      expect(result.request.derivationPath).toBe("m/84'/0'/0'/0/3");
+      expect(result.request.address).toBe('bc1qexampleaddress');
+      expect(result.request.origin).toBe('Sparrow');
+    }
+  });
+
+  it('returns an error for malformed btc-sign-request CBOR', () => {
+    const result = handleUR('btc-sign-request', Buffer.from([0xa0]));
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/Failed to parse BTC sign request/);
+    }
   });
 });
 

--- a/src/components/BtcPsbtDetail.tsx
+++ b/src/components/BtcPsbtDetail.tsx
@@ -1,8 +1,9 @@
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Icon, Text } from 'react-native-paper';
+
 import theme from '../theme';
-import { inspectBtcPsbt } from '../utils/btcPsbt';
 import InfoRow from './InfoRow';
+import { inspectBtcPsbt } from '../utils/btcPsbt';
 
 function formatSats(value: number): string {
   return `${value.toLocaleString()} sats`;
@@ -31,7 +32,9 @@ export default function BtcPsbtDetail({ psbtHex }: { psbtHex: string }) {
       <View style={styles.typeChip}>
         <Icon source="bitcoin" size={18} color={theme.colors.primary} />
         <Text variant="labelLarge" style={styles.typeChipText}>
-          Bitcoin PSBT
+          {summary.requestType === 'bip322-message'
+            ? 'Bitcoin Message'
+            : 'Bitcoin PSBT'}
         </Text>
       </View>
 
@@ -48,25 +51,43 @@ export default function BtcPsbtDetail({ psbtHex }: { psbtHex: string }) {
         />
       </View>
 
-      <View style={styles.row}>
-        <InfoRow label="Inputs" value={String(summary.inputCount)} />
-        <InfoRow label="Outputs" value={String(summary.outputCount)} />
-      </View>
+      {summary.requestType === 'bip322-message' ? (
+        <>
+          <View style={styles.row}>
+            <InfoRow label="Format" value="BIP-322 Message" />
+          </View>
 
-      {summary.feeSats !== undefined && (
-        <View style={styles.row}>
-          <InfoRow label="Fee" value={formatSats(summary.feeSats)} />
-        </View>
+          {summary.bip322Address && (
+            <View style={styles.row}>
+              <InfoRow label="Address" value={summary.bip322Address} />
+            </View>
+          )}
+        </>
+      ) : (
+        <>
+          <View style={styles.row}>
+            <InfoRow label="Inputs" value={String(summary.inputCount)} />
+            <InfoRow label="Outputs" value={String(summary.outputCount)} />
+          </View>
+
+          {summary.feeSats !== undefined && (
+            <View style={styles.row}>
+              <InfoRow label="Fee" value={formatSats(summary.feeSats)} />
+            </View>
+          )}
+
+          {summary.outputs.map((output, index) => (
+            <View key={`${output.address}-${index}`} style={styles.row}>
+              <InfoRow
+                label={`Output ${index + 1}${
+                  output.isChange ? ' (Change)' : ''
+                }`}
+                value={`${output.address}\n${formatSats(output.valueSats)}`}
+              />
+            </View>
+          ))}
+        </>
       )}
-
-      {summary.outputs.map((output, index) => (
-        <View key={`${output.address}-${index}`} style={styles.row}>
-          <InfoRow
-            label={`Output ${index + 1}${output.isChange ? ' (Change)' : ''}`}
-            value={`${output.address}\n${formatSats(output.valueSats)}`}
-          />
-        </View>
-      ))}
     </>
   );
 }

--- a/src/components/BtcSignRequestDetail.tsx
+++ b/src/components/BtcSignRequestDetail.tsx
@@ -1,0 +1,69 @@
+import { StyleSheet, View } from 'react-native';
+import { Icon, Text } from 'react-native-paper';
+
+import type { BtcSignRequest } from '../types';
+import theme from '../theme';
+import { inspectBtcSignRequest } from '../utils/btcMessage';
+import InfoRow from './InfoRow';
+
+export default function BtcSignRequestDetail({
+  request,
+}: {
+  request: BtcSignRequest;
+}) {
+  const summary = inspectBtcSignRequest(request);
+
+  return (
+    <>
+      <View style={styles.typeChip}>
+        <Icon source="bitcoin" size={18} color={theme.colors.primary} />
+        <Text variant="labelLarge" style={styles.typeChipText}>
+          Bitcoin Message
+        </Text>
+      </View>
+
+      <View style={styles.row}>
+        <InfoRow label="Format" value="btc-sign-request" />
+      </View>
+
+      <View style={styles.row}>
+        <InfoRow label="Message" value={summary.message} />
+      </View>
+
+      {request.address && (
+        <View style={styles.row}>
+          <InfoRow label="Address" value={request.address} />
+        </View>
+      )}
+
+      <View style={styles.row}>
+        <InfoRow label="Derivation path" value={request.derivationPath} />
+      </View>
+
+      {request.origin && (
+        <View style={styles.row}>
+          <InfoRow label="Origin" value={request.origin} />
+        </View>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  typeChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  typeChipText: {
+    color: theme.colors.primary,
+  },
+  row: {
+    paddingVertical: 8,
+  },
+});

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -19,6 +19,15 @@ export type KeycardParams =
       psbtHex: string;
     }
   | {
+      operation: 'sign';
+      signMode: 'btc-message';
+      requestId: string;
+      signDataHex: string;
+      derivationPath: string;
+      address?: string;
+      origin?: string;
+    }
+  | {
       operation: 'export_key';
       derivationPath: string;
     };

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -5,6 +5,13 @@ import { UR, UREncoder } from '@ngraveio/bc-ur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { KeycardScreenProps } from '../navigation/types';
+import NFCBottomSheet from '../components/NFCBottomSheet';
+import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
+import {
+  buildBtcSignatureUR,
+  hashBitcoinMessage,
+  parseKeycardBtcMessageSignature,
+} from '../utils/btcMessage';
 import { BtcSigningSession } from '../utils/btcPsbt';
 import { buildEthSignatureUR } from '../utils/ethSignature';
 import {
@@ -13,8 +20,6 @@ import {
   prepareSignHash,
   type ExportKeyResult,
 } from '../utils/keycardExport';
-import NFCBottomSheet from '../components/NFCBottomSheet';
-import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
 
 function buildEthResultUR(
   result: Uint8Array,
@@ -61,7 +66,9 @@ export default function KeycardScreen({
   const hashRef = useRef<Uint8Array | null>(null);
   const btcSessionRef = useRef<BtcSigningSession | null>(null);
 
-  const keycard = useKeycardOperation<ExportKeyResult | { psbtHex: string }>();
+  const keycard = useKeycardOperation<
+    ExportKeyResult | { psbtHex: string } | Uint8Array
+  >();
   const { phase, result, execute, cancel } = keycard;
 
   const handleSign = useCallback(() => {
@@ -71,6 +78,22 @@ export default function KeycardScreen({
 
     if (params.signMode === 'eth') {
       const hash = prepareSignHash(params.signData, params.dataType);
+      hashRef.current = hash;
+
+      execute(async cmdSet => {
+        const signResp = await cmdSet.signWithPath(
+          hash,
+          params.derivationPath,
+          false,
+        );
+        signResp.checkOK();
+        return signResp.data;
+      });
+      return;
+    }
+
+    if (params.signMode === 'btc-message') {
+      const hash = hashBitcoinMessage(params.signDataHex);
       hashRef.current = hash;
 
       execute(async cmdSet => {
@@ -169,6 +192,26 @@ export default function KeycardScreen({
     navigateToSignResult(buildBtcResultUR(result.psbtHex));
   }, [result, navigateToSignResult]);
 
+  const handleBtcMessageSignDone = useCallback(() => {
+    if (
+      params.operation !== 'sign' ||
+      params.signMode !== 'btc-message' ||
+      !hashRef.current ||
+      !(result instanceof Uint8Array)
+    ) {
+      return;
+    }
+
+    const parsed = parseKeycardBtcMessageSignature(hashRef.current, result);
+    navigateToSignResult(
+      buildBtcSignatureUR({
+        requestId: params.requestId,
+        signature: parsed.signature,
+        publicKey: parsed.publicKey,
+      }),
+    );
+  }, [result, params, navigateToSignResult]);
+
   const handleExportKeyDone = useCallback(() => {
     if (
       !result ||
@@ -199,6 +242,11 @@ export default function KeycardScreen({
           handleEthSignDone();
         } else if (params.operation === 'sign' && params.signMode === 'btc') {
           handleBtcSignDone();
+        } else if (
+          params.operation === 'sign' &&
+          params.signMode === 'btc-message'
+        ) {
+          handleBtcMessageSignDone();
         } else if (params.operation === 'export_key') {
           handleExportKeyDone();
         }
@@ -214,6 +262,7 @@ export default function KeycardScreen({
     params,
     handleEthSignDone,
     handleBtcSignDone,
+    handleBtcMessageSignDone,
     handleExportKeyDone,
   ]);
 

--- a/src/screens/TransactionDetailScreen.tsx
+++ b/src/screens/TransactionDetailScreen.tsx
@@ -4,11 +4,13 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Icon, Text } from 'react-native-paper';
 
 import { Icons } from '../assets/icons';
-import BtcPsbtDetail from '../components/BtcPsbtDetail';
-import EthSignRequestDetail from '../components/EthSignRequestDetail';
-import PrimaryButton from '../components/PrimaryButton';
 import type { TransactionDetailScreenProps } from '../navigation/types';
 import theme from '../theme';
+import BtcPsbtDetail from '../components/BtcPsbtDetail';
+import BtcSignRequestDetail from '../components/BtcSignRequestDetail';
+import EthSignRequestDetail from '../components/EthSignRequestDetail';
+import PrimaryButton from '../components/PrimaryButton';
+import { inspectBtcPsbt } from '../utils/btcPsbt';
 
 export default function TransactionDetailScreen({
   route,
@@ -16,6 +18,18 @@ export default function TransactionDetailScreen({
 }: TransactionDetailScreenProps) {
   const insets = useSafeAreaInsets();
   const { result } = route.params;
+  const isBip322Message =
+    result.kind === 'crypto-psbt' &&
+    (() => {
+      try {
+        return (
+          inspectBtcPsbt(result.request.psbtHex).requestType ===
+          'bip322-message'
+        );
+      } catch {
+        return false;
+      }
+    })();
 
   const handleSign = useCallback(() => {
     if (result.kind === 'eth-sign-request') {
@@ -35,6 +49,17 @@ export default function TransactionDetailScreen({
         signMode: 'btc',
         psbtHex: result.request.psbtHex,
       });
+    } else if (result.kind === 'btc-sign-request') {
+      const request = result.request;
+      navigation.navigate('Keycard', {
+        operation: 'sign',
+        signMode: 'btc-message',
+        requestId: request.requestId,
+        signDataHex: request.signDataHex,
+        derivationPath: request.derivationPath,
+        address: request.address,
+        origin: request.origin,
+      });
     }
   }, [result, navigation]);
 
@@ -50,6 +75,10 @@ export default function TransactionDetailScreen({
 
         {result.kind === 'crypto-psbt' && (
           <BtcPsbtDetail psbtHex={result.request.psbtHex} />
+        )}
+
+        {result.kind === 'btc-sign-request' && (
+          <BtcSignRequestDetail request={result.request} />
         )}
 
         {result.kind === 'unsupported' && (
@@ -82,10 +111,15 @@ export default function TransactionDetailScreen({
       </ScrollView>
 
       {(result.kind === 'eth-sign-request' ||
-        result.kind === 'crypto-psbt') && (
+        result.kind === 'crypto-psbt' ||
+        result.kind === 'btc-sign-request') && (
         <View style={[styles.actions, { paddingBottom: insets.bottom + 16 }]}>
           <PrimaryButton
-            label="Sign transaction"
+            label={
+              isBip322Message || result.kind === 'btc-sign-request'
+                ? 'Sign message'
+                : 'Sign transaction'
+            }
             onPress={handleSign}
             icon={Icons.nfcActivate}
           />

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,19 @@ export type BtcPsbtRequest = {
   psbtHex: string;
 };
 
+export type BtcSignRequest = {
+  requestId: string;
+  signDataHex: string;
+  dataType: number;
+  derivationPath: string;
+  address?: string;
+  origin?: string;
+};
+
 export type ScanResult =
   | { kind: 'eth-sign-request'; request: EthSignRequest }
   | { kind: 'crypto-psbt'; request: BtcPsbtRequest }
+  | { kind: 'btc-sign-request'; request: BtcSignRequest }
   | { kind: 'unsupported'; type: string }
   | { kind: 'error'; message: string };
 

--- a/src/utils/btcMessage.ts
+++ b/src/utils/btcMessage.ts
@@ -1,0 +1,216 @@
+import {
+  CryptoKeypath,
+  DataItem,
+  RegistryTypes,
+  decodeToDataItem,
+  encodeDataItem,
+} from '@keystonehq/bc-ur-registry';
+import { UR, UREncoder } from '@ngraveio/bc-ur';
+import { sha256 } from '@noble/hashes/sha2.js';
+import Keycard from 'keycard-sdk';
+
+const BTC_MESSAGE_SIGNATURE_TYPE = 'btc-signature';
+const BTC_SIGN_REQUEST_UUID_TAG = RegistryTypes.UUID.getTag();
+const BTC_SIGN_REQUEST_KEYPATH_TAG = RegistryTypes.CRYPTO_KEYPATH.getTag();
+const BTC_MESSAGE_DATA_TYPE = 1;
+const BTC_MESSAGE_SIGNATURE_HEADER = 27 + 4;
+const TLV_SIGNATURE_TEMPLATE = 0xa0;
+const TLV_PUB_KEY = 0x80;
+const TLV_ECDSA_TEMPLATE = 0x30;
+const TLV_INTEGER = 0x02;
+const SCALAR_BYTES = 32;
+
+enum BtcSignRequestKeys {
+  requestId = 1,
+  signData = 2,
+  dataType = 3,
+  derivationPaths = 4,
+  addresses = 5,
+  origin = 6,
+}
+
+enum BtcSignatureKeys {
+  requestId = 1,
+  signature = 2,
+  publicKey = 3,
+}
+
+export type BtcSignRequest = {
+  requestId: string;
+  signDataHex: string;
+  dataType: number;
+  derivationPath: string;
+  address?: string;
+  origin?: string;
+};
+
+function derIntTo32(bytes: Uint8Array): Uint8Array {
+  const stripped = bytes[0] === 0x00 ? bytes.slice(1) : bytes;
+  if (stripped.length === SCALAR_BYTES) {
+    return stripped;
+  }
+
+  const padded = new Uint8Array(SCALAR_BYTES);
+  padded.set(stripped, SCALAR_BYTES - stripped.length);
+  return padded;
+}
+
+function compressPubKey(uncompressed: Uint8Array): Buffer {
+  const x = uncompressed.slice(1, 1 + SCALAR_BYTES);
+  const y = uncompressed.slice(1 + SCALAR_BYTES, 1 + 2 * SCALAR_BYTES);
+  const prefix = y[SCALAR_BYTES - 1] % 2 === 0 ? 0x02 : 0x03;
+  return Buffer.concat([Buffer.from([prefix]), Buffer.from(x)]);
+}
+
+function formatRequestId(requestId: DataItem | Buffer | string): string {
+  if (requestId instanceof DataItem) {
+    return Buffer.from(requestId.getData()).toString('hex');
+  }
+
+  if (Buffer.isBuffer(requestId)) {
+    return requestId.toString('hex');
+  }
+
+  return String(requestId);
+}
+
+function encodeCompactSize(length: number): Buffer {
+  if (length < 253) {
+    return Buffer.from([length]);
+  }
+
+  if (length <= 0xffff) {
+    const out = Buffer.alloc(3);
+    out[0] = 0xfd;
+    out.writeUInt16LE(length, 1);
+    return out;
+  }
+
+  if (length <= 0xffffffff) {
+    const out = Buffer.alloc(5);
+    out[0] = 0xfe;
+    out.writeUInt32LE(length, 1);
+    return out;
+  }
+
+  throw new Error('Bitcoin message too long.');
+}
+
+function decodeUtf8Message(bytes: Buffer): string | undefined {
+  const text = bytes.toString('utf8');
+  if (Buffer.from(text, 'utf8').equals(bytes)) {
+    return text;
+  }
+
+  return undefined;
+}
+
+export function parseBtcSignRequest(cbor: Buffer): BtcSignRequest {
+  const map = decodeToDataItem(cbor).getData() as Record<number, any>;
+  const requestId = map[BtcSignRequestKeys.requestId];
+  const signData = map[BtcSignRequestKeys.signData];
+  const dataType = map[BtcSignRequestKeys.dataType];
+  const derivationPaths = map[BtcSignRequestKeys.derivationPaths] as
+    | DataItem[]
+    | undefined;
+  const addresses = map[BtcSignRequestKeys.addresses] as string[] | undefined;
+  const origin = map[BtcSignRequestKeys.origin] as string | undefined;
+
+  if (!requestId || !Buffer.isBuffer(signData) || !derivationPaths?.[0]) {
+    throw new Error('Malformed btc-sign-request payload.');
+  }
+
+  if (derivationPaths[0].getTag() !== BTC_SIGN_REQUEST_KEYPATH_TAG) {
+    throw new Error('Malformed btc-sign-request derivation path.');
+  }
+
+  const derivationPath = CryptoKeypath.fromDataItem(
+    derivationPaths[0],
+  ).getPath();
+  if (!derivationPath) {
+    throw new Error('Missing btc-sign-request derivation path.');
+  }
+
+  return {
+    requestId: formatRequestId(requestId),
+    signDataHex: signData.toString('hex'),
+    dataType: Number(dataType ?? BTC_MESSAGE_DATA_TYPE),
+    derivationPath: `m/${derivationPath}`,
+    address: addresses?.[0],
+    origin,
+  };
+}
+
+export function inspectBtcSignRequest(request: BtcSignRequest): {
+  message: string;
+  isUtf8: boolean;
+} {
+  const bytes = Buffer.from(request.signDataHex, 'hex');
+  const utf8 = decodeUtf8Message(bytes);
+
+  return {
+    message: utf8 ?? request.signDataHex,
+    isUtf8: utf8 !== undefined,
+  };
+}
+
+export function hashBitcoinMessage(messageHex: string): Uint8Array {
+  const message = Buffer.from(messageHex, 'hex');
+  const payload = Buffer.concat([
+    Buffer.from('\x18Bitcoin Signed Message:\n', 'binary'),
+    encodeCompactSize(message.length),
+    message,
+  ]);
+
+  return sha256(sha256(payload));
+}
+
+export function parseKeycardBtcMessageSignature(
+  hash: Uint8Array,
+  data: Uint8Array,
+): {
+  signature: Buffer;
+  publicKey: Buffer;
+} {
+  const recoverable = new Keycard.RecoverableSignature({
+    hash,
+    tlvData: data,
+  });
+  const tlv = new Keycard.BERTLV(data);
+  tlv.enterConstructed(TLV_SIGNATURE_TEMPLATE);
+  const publicKey = compressPubKey(tlv.readPrimitive(TLV_PUB_KEY));
+  tlv.enterConstructed(TLV_ECDSA_TEMPLATE);
+  const r = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
+  const s = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
+
+  return {
+    signature: Buffer.concat([
+      Buffer.from([BTC_MESSAGE_SIGNATURE_HEADER + (recoverable.recId ?? 0)]),
+      Buffer.from(r),
+      Buffer.from(s),
+    ]),
+    publicKey,
+  };
+}
+
+export function buildBtcSignatureUR(args: {
+  requestId: string;
+  signature: Buffer;
+  publicKey: Buffer;
+}): string {
+  const cbor = encodeDataItem(
+    new DataItem({
+      [BtcSignatureKeys.requestId]: new DataItem(
+        Buffer.from(args.requestId, 'hex'),
+        BTC_SIGN_REQUEST_UUID_TAG,
+      ),
+      [BtcSignatureKeys.signature]: args.signature,
+      [BtcSignatureKeys.publicKey]: args.publicKey,
+    }),
+  );
+
+  return new UREncoder(
+    new UR(cbor, BTC_MESSAGE_SIGNATURE_TYPE),
+    Math.max(cbor.length, 100),
+  ).nextPart();
+}

--- a/src/utils/btcPsbt.ts
+++ b/src/utils/btcPsbt.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
-import { Psbt, address, networks } from 'bitcoinjs-lib';
+import { Psbt, Transaction, address, networks } from 'bitcoinjs-lib';
 import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
@@ -22,12 +22,14 @@ export type BtcPsbtOutputSummary = {
 };
 
 export type BtcPsbtSummary = {
+  requestType: 'transaction' | 'bip322-message';
   network: NetworkName;
   inputCount: number;
   outputCount: number;
   outputs: BtcPsbtOutputSummary[];
   feeSats?: number;
   totalOutputSats: number;
+  bip322Address?: string;
 };
 
 type KeycardSignature = {
@@ -111,6 +113,62 @@ function extractInputPath(
   return input.bip32Derivation?.[0]?.path;
 }
 
+function getInputUtxo(
+  psbt: Psbt,
+  index: number,
+):
+  | {
+      script: Buffer;
+      valueSats: number;
+    }
+  | undefined {
+  const input = psbt.data.inputs[index];
+  if (!input) {
+    return undefined;
+  }
+
+  if (input.witnessUtxo) {
+    return {
+      script: input.witnessUtxo.script,
+      valueSats: input.witnessUtxo.value,
+    };
+  }
+
+  if (input.nonWitnessUtxo) {
+    const prevTx = Transaction.fromBuffer(input.nonWitnessUtxo).outs;
+    const prevout = prevTx[psbt.txInputs[index]?.index ?? -1];
+    if (!prevout) {
+      return undefined;
+    }
+
+    return {
+      script: prevout.script,
+      valueSats: prevout.value,
+    };
+  }
+
+  return undefined;
+}
+
+function isBip322MessagePsbt(psbt: Psbt): boolean {
+  if (psbt.inputCount !== 1 || psbt.txOutputs.length !== 1) {
+    return false;
+  }
+
+  const input = psbt.txInputs[0];
+  const output = psbt.txOutputs[0];
+  const utxo = getInputUtxo(psbt, 0);
+
+  return (
+    input.sequence === 0 &&
+    input.index === 0 &&
+    output.value === 0 &&
+    output.script.length === 1 &&
+    output.script[0] === 0x6a &&
+    utxo?.valueSats === 0
+  );
+}
+
 function isChangeOutput(output: Psbt['data']['outputs'][number]): boolean {
   return (
     (output.bip32Derivation?.length ?? 0) > 0 ||
@@ -189,6 +247,9 @@ export function parseCryptoPsbtRequest(cbor: Buffer): { psbtHex: string } {
 
 export function inspectBtcPsbt(psbtHex: string): BtcPsbtSummary {
   const psbt = toPsbt(psbtHex);
+  const requestType = isBip322MessagePsbt(psbt)
+    ? 'bip322-message'
+    : 'transaction';
   const network =
     inferNetworkFromPath(
       psbt.data.inputs[0] ? extractInputPath(psbt.data.inputs[0]) : undefined,
@@ -206,12 +267,17 @@ export function inspectBtcPsbt(psbtHex: string): BtcPsbtSummary {
   } catch {}
 
   return {
+    requestType,
     network,
     inputCount: psbt.inputCount,
     outputCount: psbt.txOutputs.length,
     outputs,
     feeSats,
     totalOutputSats: outputs.reduce((sum, output) => sum + output.valueSats, 0),
+    bip322Address:
+      requestType === 'bip322-message' && getInputUtxo(psbt, 0)
+        ? decodeAddress(getInputUtxo(psbt, 0)!.script, network)
+        : undefined,
   };
 }
 

--- a/src/utils/ur.ts
+++ b/src/utils/ur.ts
@@ -1,10 +1,11 @@
 import { EthSignRequest } from '@keystonehq/bc-ur-registry-eth';
 
-import { parseCryptoPsbtRequest } from './btcPsbt';
 import type {
   EthSignRequest as EthSignRequestType,
   ScanResult,
 } from '../types';
+import { parseBtcSignRequest } from './btcMessage';
+import { parseCryptoPsbtRequest } from './btcPsbt';
 
 function parseEthSignRequest(cbor: Buffer): EthSignRequestType {
   const parsed = EthSignRequest.fromCBOR(cbor);
@@ -55,6 +56,17 @@ export function handleUR(type: string, cbor: Buffer): ScanResult {
       return {
         kind: 'error',
         message: `Failed to parse PSBT: ${e.message}`,
+      };
+    }
+  }
+
+  if (type === 'btc-sign-request') {
+    try {
+      return { kind: 'btc-sign-request', request: parseBtcSignRequest(cbor) };
+    } catch (e: any) {
+      return {
+        kind: 'error',
+        message: `Failed to parse BTC sign request: ${e.message}`,
       };
     }
   }


### PR DESCRIPTION
Adds Bitcoin message signing support across both supported QR request styles.

- detect BIP-322-style message requests embedded in `crypto-psbt`
- add direct `btc-sign-request` parsing and review UI
- sign Bitcoin messages with Keycard and return `btc-signature` URs
- add test coverage for parsing, review, and Keycard result routing