### PR TITLE
feat: add NFC indicators to Keycard actions and menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Add Keycard menu and NFC action indicators so every visible NFC-triggering action shows the `Icons.nfcActivate` marker
+
 ## [0.9.0] - 2026-04-09
 
 ### Added

--- a/__tests__/AddressMenuScreen.test.tsx
+++ b/__tests__/AddressMenuScreen.test.tsx
@@ -65,6 +65,20 @@ describe('AddressMenuScreen', () => {
       const renderer = await renderScreen();
       expect(toJson(renderer)).toContain('Bitcoin');
     });
+
+    it('shows the NFC indicator for both address entries', async () => {
+      const renderer = await renderScreen();
+      expect(
+        renderer.root.findAll(
+          (node: any) => node.props.testID === 'menu-nfc-indicator-0',
+        ),
+      ).toHaveLength(1);
+      expect(
+        renderer.root.findAll(
+          (node: any) => node.props.testID === 'menu-nfc-indicator-1',
+        ),
+      ).toHaveLength(1);
+    });
   });
 
   describe('navigation', () => {

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -63,6 +63,18 @@ describe('ExportKeyScreen', () => {
       const renderer = await renderScreen();
       expect(toJson(renderer)).toContain('Ethereum');
     });
+
+    it('shows the NFC indicator for every export option', async () => {
+      const renderer = await renderScreen();
+
+      for (const index of [0, 1, 2, 3, 4, 5, 6]) {
+        expect(
+          renderer.root.findAll(
+            (node: any) => node.props.testID === `menu-nfc-indicator-${index}`,
+          ),
+        ).toHaveLength(1);
+      }
+    });
   });
 
   describe('navigation', () => {

--- a/__tests__/FactoryResetScreen.test.tsx
+++ b/__tests__/FactoryResetScreen.test.tsx
@@ -240,7 +240,7 @@ describe('FactoryResetScreen', () => {
 
   describe('dashboardEntry', () => {
     it('has the correct label', () => {
-      expect(dashboardEntry.label).toBe('Factory reset card');
+      expect(dashboardEntry.label).toBe('Factory reset');
     });
 
     it('navigates to FactoryReset when invoked', () => {

--- a/__tests__/InitCardScreen.test.tsx
+++ b/__tests__/InitCardScreen.test.tsx
@@ -313,7 +313,7 @@ describe('InitCardScreen', () => {
 
   describe('dashboardEntry', () => {
     it('has the correct label', () => {
-      expect(dashboardEntry.label).toBe('Initialize a Keycard');
+      expect(dashboardEntry.label).toBe('Initialize');
     });
 
     it('navigates to InitCard when invoked', () => {

--- a/__tests__/KeycardMenuScreen.test.tsx
+++ b/__tests__/KeycardMenuScreen.test.tsx
@@ -1,0 +1,128 @@
+import React, { act } from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+import KeycardMenuScreen, {
+  dashboardEntry,
+} from '../src/screens/KeycardMenuScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return { MD3DarkTheme: { colors: {} }, Text };
+});
+
+const navigation = { navigate: jest.fn() } as any;
+const route = { key: 'KeycardMenu', name: 'KeycardMenu' } as any;
+
+async function renderScreen() {
+  let renderer!: ReactTestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = ReactTestRenderer.create(
+      <KeycardMenuScreen navigation={navigation} route={route} />,
+    );
+  });
+  return renderer;
+}
+
+function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
+  return JSON.stringify(r.toJSON());
+}
+
+function extractText(node: any): string {
+  if (typeof node === 'string') return node;
+  if (Array.isArray(node)) return node.map(extractText).join('');
+  if (node?.children) return extractText(node.children);
+  return '';
+}
+
+function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
+  return renderer.root.findAll(
+    (node: any) =>
+      typeof node.props.onPress === 'function' && !node.props.disabled,
+    { deep: true },
+  );
+}
+
+describe('KeycardMenuScreen', () => {
+  beforeEach(() => {
+    navigation.navigate.mockClear();
+  });
+
+  it('renders the requested submenu items', async () => {
+    const renderer = await renderScreen();
+    const json = toJson(renderer);
+
+    expect(json).toContain('Initialize');
+    expect(json).toContain('Keypair');
+    expect(json).toContain('Secrets');
+    expect(json).toContain('Factory reset');
+  });
+
+  it('shows the NFC indicator only for Initialize', async () => {
+    const renderer = await renderScreen();
+
+    expect(
+      renderer.root.findAll(
+        (node: any) => node.props.testID === 'menu-nfc-indicator-0',
+      ),
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAll(
+        (node: any) => node.props.testID === 'menu-nfc-indicator-1',
+      ),
+    ).toHaveLength(0);
+    expect(
+      renderer.root.findAll(
+        (node: any) => node.props.testID === 'menu-nfc-indicator-2',
+      ),
+    ).toHaveLength(0);
+    expect(
+      renderer.root.findAll(
+        (node: any) => node.props.testID === 'menu-nfc-indicator-3',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('renders the NFC indicator with the primary accent color', async () => {
+    const renderer = await renderScreen();
+    const indicators = renderer.root.findAll(
+      (node: any) => node.props.testID === 'menu-nfc-indicator-0',
+    );
+
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0].props.color).toBe('#FF6400');
+  });
+
+  it('navigates to the expected screens', async () => {
+    const renderer = await renderScreen();
+    const pressables = getActivePressables(renderer);
+
+    for (const [label, screen] of [
+      ['Initialize', 'InitCard'],
+      ['Keypair', 'KeyPairMenu'],
+      ['Secrets', 'SecretsMenu'],
+      ['Factory reset', 'FactoryReset'],
+    ] as const) {
+      const entry = pressables.find(p => extractText(p).includes(label));
+      await act(async () => {
+        entry!.props.onPress();
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith(screen);
+    }
+  });
+
+  describe('dashboardEntry', () => {
+    it('has the correct label', () => {
+      expect(dashboardEntry.label).toBe('Keycard');
+    });
+
+    it('navigates to KeycardMenu when invoked', () => {
+      const nav = { navigate: jest.fn() } as any;
+      dashboardEntry.navigate(nav);
+      expect(nav.navigate).toHaveBeenCalledWith('KeycardMenu');
+    });
+  });
+});

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -5,6 +5,7 @@ import { Icons } from '../assets/icons';
 type Entry = {
   label: string;
   onPress: () => void;
+  requiresNfc?: boolean;
 };
 
 type Props = {
@@ -25,7 +26,17 @@ export default function Menu({ entries }: Props) {
             onPress={action.onPress}
           >
             <Text style={styles.itemLabel}>{action.label}</Text>
-            <Icons.chevronRight width={24} height={24} />
+            <View style={styles.trailingIcons}>
+              {action.requiresNfc ? (
+                <Icons.nfcActivate
+                  testID={`menu-nfc-indicator-${i}`}
+                  width={20}
+                  height={20}
+                  color={theme.colors.primary}
+                />
+              ) : null}
+              <Icons.chevronRight width={24} height={24} />
+            </View>
           </Pressable>
         ))}
       </View>
@@ -73,5 +84,10 @@ const styles = StyleSheet.create({
     lineHeight: 15 * 1.45,
     letterSpacing: -0.135,
     color: theme.colors.onSurface,
+  },
+  trailingIcons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
 });

--- a/src/navigation/dashboardActions.ts
+++ b/src/navigation/dashboardActions.ts
@@ -1,17 +1,11 @@
 import { DashboardAction } from './types';
 
 import { dashboardEntry as exportKeyEntry } from '../screens/ExportKeyScreen';
-import { dashboardEntry as factoryReset } from '../screens/FactoryResetScreen';
-import { dashboardEntry as initCard } from '../screens/InitCardScreen';
+import { dashboardEntry as keycardMenu } from '../screens/KeycardMenuScreen';
 import { dashboardEntry as addressMenu } from '../screens/address/AddressMenuScreen';
-import { dashboardEntry as keyPairMenu } from '../screens/keypair/KeyPairMenuScreen';
-import { dashboardEntry as secretsMenu } from '../screens/secrets/SecretsMenuScreen';
 
 export const dashboardActions: DashboardAction[] = [
-  initCard,
   exportKeyEntry,
-  keyPairMenu,
   addressMenu,
-  secretsMenu,
-  factoryReset,
+  keycardMenu,
 ];

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -9,6 +9,7 @@ import DashboardScreen from '../screens/DashboardScreen';
 import ExportKeyScreen from '../screens/ExportKeyScreen';
 import FactoryResetScreen from '../screens/FactoryResetScreen';
 import InitCardScreen from '../screens/InitCardScreen';
+import KeycardMenuScreen from '../screens/KeycardMenuScreen';
 import KeycardScreen from '../screens/KeycardScreen';
 import QRResultScreen from '../screens/QRResultScreen';
 import QRScannerScreen from '../screens/QRScannerScreen';
@@ -54,6 +55,11 @@ export const routes: Route[] = [
 
   // Keycard operations
   {
+    name: 'KeycardMenu',
+    component: KeycardMenuScreen,
+    options: { ...defaultHeaderOptions, title: 'Keycard' },
+  },
+  {
     name: 'InitCard',
     component: InitCardScreen,
     options: defaultHeaderOptions,
@@ -66,7 +72,7 @@ export const routes: Route[] = [
   {
     name: 'ExportKey',
     component: ExportKeyScreen,
-    options: { ...defaultHeaderOptions, title: 'Chain selection' },
+    options: { ...defaultHeaderOptions, title: 'Connect software wallet' },
   },
 
   // Key pair flow

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -38,6 +38,7 @@ export type SecretType = 'pin' | 'puk' | 'pairing';
 
 export type RootStackParamList = {
   Dashboard: { toast?: string } | undefined;
+  KeycardMenu: undefined;
   InitCard: undefined;
   SecretsMenu: undefined;
   ChangeSecret: { secretType: SecretType };
@@ -68,6 +69,11 @@ export type DashboardScreenProps = NativeStackScreenProps<
 export type InitCardScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'InitCard'
+>;
+
+export type KeycardMenuScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'KeycardMenu'
 >;
 
 export type QRScannerScreenProps = NativeStackScreenProps<

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -16,6 +16,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
   const entries = [
     {
       label: 'Ethereum',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -24,6 +25,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Bitcoin',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -32,6 +34,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Bitcoin Multisig',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -40,6 +43,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Bitcoin Testnet',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -48,6 +52,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Bitget',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -56,6 +61,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Ledger Live',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',
@@ -65,6 +71,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     },
     {
       label: 'Ledger Legacy',
+      requiresNfc: true,
       onPress: () =>
         navigation.navigate('Keycard', {
           operation: 'export_key',

--- a/src/screens/FactoryResetScreen.tsx
+++ b/src/screens/FactoryResetScreen.tsx
@@ -11,7 +11,7 @@ import { useFactoryReset } from '../hooks/keycard/useFactoryReset';
 import { Icons } from '../assets/icons';
 
 export const dashboardEntry: DashboardAction = {
-  label: 'Factory reset card',
+  label: 'Factory reset',
   navigate: nav => nav.navigate('FactoryReset'),
 };
 

--- a/src/screens/InitCardScreen.tsx
+++ b/src/screens/InitCardScreen.tsx
@@ -20,7 +20,7 @@ import NFCBottomSheet from '../components/NFCBottomSheet';
 import PinPad from '../components/PinPad';
 
 export const dashboardEntry: DashboardAction = {
-  label: 'Initialize a Keycard',
+  label: 'Initialize',
   navigate: nav => nav.navigate('InitCard'),
 };
 

--- a/src/screens/KeycardMenuScreen.tsx
+++ b/src/screens/KeycardMenuScreen.tsx
@@ -1,0 +1,47 @@
+import { StyleSheet, View } from 'react-native';
+
+import { DashboardAction, KeycardMenuScreenProps } from '../navigation/types';
+import Menu from '../components/Menu';
+import theme from '../theme';
+
+export const dashboardEntry: DashboardAction = {
+  label: 'Keycard',
+  navigate: nav => nav.navigate('KeycardMenu'),
+};
+
+export default function KeycardMenuScreen({
+  navigation,
+}: KeycardMenuScreenProps) {
+  const entries = [
+    {
+      label: 'Initialize',
+      requiresNfc: true,
+      onPress: () => navigation.navigate('InitCard'),
+    },
+    {
+      label: 'Keypair',
+      onPress: () => navigation.navigate('KeyPairMenu'),
+    },
+    {
+      label: 'Secrets',
+      onPress: () => navigation.navigate('SecretsMenu'),
+    },
+    {
+      label: 'Factory reset',
+      onPress: () => navigation.navigate('FactoryReset'),
+    },
+  ];
+
+  return (
+    <View style={styles.container}>
+      <Menu entries={entries} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+});

--- a/src/screens/address/AddressMenuScreen.tsx
+++ b/src/screens/address/AddressMenuScreen.tsx
@@ -21,10 +21,12 @@ export default function AddressesMenuScreen({
   const entries = [
     {
       label: 'Ethereum',
+      requiresNfc: true,
       onPress: () => navigation.navigate('AddressList', { coin: 'eth' }),
     },
     {
       label: 'Bitcoin',
+      requiresNfc: true,
       onPress: () => navigation.navigate('AddressList', { coin: 'btc' }),
     },
   ];


### PR DESCRIPTION
- add a dedicated Keycard menu screen and surface NFC indicators on visible actions that start NFC flows
- update shared menu rendering so NFC-triggering items display `Icons.nfcActivate`
