### PR TITLE
fix: handle EIP-191 personal_sign (dataType=3) in prepareSignHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fix Ethereum `crypto-hdkey` exports to include source fingerprints for Rabby compatibility
+- Fix SIWE / personal_sign (`dataType=3`) failing with Invalid MAC by applying EIP-191 prefix hash before signing
 - Fix PIN pad bottom key obscured by Android gesture navigation bar
 
 ## [0.7.0] - 2026-03-23

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -1,0 +1,56 @@
+import { keccak_256 } from '@noble/hashes/sha3.js';
+
+import { prepareSignHash } from '../src/utils/keycardExport';
+
+jest.mock('keycard-sdk', () => ({ __esModule: true, default: {} }));
+
+function hex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('hex');
+}
+
+describe('prepareSignHash', () => {
+  const message = 'hello world';
+  const messageHex = Buffer.from(message, 'utf8').toString('hex');
+
+  it('dataType=1 returns keccak256 of raw bytes', () => {
+    const raw = Buffer.from(messageHex, 'hex');
+    const expected = hex(keccak_256(raw));
+    expect(hex(prepareSignHash(messageHex, 1))).toBe(expected);
+  });
+
+  it('dataType=4 returns keccak256 of raw bytes', () => {
+    const raw = Buffer.from(messageHex, 'hex');
+    const expected = hex(keccak_256(raw));
+    expect(hex(prepareSignHash(messageHex, 4))).toBe(expected);
+  });
+
+  it('dataType=3 returns EIP-191 personal_sign hash', () => {
+    const raw = Buffer.from(message, 'utf8');
+    const prefix = `\x19Ethereum Signed Message:\n${raw.length}`;
+    const prefixBytes = new TextEncoder().encode(prefix);
+    const combined = new Uint8Array(prefixBytes.length + raw.length);
+    combined.set(prefixBytes);
+    combined.set(raw, prefixBytes.length);
+    const expected = hex(keccak_256(combined));
+    expect(hex(prepareSignHash(messageHex, 3))).toBe(expected);
+  });
+
+  it('dataType=3 produces a 32-byte hash regardless of message length', () => {
+    const long = 'x'.repeat(200);
+    const longHex = Buffer.from(long, 'utf8').toString('hex');
+    const result = prepareSignHash(longHex, 3);
+    expect(result).toHaveLength(32);
+  });
+
+  it('dataType=2 returns raw bytes unchanged', () => {
+    const hash32Hex = 'ab'.repeat(32);
+    const result = prepareSignHash(hash32Hex, 2);
+    expect(hex(result)).toBe(hash32Hex);
+  });
+
+  it('undefined dataType returns raw bytes unchanged', () => {
+    const hash32Hex = 'cd'.repeat(32);
+    const result = prepareSignHash(hash32Hex, undefined);
+    expect(hex(result)).toBe(hash32Hex);
+  });
+});

--- a/__tests__/useNFCSession.test.ts
+++ b/__tests__/useNFCSession.test.ts
@@ -178,6 +178,30 @@ describe('useNFCSession', () => {
       expect(latestHook.phase).toBe('done');
     });
 
+    it('ignores a second card connected event while an operation is in flight', async () => {
+      await mountHook();
+      let resolveFirst!: () => void;
+      const firstOpPromise = new Promise<void>(resolve => {
+        resolveFirst = resolve;
+      });
+      mockOnCardConnected.mockImplementationOnce(() => firstOpPromise);
+      await act(async () => {
+        latestHook.startNFC();
+      });
+      // Fire first connection — onCardConnected is now in flight (pending)
+      // Fire second connection immediately after; it should be ignored
+      await act(async () => {
+        capturedOnConnected?.(); // intentionally not awaited — starts the in-flight op
+        await capturedOnConnected?.(); // second tap: should be blocked by inFlightRef
+      });
+      expect(mockOnCardConnected).toHaveBeenCalledTimes(1);
+      // Resolve the first operation and confirm it completes normally
+      await act(async () => {
+        resolveFirst();
+      });
+      expect(latestHook.phase).toBe('done');
+    });
+
     it('handles card connected when phase is nfc', async () => {
       await mountHook();
       await act(async () => {

--- a/src/hooks/keycard/useNFCSession.ts
+++ b/src/hooks/keycard/useNFCSession.ts
@@ -25,6 +25,7 @@ export default function useNFCSession(
   phaseRef.current = phase;
   const disconnectedRef = useRef(false);
   const realErrorRef = useRef(false);
+  const inFlightRef = useRef(false);
 
   const handleCardConnected = useCallback(async () => {
     if (phaseRef.current !== 'nfc' && phaseRef.current !== 'error') {
@@ -33,12 +34,16 @@ export default function useNFCSession(
       );
       return;
     }
+    if (inFlightRef.current) {
+      return;
+    }
     if (phaseRef.current === 'error') {
       // User re-tapped after an error — reset stale error state and retry.
       realErrorRef.current = false;
       setPhase('nfc');
     }
     console.log('[Keycard] Card connected');
+    inFlightRef.current = true;
     try {
       setStatus('Selecting applet...');
       const channel = new RNKeycard.NFCCardChannel();
@@ -65,6 +70,8 @@ export default function useNFCSession(
       console.log(`[Keycard] Error: ${e.message}`, e);
       setStatus(e.message);
       setPhase('error');
+    } finally {
+      inFlightRef.current = false;
     }
   }, [onCardConnected]);
 

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -40,6 +40,15 @@ export function prepareSignHash(
   if (dataType === 1 || dataType === 4) {
     return keccak_256(raw);
   }
+  if (dataType === 3) {
+    // EIP-191 personal_sign: keccak256("\x19Ethereum Signed Message:\n{len}{message}")
+    const prefix = `\x19Ethereum Signed Message:\n${raw.length}`;
+    const prefixBytes = new TextEncoder().encode(prefix);
+    const combined = new Uint8Array(prefixBytes.length + raw.length);
+    combined.set(prefixBytes);
+    combined.set(raw, prefixBytes.length);
+    return keccak_256(combined);
+  }
   return raw;
 }
 


### PR DESCRIPTION
Signing in with Ethereum (OpenSea, etc.) failed with Invalid MAC after PIN entry.

### Root cause

 `prepareSignHash` only hashed `dataType=1` and `dataType=4`. SIWE requests arrive as `dataType=3` (personal_sign) with the full UTF-8 message text as signData (~150 bytes). Passing that raw blob to `signWithPath` corrupted APDU framing inside the secure channel, causing the Keycard to reject it with `Invalid MAC`.

### Changes

- src/utils/keycardExport.ts — apply EIP-191 prefix hash for dataType=3: keccak256("\x19Ethereum Signed Message:\n{len}{message}")
- src/hooks/keycard/useNFCSession.ts — add inFlightRef to block concurrent card-connected events (prevents a duplicate secure channel attempt if Android NFC fires a second event mid-operation)
