### PR TITLE
feat: export key for Ledger Live and Ledger Legacy (#36, #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add Ledger Live and Ledger Legacy export via `crypto-hdkey` with EIP-4527 `source` and `children` fields
+
 ## [0.8.0] - 2026-04-06
 
 ### Added

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -84,6 +84,48 @@ describe('ExportKeyScreen', () => {
       });
     });
 
+    it('navigates to Keycard with source "account.ledger_live" when Ledger Live is pressed', async () => {
+      const renderer = await renderScreen();
+      const pressables = renderer.root.findAll(
+        (node: any) => typeof node.props.onPress === 'function',
+      );
+      const pressable = pressables.find(
+        node =>
+          node.findAll((n: any) => n.props.children === 'Ledger Live').length >
+          0,
+      )!;
+      expect(pressable).toBeDefined();
+      await act(async () => {
+        pressable.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+        operation: 'export_key',
+        derivationPath: "m/44'/60'/0'",
+        source: 'account.ledger_live',
+      });
+    });
+
+    it('navigates to Keycard with source "account.ledger_legacy" when Ledger Legacy is pressed', async () => {
+      const renderer = await renderScreen();
+      const pressables = renderer.root.findAll(
+        (node: any) => typeof node.props.onPress === 'function',
+      );
+      const pressable = pressables.find(
+        node =>
+          node.findAll((n: any) => n.props.children === 'Ledger Legacy')
+            .length > 0,
+      )!;
+      expect(pressable).toBeDefined();
+      await act(async () => {
+        pressable.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+        operation: 'export_key',
+        derivationPath: "m/44'/60'/0'",
+        source: 'account.ledger_legacy',
+      });
+    });
+
     it('navigates to Keycard with derivationPath "bitget" when Bitget is pressed', async () => {
       const renderer = await renderScreen();
       const pressables = renderer.root.findAll(

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -318,6 +318,7 @@ describe('KeycardScreen', () => {
         new Uint8Array([1, 2, 3]),
         "m/44'/60'/0'",
         0xdeadbeef,
+        undefined,
       );
       expect(navigation.reset).toHaveBeenCalledTimes(1);
     });

--- a/__tests__/cryptoHdKey.test.ts
+++ b/__tests__/cryptoHdKey.test.ts
@@ -158,6 +158,51 @@ describe('buildCryptoHdKeyUR', () => {
     });
   });
 
+  describe('source / note field', () => {
+    it('encodes the source string in key 10 (note) when provided', () => {
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+        'account.ledger_live',
+      );
+      const decoded = decodeUR(ur);
+      expect(decoded[10]).toBe('account.ledger_live');
+    });
+
+    it('encodes a children keypath in key 7 for account.ledger_legacy', () => {
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+        'account.ledger_legacy',
+      );
+      const decoded = decodeUR(ur);
+      expect(decoded[7]).toBeDefined();
+    });
+
+    it('omits key 7 (children) for non-legacy sources', () => {
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+        'account.ledger_live',
+      );
+      const decoded = decodeUR(ur);
+      expect(decoded[7]).toBeUndefined();
+    });
+
+    it('omits key 10 (note) when source is not provided', () => {
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        DERIVATION_PATH,
+        SOURCE_FINGERPRINT,
+      );
+      const decoded = decodeUR(ur);
+      expect(decoded[10]).toBeUndefined();
+    });
+  });
+
   it('throws when TLV data is malformed', () => {
     expect(() =>
       buildCryptoHdKeyUR(

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,6 +107,7 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            crunchPngs false
         }
     }
 }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -30,6 +30,7 @@ export type KeycardParams =
   | {
       operation: 'export_key';
       derivationPath: string;
+      source?: string;
     };
 // Future: | { operation: 'change_pin' } | { operation: 'generate_key' }
 

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -54,6 +54,24 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
           derivationPath: 'bitget',
         }),
     },
+    {
+      label: 'Ledger Live',
+      onPress: () =>
+        navigation.navigate('Keycard', {
+          operation: 'export_key',
+          derivationPath: "m/44'/60'/0'",
+          source: 'account.ledger_live',
+        }),
+    },
+    {
+      label: 'Ledger Legacy',
+      onPress: () =>
+        navigation.navigate('Keycard', {
+          operation: 'export_key',
+          derivationPath: "m/44'/60'/0'",
+          source: 'account.ledger_legacy',
+        }),
+    },
   ];
 
   return (

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -5,8 +5,11 @@ import { UR, UREncoder } from '@ngraveio/bc-ur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { KeycardScreenProps } from '../navigation/types';
+
 import NFCBottomSheet from '../components/NFCBottomSheet';
+
 import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
+
 import {
   buildBtcSignatureUR,
   hashBitcoinMessage,
@@ -220,6 +223,7 @@ export default function KeycardScreen({
   const handleExportKeyDone = useCallback(() => {
     if (
       !result ||
+      ArrayBuffer.isView(result) ||
       !(
         'exportRespData' in result ||
         'descriptors' in result ||
@@ -231,7 +235,8 @@ export default function KeycardScreen({
     navigateToExportResult(
       buildExportUr(
         result,
-        (params as { derivationPath: string }).derivationPath,
+        (params as { derivationPath: string; source?: string }).derivationPath,
+        (params as { derivationPath: string; source?: string }).source,
       ),
     );
   }, [result, params, navigateToExportResult]);

--- a/src/utils/cryptoHdKey.ts
+++ b/src/utils/cryptoHdKey.ts
@@ -1,4 +1,8 @@
-import { CryptoHDKey } from '@keystonehq/bc-ur-registry';
+import {
+  CryptoHDKey,
+  CryptoKeypath,
+  PathComponent,
+} from '@keystonehq/bc-ur-registry';
 import { UR, UREncoder } from '@ngraveio/bc-ur';
 
 import {
@@ -6,6 +10,8 @@ import {
   derivationPathToKeypath,
   parseKeyFromTLV,
 } from './hdKeyUtils';
+
+const LEDGER_LEGACY_SOURCE = 'account.ledger_legacy';
 
 /**
  * Parse the raw Keycard exportKey TLV response, encode it as a
@@ -21,6 +27,7 @@ export function buildCryptoHdKeyUR(
   exportRespData: Uint8Array,
   derivationPath: string,
   sourceFingerprint: number,
+  source?: string,
 ): string {
   const { pubKeyUncompressed, chainCode } = parseKeyFromTLV(exportRespData);
 
@@ -30,6 +37,12 @@ export function buildCryptoHdKeyUR(
     chainCode: Buffer.from(chainCode),
     origin: derivationPathToKeypath(derivationPath, sourceFingerprint),
     name: 'GapSign',
+    ...(source !== undefined && { note: source }),
+    ...(source === LEDGER_LEGACY_SOURCE && {
+      children: new CryptoKeypath([
+        new PathComponent({ index: undefined, hardened: false }),
+      ]),
+    }),
   });
 
   const cbor = hdKey.toCBOR();

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -55,12 +55,14 @@ export function prepareSignHash(
 export function buildExportUr(
   result: ExportKeyResult,
   derivationPath: string,
+  source?: string,
 ): string {
   if ('exportRespData' in result) {
     return buildCryptoHdKeyUR(
       result.exportRespData,
       derivationPath,
       result.sourceFingerprint,
+      source,
     );
   }
   if ('keys' in result) {


### PR DESCRIPTION
Adds two new wallet export targets to the Connect software wallet menu,
matching the keycard-shell menu order.

## Changes

- **Ledger Live** — exports `crypto-hdkey` with `source: "account.ledger_live"` (EIP-4527 note field)
- **Ledger Legacy** — exports `crypto-hdkey` with `source: "account.ledger_legacy"` and a `children` keypath (single wildcard non-hardened component), matching keycard-shell `core.c` lines 412–418
- `buildCryptoHdKeyUR` accepts an optional `source` parameter and auto-populates the `children` field for Ledger Legacy
- `buildExportUr` and `KeycardScreen` thread `source` through from navigation params
- Menu order updated to match keycard-shell: Ethereum, Bitcoin, Bitcoin Multisig, Bitcoin Testnet, Bitget, Ledger Live, Ledger Legacy