### PR TITLE
fix: include source fingerprint in ethereum crypto-hdkey export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix Ethereum `crypto-hdkey` exports to include source fingerprints for Rabby compatibility
 - Fix PIN pad bottom key obscured by Android gesture navigation bar
 
 ## [0.7.0] - 2026-03-23

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -26,6 +26,10 @@ jest.mock('../src/utils/cryptoAccount', () => ({
   pubKeyFingerprint: jest.fn(),
 }));
 
+jest.mock('../src/utils/cryptoHdKey', () => ({
+  buildCryptoHdKeyUR: jest.fn(),
+}));
+
 jest.mock('../src/utils/cryptoMultiAccounts', () => ({
   buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
   exportKeysForBitget: jest.fn(),
@@ -109,6 +113,15 @@ const btcExportRoute = {
   params: {
     operation: 'export_key',
     derivationPath: "m/84'/0'/0'",
+  },
+  key: 'Keycard',
+  name: 'Keycard',
+} as any;
+
+const ethExportRoute = {
+  params: {
+    operation: 'export_key',
+    derivationPath: "m/44'/60'/0'",
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -276,6 +289,36 @@ describe('KeycardScreen', () => {
         masterFingerprint: 1,
         descriptors: [],
       });
+      expect(navigation.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses crypto-hdkey URs for ethereum wallet export with fingerprinted export result', async () => {
+      const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey') as {
+        buildCryptoHdKeyUR: jest.Mock;
+      };
+      buildCryptoHdKeyUR.mockReturnValue('UR:CRYPTO-HDKEY/...');
+
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: {
+          exportRespData: new Uint8Array([1, 2, 3]),
+          sourceFingerprint: 0xdeadbeef,
+        },
+      });
+      await act(async () => {
+        ReactTestRenderer.create(
+          <KeycardScreen route={ethExportRoute} navigation={navigation} />,
+        );
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+
+      expect(buildCryptoHdKeyUR).toHaveBeenCalledWith(
+        new Uint8Array([1, 2, 3]),
+        "m/44'/60'/0'",
+        0xdeadbeef,
+      );
       expect(navigation.reset).toHaveBeenCalledTimes(1);
     });
   });

--- a/__tests__/cryptoHdKey.test.ts
+++ b/__tests__/cryptoHdKey.test.ts
@@ -68,6 +68,7 @@ PUB_KEY_UNCOMPRESSED[32] = 0x01; // x[31] = 1
 const CHAIN_CODE = new Uint8Array(32).fill(0xcc);
 
 const DERIVATION_PATH = "m/44'/60'/0'";
+const SOURCE_FINGERPRINT = 0xdeadbeef;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -81,7 +82,7 @@ describe('buildCryptoHdKeyUR', () => {
   });
 
   it('returns a ur:crypto-hdkey string', () => {
-    const ur = buildCryptoHdKeyUR(tlvData, DERIVATION_PATH);
+    const ur = buildCryptoHdKeyUR(tlvData, DERIVATION_PATH, SOURCE_FINGERPRINT);
     expect(ur.toLowerCase()).toMatch(/^ur:crypto-hdkey\//);
   });
 
@@ -89,7 +90,11 @@ describe('buildCryptoHdKeyUR', () => {
     let decoded: Record<number, any>;
 
     beforeAll(() => {
-      const ur = buildCryptoHdKeyUR(tlvData, DERIVATION_PATH);
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+      );
       decoded = decodeUR(ur);
     });
 
@@ -117,6 +122,12 @@ describe('buildCryptoHdKeyUR', () => {
       expect(decoded[6]).toBeDefined();
     });
 
+    it('origin includes a source fingerprint', () => {
+      const origin = decoded[6];
+      const keypathMap = origin?.value ?? origin;
+      expect(keypathMap[2]).toBe(SOURCE_FINGERPRINT);
+    });
+
     it('key 9 (name) is "GapSign"', () => {
       expect(decoded[9]).toBe('GapSign');
     });
@@ -124,7 +135,11 @@ describe('buildCryptoHdKeyUR', () => {
 
   describe('derivation path encoding', () => {
     it("encodes m/44'/60'/0' with correct depth", () => {
-      const ur = buildCryptoHdKeyUR(tlvData, DERIVATION_PATH);
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+      );
       const decoded = decodeUR(ur);
       // The origin (key 6) is a CBOR tagged value (tag 304).
       // cbor-sync decodes tags as {tag, value} or unwraps them — check depth field (key 3).
@@ -135,7 +150,7 @@ describe('buildCryptoHdKeyUR', () => {
     });
 
     it('encodes a non-hardened path correctly', () => {
-      const ur = buildCryptoHdKeyUR(tlvData, 'm/0/1');
+      const ur = buildCryptoHdKeyUR(tlvData, 'm/0/1', SOURCE_FINGERPRINT);
       const decoded = decodeUR(ur);
       const origin = decoded[6];
       const keypathMap = origin?.value ?? origin;
@@ -145,7 +160,11 @@ describe('buildCryptoHdKeyUR', () => {
 
   it('throws when TLV data is malformed', () => {
     expect(() =>
-      buildCryptoHdKeyUR(new Uint8Array([0x00, 0x00]), DERIVATION_PATH),
+      buildCryptoHdKeyUR(
+        new Uint8Array([0x00, 0x00]),
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+      ),
     ).toThrow();
   });
 });

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -186,7 +186,12 @@ export default function KeycardScreen({
   }, [result, params, navigateToSignResult]);
 
   const handleBtcSignDone = useCallback(() => {
-    if (!result || !('psbtHex' in result)) {
+    if (
+      !result ||
+      !('psbtHex' in result) ||
+      typeof result.psbtHex !== 'string' ||
+      result.psbtHex.length === 0
+    ) {
       return;
     }
     navigateToSignResult(buildBtcResultUR(result.psbtHex));
@@ -216,7 +221,7 @@ export default function KeycardScreen({
     if (
       !result ||
       !(
-        result instanceof Uint8Array ||
+        'exportRespData' in result ||
         'descriptors' in result ||
         'keys' in result
       )

--- a/src/utils/cryptoHdKey.ts
+++ b/src/utils/cryptoHdKey.ts
@@ -1,26 +1,11 @@
-import {
-  CryptoHDKey,
-  CryptoKeypath,
-  PathComponent,
-} from '@keystonehq/bc-ur-registry';
+import { CryptoHDKey } from '@keystonehq/bc-ur-registry';
 import { UR, UREncoder } from '@ngraveio/bc-ur';
 
-import { compressPubKey, parseKeyFromTLV } from './hdKeyUtils';
-
-function derivationPathToKeypathNoFingerprint(
-  derivationPath: string,
-): CryptoKeypath {
-  const components = derivationPath
-    .split('/')
-    .slice(1)
-    .map(part => {
-      const hardened = part.endsWith("'");
-      const index = parseInt(hardened ? part.slice(0, -1) : part, 10);
-      return new PathComponent({ index, hardened });
-    });
-
-  return new CryptoKeypath(components, undefined, components.length);
-}
+import {
+  compressPubKey,
+  derivationPathToKeypath,
+  parseKeyFromTLV,
+} from './hdKeyUtils';
 
 /**
  * Parse the raw Keycard exportKey TLV response, encode it as a
@@ -35,6 +20,7 @@ function derivationPathToKeypathNoFingerprint(
 export function buildCryptoHdKeyUR(
   exportRespData: Uint8Array,
   derivationPath: string,
+  sourceFingerprint: number,
 ): string {
   const { pubKeyUncompressed, chainCode } = parseKeyFromTLV(exportRespData);
 
@@ -42,7 +28,7 @@ export function buildCryptoHdKeyUR(
     isMaster: false,
     key: compressPubKey(pubKeyUncompressed),
     chainCode: Buffer.from(chainCode),
-    origin: derivationPathToKeypathNoFingerprint(derivationPath),
+    origin: derivationPathToKeypath(derivationPath, sourceFingerprint),
     name: 'GapSign',
   });
 

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -16,7 +16,10 @@ import {
 } from './cryptoMultiAccounts';
 
 export type ExportKeyResult =
-  | Uint8Array
+  | {
+      exportRespData: Uint8Array;
+      sourceFingerprint: number;
+    }
   | BitcoinCryptoAccount
   | BitgetExportResult;
 
@@ -44,8 +47,12 @@ export function buildExportUr(
   result: ExportKeyResult,
   derivationPath: string,
 ): string {
-  if (result instanceof Uint8Array) {
-    return buildCryptoHdKeyUR(result, derivationPath);
+  if ('exportRespData' in result) {
+    return buildCryptoHdKeyUR(
+      result.exportRespData,
+      derivationPath,
+      result.sourceFingerprint,
+    );
   }
   if ('keys' in result) {
     return buildCryptoMultiAccountsUR(result);
@@ -63,9 +70,18 @@ export async function exportKeyForWallet(
   }
 
   if (!isBitcoinPath(derivationPath)) {
+    const parentPath = derivationPath.split('/').slice(0, -1).join('/') || 'm';
+    const parentResp = await cmdSet.exportKey(0, true, parentPath, false);
+    parentResp.checkOK();
+
     const resp = await cmdSet.exportExtendedKey(0, derivationPath, false);
     resp.checkOK();
-    return resp.data;
+    return {
+      exportRespData: resp.data,
+      sourceFingerprint: pubKeyFingerprint(
+        parsePublicKeyFromTLV(parentResp.data),
+      ),
+    };
   }
 
   const rootResp = await cmdSet.exportKey(0, true, 'm', false);


### PR DESCRIPTION
Adds the origin source fingerprint to Ethereum `crypto-hdkey` exports so Rabby accepts the QR.

- derive the parent fingerprint during Ethereum export
- include the fingerprint in the exported `crypto-hdkey` origin keypath
- update Keycard export handling for the fingerprinted result shape
- add tests for `crypto-hdkey` encoding and export result routing
- tighten BTC PSBT result guards to avoid noisy non-failing test logs
