### PR TITLE
feat: Support legacy Bitcoin message signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Centralize all colors in `theme.ts`; replace hardcoded hex strings throughout components and screens with theme tokens
 
+### Fixed
+
+- Reject unsupported `btc-sign-request` data types instead of treating them as legacy Bitcoin messages
+
 ## [0.8.0] - 2026-04-06
 
 ### Added

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -1,7 +1,8 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import KeycardScreen from '../src/screens/KeycardScreen';
+
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import KeycardScreen from '../src/screens/KeycardScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -417,9 +418,34 @@ describe('KeycardScreen', () => {
   });
 
   describe('BTC message sign navigation', () => {
-    it('calls execute for a btc message sign operation', async () => {
+    it('signs the legacy Bitcoin message hash with the requested path', async () => {
+      const { hashBitcoinMessage } = require('../src/utils/btcMessage') as {
+        hashBitcoinMessage: jest.Mock;
+      };
+      const hash = new Uint8Array(32).fill(0xab);
+      hashBitcoinMessage.mockReturnValue(hash);
+      const checkOK = jest.fn();
+      const signWithPath = jest.fn().mockResolvedValue({
+        checkOK,
+        data: new Uint8Array([1, 2, 3]),
+      });
+
       await renderScreen('pin_entry', btcMessageSignRoute);
+
       expect(mockExecute).toHaveBeenCalledTimes(1);
+      const signOperation = mockExecute.mock.calls[0][0];
+      const result = await signOperation({ signWithPath });
+
+      expect(hashBitcoinMessage).toHaveBeenCalledWith(
+        btcMessageSignRoute.params.signDataHex,
+      );
+      expect(signWithPath).toHaveBeenCalledWith(
+        hash,
+        btcMessageSignRoute.params.derivationPath,
+        false,
+      );
+      expect(checkOK).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(new Uint8Array([1, 2, 3]));
     });
 
     it('navigates to QRResult after btc message sign completes', async () => {

--- a/__tests__/btcMessage.test.ts
+++ b/__tests__/btcMessage.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable no-bitwise */
+import * as secp from '@noble/secp256k1';
+import { URDecoder } from '@ngraveio/bc-ur';
+import CBOR from 'cbor-sync';
+
+import {
+  buildBtcSignatureUR,
+  hashBitcoinMessage,
+  parseKeycardBtcMessageSignature,
+} from '../src/utils/btcMessage';
+
+function tlvEncode(tag: number, value: Uint8Array): Uint8Array {
+  const len = value.length;
+  let header: Uint8Array;
+  if (len < 0x80) {
+    header = new Uint8Array([tag, len]);
+  } else if (len < 0x100) {
+    header = new Uint8Array([tag, 0x81, len]);
+  } else {
+    header = new Uint8Array([tag, 0x82, (len >> 8) & 0xff, len & 0xff]);
+  }
+  const out = new Uint8Array(header.length + len);
+  out.set(header, 0);
+  out.set(value, header.length);
+  return out;
+}
+
+function derInt(n: Uint8Array): Uint8Array {
+  let start = 0;
+  while (start < n.length - 1 && n[start] === 0) {
+    start++;
+  }
+  const trimmed = n.slice(start);
+  if (trimmed[0] >= 0x80) {
+    const padded = new Uint8Array(trimmed.length + 1);
+    padded[0] = 0x00;
+    padded.set(trimmed, 1);
+    return tlvEncode(0x02, padded);
+  }
+  return tlvEncode(0x02, trimmed);
+}
+
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.length;
+  }
+  return out;
+}
+
+function buildSignatureTLV(
+  pubKey: Uint8Array,
+  r: Uint8Array,
+  s: Uint8Array,
+): Uint8Array {
+  const sequence = tlvEncode(0x30, concatBytes(derInt(r), derInt(s)));
+  const inner = concatBytes(tlvEncode(0x80, pubKey), sequence);
+  return tlvEncode(0xa0, inner);
+}
+
+function decodeUR(urString: string): Record<number, any> {
+  const decoder = new URDecoder();
+  decoder.receivePart(urString);
+  return CBOR.decode(decoder.resultUR().cbor);
+}
+
+const PRIV_KEY = new Uint8Array(32);
+PRIV_KEY[31] = 1;
+
+describe('btcMessage', () => {
+  it('hashes legacy Bitcoin messages with the shell-compatible prefix', () => {
+    const hash = hashBitcoinMessage(
+      Buffer.from('hello btc', 'utf8').toString('hex'),
+    );
+
+    expect(Buffer.from(hash).toString('hex')).toBe(
+      'f43270780f43a66bd855d3640d581d2621589f760eadc69a282d0e37d4f77783',
+    );
+  });
+
+  it('converts a Keycard recoverable signature into compact Bitcoin message format', async () => {
+    const hash = hashBitcoinMessage(
+      Buffer.from('hello btc', 'utf8').toString('hex'),
+    );
+    const sigBytes = await secp.signAsync(hash, PRIV_KEY, {
+      prehash: false,
+      format: 'recovered',
+      extraEntropy: false,
+    });
+    const recId = sigBytes[0];
+    const r = sigBytes.slice(1, 33);
+    const s = sigBytes.slice(33, 65);
+    const pubKey = secp.getPublicKey(PRIV_KEY, false);
+    const tlv = buildSignatureTLV(pubKey, r, s);
+
+    const { signature, publicKey } = parseKeycardBtcMessageSignature(hash, tlv);
+
+    expect(signature).toHaveLength(65);
+    expect(signature[0]).toBe(31 + recId);
+    expect(signature.subarray(1, 33)).toEqual(Buffer.from(r));
+    expect(signature.subarray(33, 65)).toEqual(Buffer.from(s));
+    expect(publicKey).toEqual(Buffer.from(secp.getPublicKey(PRIV_KEY, true)));
+  });
+
+  it('builds a btc-signature UR with signature and public key bytes', () => {
+    const signature = Buffer.alloc(65, 0x11);
+    const publicKey = Buffer.alloc(33, 0x02);
+    const ur = buildBtcSignatureUR({
+      requestId: '00112233445566778899aabbccddeeff',
+      signature,
+      publicKey,
+    });
+
+    const decoded = decodeUR(ur);
+
+    expect(ur.toLowerCase()).toMatch(/^ur:btc-signature\//);
+    expect(decoded[2]).toEqual(signature);
+    expect(decoded[3]).toEqual(publicKey);
+  });
+});

--- a/__tests__/ur.test.ts
+++ b/__tests__/ur.test.ts
@@ -52,6 +52,7 @@ function buildBtcSignRequestCbor(
   opts: {
     xfp?: string;
     uuid?: string;
+    dataType?: number;
     address?: string;
     origin?: string;
   } = {},
@@ -79,7 +80,7 @@ function buildBtcSignRequestCbor(
       RegistryTypes.UUID.getTag(),
     ),
     2: Buffer.from(message, 'utf8'),
-    3: 1,
+    3: opts.dataType ?? 1,
     4: [keypathItem],
   };
 
@@ -263,6 +264,19 @@ describe('handleUR – btc-sign-request', () => {
     expect(result.kind).toBe('error');
     if (result.kind === 'error') {
       expect(result.message).toMatch(/Failed to parse BTC sign request/);
+    }
+  });
+
+  it('returns an error for unsupported btc-sign-request data types', () => {
+    const cbor = buildBtcSignRequestCbor('hello btc', "m/84'/0'/0'/0/3", {
+      dataType: 2,
+    });
+
+    const result = handleUR('btc-sign-request', cbor);
+
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/Unsupported btc-sign-request data type/);
     }
   });
 });

--- a/src/utils/btcMessage.ts
+++ b/src/utils/btcMessage.ts
@@ -131,10 +131,15 @@ export function parseBtcSignRequest(cbor: Buffer): BtcSignRequest {
     throw new Error('Missing btc-sign-request derivation path.');
   }
 
+  const normalizedDataType = Number(dataType ?? BTC_MESSAGE_DATA_TYPE);
+  if (normalizedDataType !== BTC_MESSAGE_DATA_TYPE) {
+    throw new Error('Unsupported btc-sign-request data type.');
+  }
+
   return {
     requestId: formatRequestId(requestId),
     signDataHex: signData.toString('hex'),
-    dataType: Number(dataType ?? BTC_MESSAGE_DATA_TYPE),
+    dataType: normalizedDataType,
     derivationPath: `m/${derivationPath}`,
     address: addresses?.[0],
     origin,


### PR DESCRIPTION
- Align direct `btc-sign-request` handling with keycard-shell legacy Bitcoin message signing behavior
- Reject unsupported `btc-sign-request` data types instead of treating them as legacy Bitcoin messages
- Add coverage for Bitcoin Signed Message hashing, compact signature encoding, `btc-signature` UR output, and Keycard signing flow
