### PR TITLE
feat: add mnemonic verification flow (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Add Ledger Live and Ledger Legacy export via `crypto-hdkey` with EIP-4527 `source` and `children` fields
+- Add mnemonic verification flow: enter recovery phrase, tap Keycard, confirm fingerprint match
 
 ### Changed
 

--- a/__tests__/KeyPairMenuScreen.test.tsx
+++ b/__tests__/KeyPairMenuScreen.test.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+
 import KeyPairMenuScreen, {
   dashboardEntry,
 } from '../src/screens/keypair/KeyPairMenuScreen';
@@ -72,10 +73,15 @@ describe('KeyPairMenuScreen', () => {
       const renderer = await renderScreen();
       expect(toJson(renderer)).toContain('Import recovery phrase');
     });
+
+    it('renders the "Verify recovery phrase" menu entry', async () => {
+      const renderer = await renderScreen();
+      expect(toJson(renderer)).toContain('Verify recovery phrase');
+    });
   });
 
   describe('navigation', () => {
-    it('navigates to ImportKey when "Import recovery phrase" is pressed', async () => {
+    it('navigates to Mnemonic when "Import recovery phrase" is pressed', async () => {
       const renderer = await renderScreen();
       const pressables = getActivePressables(renderer);
       const entry = pressables.find(p =>
@@ -84,7 +90,21 @@ describe('KeyPairMenuScreen', () => {
       await act(async () => {
         entry!.props.onPress();
       });
-      expect(navigation.navigate).toHaveBeenCalledWith('ImportKey');
+      expect(navigation.navigate).toHaveBeenCalledWith('Mnemonic');
+    });
+
+    it('navigates to Mnemonic with verify mode when "Verify recovery phrase" is pressed', async () => {
+      const renderer = await renderScreen();
+      const pressables = getActivePressables(renderer);
+      const entry = pressables.find(p =>
+        extractText(p).includes('Verify recovery phrase'),
+      );
+      await act(async () => {
+        entry!.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('Mnemonic', {
+        mode: 'verify',
+      });
     });
 
     it('navigates to KeySize when "Generate new key pair" is pressed', async () => {
@@ -102,7 +122,7 @@ describe('KeyPairMenuScreen', () => {
 
   describe('dashboardEntry', () => {
     it('has the correct label', () => {
-      expect(dashboardEntry.label).toBe('Add Keypair');
+      expect(dashboardEntry.label).toBe('Keypair');
     });
 
     it('navigates to KeyPairMenu when invoked', () => {

--- a/__tests__/MnemonicScreen.test.tsx
+++ b/__tests__/MnemonicScreen.test.tsx
@@ -1,7 +1,8 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import ImportKeyScreen from '../src/screens/keypair/ImportKeyScreen';
+
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import MnemonicScreen from '../src/screens/keypair/MnemonicScreen';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -31,9 +32,14 @@ const mockStart = jest.fn();
 const mockCancel = jest.fn();
 const mockSubmitPin = jest.fn();
 const mockUseLoadKey = jest.fn();
+const mockUseVerifyMnemonic = jest.fn();
 
 jest.mock('../src/hooks/keycard/useLoadKey', () => ({
   useLoadKey: (...args: any[]) => mockUseLoadKey(...args),
+}));
+
+jest.mock('../src/hooks/keycard/useVerifyMnemonic', () => ({
+  useVerifyMnemonic: (...args: any[]) => mockUseVerifyMnemonic(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -49,14 +55,21 @@ const VALID_24 =
 
 const navigation = {
   navigate: jest.fn(),
+  reset: jest.fn(),
   setOptions: jest.fn(),
 } as any;
 
-const route = { key: 'ImportKey', name: 'ImportKey' } as any;
+const route = { key: 'Mnemonic', name: 'Mnemonic', params: undefined } as any;
+const routeVerify = {
+  key: 'Mnemonic',
+  name: 'Mnemonic',
+  params: { mode: 'verify' },
+} as any;
 
-function hookMock(phase = 'idle') {
+function hookMock(phase = 'idle', result: string | null = null) {
   return {
     phase,
+    result,
     status: '',
     pinError: null,
     start: mockStart,
@@ -67,10 +80,11 @@ function hookMock(phase = 'idle') {
 
 async function renderScreen(phase = 'idle') {
   mockUseLoadKey.mockReturnValue(hookMock(phase));
+  mockUseVerifyMnemonic.mockReturnValue(hookMock(phase));
   let renderer!: ReactTestRenderer.ReactTestRenderer;
   await act(async () => {
     renderer = ReactTestRenderer.create(
-      <ImportKeyScreen navigation={navigation} route={route} />,
+      <MnemonicScreen navigation={navigation} route={route} />,
     );
   });
   return renderer;
@@ -120,14 +134,16 @@ function setInput(renderer: ReactTestRenderer.ReactTestRenderer, text: string) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('ImportKeyScreen', () => {
+describe('MnemonicScreen', () => {
   beforeEach(() => {
     navigation.navigate.mockClear();
+    navigation.reset.mockClear();
     navigation.setOptions.mockClear();
     mockStart.mockClear();
     mockCancel.mockClear();
     MockNFCBottomSheet.mockClear();
     mockUseLoadKey.mockReturnValue(hookMock());
+    mockUseVerifyMnemonic.mockReturnValue(hookMock());
   });
 
   describe('layout', () => {
@@ -307,7 +323,7 @@ describe('ImportKeyScreen', () => {
   });
 
   describe('navigation', () => {
-    it('navigates to Dashboard with toast when phase is done', async () => {
+    it('navigates to Dashboard with toast when phase is done (import mode)', async () => {
       await renderScreen('done');
       expect(navigation.navigate).toHaveBeenCalledWith('Dashboard', {
         toast: 'Key pair has been added to Keycard',
@@ -317,6 +333,48 @@ describe('ImportKeyScreen', () => {
     it('does not navigate when phase is not done', async () => {
       await renderScreen('idle');
       expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verify mode', () => {
+    async function renderVerify(phase = 'idle', result: string | null = null) {
+      mockUseLoadKey.mockReturnValue(hookMock(phase));
+      mockUseVerifyMnemonic.mockReturnValue(hookMock(phase, result));
+      let renderer!: ReactTestRenderer.ReactTestRenderer;
+      await act(async () => {
+        renderer = ReactTestRenderer.create(
+          <MnemonicScreen navigation={navigation} route={routeVerify} />,
+        );
+      });
+      return renderer;
+    }
+
+    it('shows "Verify" button label', async () => {
+      const renderer = await renderVerify();
+      expect(JSON.stringify(renderer.toJSON())).toContain('Verify');
+    });
+
+    it('resets to Dashboard with match toast', async () => {
+      await renderVerify('done', 'match');
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          { name: 'Dashboard', params: { toast: 'Recovery phrase matches' } },
+        ],
+      });
+    });
+
+    it('resets to Dashboard with mismatch toast', async () => {
+      await renderVerify('done', 'mismatch');
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          {
+            name: 'Dashboard',
+            params: { toast: 'Recovery phrase does not match' },
+          },
+        ],
+      });
     });
   });
 

--- a/__tests__/useVerifyMnemonic.test.ts
+++ b/__tests__/useVerifyMnemonic.test.ts
@@ -1,0 +1,196 @@
+import React, { act } from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+import { useVerifyMnemonic } from '../src/hooks/keycard/useVerifyMnemonic';
+
+// ---------------------------------------------------------------------------
+// Mock useKeycardOperation
+// ---------------------------------------------------------------------------
+
+type OperationFn = (cmdSet: any) => Promise<any>;
+
+let capturedOperation: OperationFn | null = null;
+let capturedOptions: { requiresPin?: boolean } | null = null;
+
+const mockExecute = jest.fn(
+  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+  },
+);
+const mockCancel = jest.fn();
+const mockReset = jest.fn();
+const mockSubmitPin = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOperation: () => ({
+    phase: 'idle',
+    status: '',
+    result: null,
+    execute: mockExecute,
+    cancel: mockCancel,
+    reset: mockReset,
+    submitPin: mockSubmitPin,
+  }),
+}));
+
+// Mock Mnemonic and BIP32KeyPair
+const mockToBinarySeed = jest.fn().mockReturnValue(Buffer.from('seed'));
+const mockFromBinarySeed = jest
+  .fn()
+  .mockReturnValue({ publicKey: new Uint8Array([4, 1, 2]) });
+
+jest.mock('keycard-sdk/dist/mnemonic', () => ({
+  Mnemonic: { toBinarySeed: (...args: any[]) => mockToBinarySeed(...args) },
+}));
+
+jest.mock('keycard-sdk/dist/bip32key', () => ({
+  BIP32KeyPair: {
+    fromBinarySeed: (...args: any[]) => mockFromBinarySeed(...args),
+  },
+}));
+
+// Mock pubKeyFingerprint and parsePublicKeyFromTLV
+const mockPubKeyFingerprint = jest.fn();
+const mockParsePublicKeyFromTLV = jest.fn();
+
+jest.mock('../src/utils/cryptoAccount', () => ({
+  pubKeyFingerprint: (...args: any[]) => mockPubKeyFingerprint(...args),
+}));
+
+jest.mock('../src/utils/keycardExport', () => ({
+  parsePublicKeyFromTLV: (...args: any[]) => mockParsePublicKeyFromTLV(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Test wrapper
+// ---------------------------------------------------------------------------
+
+const WORDS = Array(12).fill('word');
+
+let hookStart: () => void;
+
+function TestHook({ passphrase }: { passphrase?: string } = {}) {
+  const { start } = useVerifyMnemonic(WORDS, passphrase);
+  hookStart = start;
+  return null;
+}
+
+async function mountHook(passphrase?: string) {
+  let renderer!: ReactTestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = ReactTestRenderer.create(
+      React.createElement(TestHook, { passphrase }),
+    );
+  });
+  return renderer;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useVerifyMnemonic', () => {
+  beforeEach(() => {
+    mockExecute.mockClear();
+    mockToBinarySeed.mockClear();
+    mockFromBinarySeed.mockClear();
+    mockPubKeyFingerprint.mockClear();
+    mockParsePublicKeyFromTLV.mockClear();
+    capturedOperation = null;
+    capturedOptions = null;
+  });
+
+  it('calls execute with requiresPin: true', async () => {
+    await mountHook();
+    await act(async () => {
+      hookStart();
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(capturedOptions).toEqual({ requiresPin: true });
+  });
+
+  describe('operation callback', () => {
+    async function runOperation(cmdSet: any) {
+      await mountHook();
+      await act(async () => {
+        hookStart();
+      });
+      return capturedOperation!(cmdSet);
+    }
+
+    it('returns "match" when fingerprints match', async () => {
+      const cardPubKey = new Uint8Array([4, 9, 8]);
+      mockParsePublicKeyFromTLV.mockReturnValue(cardPubKey);
+      mockPubKeyFingerprint
+        .mockReturnValueOnce(0xdeadbeef) // mnemonic fingerprint
+        .mockReturnValueOnce(0xdeadbeef); // card fingerprint
+
+      const mockCheckOK = jest.fn();
+      const cmdSet = {
+        exportKey: jest
+          .fn()
+          .mockResolvedValue({ checkOK: mockCheckOK, data: cardPubKey }),
+      };
+
+      const result = await runOperation(cmdSet);
+
+      expect(result).toBe('match');
+      expect(cmdSet.exportKey).toHaveBeenCalledWith(0, true, 'm', false);
+      expect(mockCheckOK).toHaveBeenCalled();
+    });
+
+    it('returns "mismatch" when fingerprints differ', async () => {
+      const cardPubKey = new Uint8Array([4, 9, 8]);
+      mockParsePublicKeyFromTLV.mockReturnValue(cardPubKey);
+      mockPubKeyFingerprint
+        .mockReturnValueOnce(0x11111111) // mnemonic fingerprint
+        .mockReturnValueOnce(0x22222222); // card fingerprint
+
+      const cmdSet = {
+        exportKey: jest.fn().mockResolvedValue({
+          checkOK: jest.fn(),
+          data: cardPubKey,
+        }),
+      };
+
+      const result = await runOperation(cmdSet);
+      expect(result).toBe('mismatch');
+    });
+
+    it('passes passphrase to toBinarySeed', async () => {
+      mockParsePublicKeyFromTLV.mockReturnValue(new Uint8Array([4]));
+      mockPubKeyFingerprint.mockReturnValue(0);
+
+      const cmdSet = {
+        exportKey: jest.fn().mockResolvedValue({
+          checkOK: jest.fn(),
+          data: new Uint8Array([4]),
+        }),
+      };
+
+      await mountHook('secret');
+      await act(async () => {
+        hookStart();
+      });
+      await capturedOperation!(cmdSet);
+
+      expect(mockToBinarySeed).toHaveBeenCalledWith(WORDS.join(' '), 'secret');
+    });
+
+    it('uses empty string passphrase when none provided', async () => {
+      mockParsePublicKeyFromTLV.mockReturnValue(new Uint8Array([4]));
+      mockPubKeyFingerprint.mockReturnValue(0);
+
+      const cmdSet = {
+        exportKey: jest.fn().mockResolvedValue({
+          checkOK: jest.fn(),
+          data: new Uint8Array([4]),
+        }),
+      };
+
+      await runOperation(cmdSet);
+      expect(mockToBinarySeed).toHaveBeenCalledWith(WORDS.join(' '), '');
+    });
+  });
+});

--- a/src/hooks/keycard/useVerifyMnemonic.ts
+++ b/src/hooks/keycard/useVerifyMnemonic.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+
+import { BIP32KeyPair } from 'keycard-sdk/dist/bip32key';
+import { Mnemonic } from 'keycard-sdk/dist/mnemonic';
+
+import { pubKeyFingerprint } from '../../utils/cryptoAccount';
+import { parsePublicKeyFromTLV } from '../../utils/keycardExport';
+import { useKeycardOperation } from './useKeycardOperation';
+
+export type VerifyMnemonicResult = 'match' | 'mismatch';
+
+export function useVerifyMnemonic(words: string[], passphrase?: string) {
+  const keycard = useKeycardOperation<VerifyMnemonicResult>();
+
+  const start = useCallback(() => {
+    keycard.execute(
+      async cmdSet => {
+        const phrase = words.join(' ');
+        const seed = Mnemonic.toBinarySeed(phrase, passphrase ?? '');
+        const masterKeyPair = BIP32KeyPair.fromBinarySeed(seed);
+        const mnemonicFingerprint = pubKeyFingerprint(masterKeyPair.publicKey);
+
+        const resp = await cmdSet.exportKey(0, true, 'm', false);
+        resp.checkOK();
+        const cardFingerprint = pubKeyFingerprint(
+          parsePublicKeyFromTLV(resp.data),
+        );
+
+        return mnemonicFingerprint === cardFingerprint ? 'match' : 'mismatch';
+      },
+      { requiresPin: true },
+    );
+  }, [keycard, words, passphrase]);
+
+  return { ...keycard, start };
+}

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -1,5 +1,5 @@
-import React from 'react';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import React from 'react';
 
 import theme from '../theme';
 import type { RootStackParamList } from './types';
@@ -22,9 +22,9 @@ import AddressesMenuScreen from '../screens/address/AddressMenuScreen';
 // Key pair screens
 import ConfirmKeyScreen from '../screens/keypair/ConfirmKeyScreen';
 import GenerateKeyScreen from '../screens/keypair/GenerateKeyScreen';
-import ImportKeyScreen from '../screens/keypair/ImportKeyScreen';
 import KeyPairMenuScreen from '../screens/keypair/KeyPairMenuScreen';
 import KeySizeScreen from '../screens/keypair/KeySizeScreen';
+import MnemonicScreen from '../screens/keypair/MnemonicScreen';
 
 // Secrets screens
 import ChangeSecretScreen from '../screens/secrets/ChangeSecretScreen';
@@ -90,8 +90,8 @@ export const routes: Route[] = [
     options: defaultHeaderOptions,
   },
   {
-    name: 'ImportKey',
-    component: ImportKeyScreen,
+    name: 'Mnemonic',
+    component: MnemonicScreen,
     options: defaultHeaderOptions,
   },
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -49,7 +49,7 @@ export type RootStackParamList = {
   KeySize: undefined;
   GenerateKey: { size: 12 | 24; passphrase?: boolean };
   ConfirmKey: { words: string[]; passphrase?: string };
-  ImportKey: undefined;
+  Mnemonic: { mode?: 'import' | 'verify' } | undefined;
   FactoryReset: undefined;
   AddressMenu: undefined;
   AddressList: { coin: 'btc' | 'eth' };
@@ -94,9 +94,9 @@ export type ExportKeyScreenProps = NativeStackScreenProps<
   'ExportKey'
 >;
 
-export type ImportKeyScreenProps = NativeStackScreenProps<
+export type MnemonicScreenProps = NativeStackScreenProps<
   RootStackParamList,
-  'ImportKey'
+  'Mnemonic'
 >;
 
 export type FactoryResetSreenProps = NativeStackScreenProps<

--- a/src/screens/keypair/KeyPairMenuScreen.tsx
+++ b/src/screens/keypair/KeyPairMenuScreen.tsx
@@ -9,7 +9,7 @@ import theme from '../../theme';
 import Menu from '../../components/Menu';
 
 export const dashboardEntry: DashboardAction = {
-  label: 'Add Keypair',
+  label: 'Keypair',
   navigate: nav => nav.navigate('KeyPairMenu'),
 };
 
@@ -19,11 +19,15 @@ export default function KeyPairMenuScreen({
   const entries = [
     {
       label: 'Import recovery phrase',
-      onPress: () => navigation.navigate('ImportKey'),
+      onPress: () => navigation.navigate('Mnemonic'),
     },
     {
       label: 'Generate new key pair',
       onPress: () => navigation.navigate('KeySize'),
+    },
+    {
+      label: 'Verify recovery phrase',
+      onPress: () => navigation.navigate('Mnemonic', { mode: 'verify' }),
     },
   ];
   return (

--- a/src/screens/keypair/MnemonicScreen.tsx
+++ b/src/screens/keypair/MnemonicScreen.tsx
@@ -6,6 +6,8 @@ import {
   useState,
 } from 'react';
 import {
+  Keyboard,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -17,24 +19,43 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 
-import { ImportKeyScreenProps } from '../../navigation/types';
+import { MnemonicScreenProps } from '../../navigation/types';
 import theme from '../../theme';
 
+import { Icons } from '../../assets/icons';
 import NFCBottomSheet from '../../components/NFCBottomSheet';
 import PrimaryButton from '../../components/PrimaryButton';
-import { Icons } from '../../assets/icons';
 
 import { useLoadKey } from '../../hooks/keycard/useLoadKey';
+import { useVerifyMnemonic } from '../../hooks/keycard/useVerifyMnemonic';
 
-const TOAST = 'Key pair has been added to Keycard';
-
-export default function ImportKeyScreen({ navigation }: ImportKeyScreenProps) {
+export default function MnemonicScreen({
+  navigation,
+  route,
+}: MnemonicScreenProps) {
+  const mode = route.params?.mode ?? 'import';
   const insets = useSafeAreaInsets();
   const [wordCount, setWordCount] = useState<12 | 24>(12);
   const [input, setInput] = useState('');
   const [passphrase, setPassphrase] = useState('');
   const [wordError, setWordError] = useState<string | null>(null);
   const [phraseError, setPhraseError] = useState<string | null>(null);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const show = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
+      e => setKeyboardHeight(e.endCoordinates.height),
+    );
+    const hide = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      () => setKeyboardHeight(0),
+    );
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
 
   const words = useMemo(
     () =>
@@ -45,8 +66,10 @@ export default function ImportKeyScreen({ navigation }: ImportKeyScreenProps) {
     [input],
   );
 
-  const keycard = useLoadKey(words, passphrase || undefined);
-  const { phase, start, cancel } = keycard;
+  const loadKey = useLoadKey(words, passphrase || undefined);
+  const verifyMnemonic = useVerifyMnemonic(words, passphrase || undefined);
+  const keycard = mode === 'verify' ? verifyMnemonic : loadKey;
+  const { phase, result, start, cancel } = keycard;
 
   const handleTextChange = useCallback((text: string) => {
     setInput(text);
@@ -73,17 +96,41 @@ export default function ImportKeyScreen({ navigation }: ImportKeyScreenProps) {
   }, [cancel]);
 
   useEffect(() => {
-    if (phase === 'done') {
-      navigation.navigate('Dashboard', { toast: TOAST });
+    if (phase !== 'done') {
+      return;
     }
-  }, [phase, navigation]);
+    if (mode === 'verify') {
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: 'Dashboard',
+            params: {
+              toast:
+                result === 'match'
+                  ? 'Recovery phrase matches'
+                  : 'Recovery phrase does not match',
+            },
+          },
+        ],
+      });
+    } else {
+      navigation.navigate('Dashboard', {
+        toast: 'Key pair has been added to Keycard',
+      });
+    }
+  }, [phase, result, mode, navigation]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
       title:
-        phase === 'pin_entry' ? 'Enter Keycard PIN' : 'Import recovery phrase',
+        phase === 'pin_entry'
+          ? 'Enter Keycard PIN'
+          : mode === 'verify'
+          ? 'Verify recovery phrase'
+          : 'Import recovery phrase',
     });
-  }, [navigation, phase]);
+  }, [navigation, phase, mode]);
 
   const isComplete = words.length === wordCount;
 
@@ -157,9 +204,14 @@ export default function ImportKeyScreen({ navigation }: ImportKeyScreenProps) {
         />
       </ScrollView>
 
-      <View style={styles.buttonContainer}>
+      <View
+        style={[
+          styles.buttonContainer,
+          keyboardHeight > 0 && { paddingBottom: keyboardHeight + 8 },
+        ]}
+      >
         <PrimaryButton
-          label="Continue"
+          label={mode === 'verify' ? 'Verify' : 'Continue'}
           icon={Icons.nfcActivate}
           onPress={handleContinue}
           disabled={!isComplete}

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -208,7 +208,7 @@ function bitcoinDescriptorPlan(path: string): BitcoinDescriptorPlan[] {
   ];
 }
 
-function parsePublicKeyFromTLV(data: Uint8Array): Uint8Array {
+export function parsePublicKeyFromTLV(data: Uint8Array): Uint8Array {
   const tlv = new Keycard.BERTLV(data);
   tlv.enterConstructed(TLV_KEY_TEMPLATE);
   return tlv.readPrimitive(TLV_PUB_KEY);


### PR DESCRIPTION
- Adds a "Verify recovery phrase" entry to the Keypair menu. The user enters their mnemonic (and optional passphrase), taps the Keycard, and sees a match/mismatch result — without loading any key onto the card.
- Unifies ImportKeyScreen and the new verify flow into a single MnemonicScreen component, selected via a mode param (import | verify). No duplicated UI.
- useVerifyMnemonic derives the BIP32 master key fingerprint from the entered phrase and compares it against the fingerprint exported from the card via exportKey(m).
- Fixes keyboard covering the Continue/Verify button by tracking keyboard height with Keyboard.
- Renames the dashboard entry "Add Keypair" → "Keypair".