### PR TITLE
feat: fdroid release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -70,6 +70,15 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x android/gradlew
 
+      - name: Build unsigned release APK
+        run: cd android && ./gradlew assembleRelease --no-daemon
+
+      - name: Upload unsigned release APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gapsign-unsigned-${{ steps.ver.outputs.tag }}
+          path: android/app/build/outputs/apk/release/app-release-unsigned.apk
+
       - name: Decode keystore
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.keystore
@@ -79,7 +88,7 @@ jobs:
           ANDROID_KEYSTORE_PATH: release.keystore
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-        run: cd android && ./gradlew assembleRelease --no-daemon
+        run: cd android && ./gradlew clean assembleRelease --no-daemon
 
       - name: Create GitHub Release and upload APK
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- F-Droid release metadata, store listing text, and unsigned Android release artifact workflow
 - About screen with app description, Keycard link, contributors, and license list
 - Keycard menu and NFC action indicators so every visible NFC-triggering action shows the `Icons.nfcActivate` marker
 - Dismissible dashboard Keycard purchase notice

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -17,6 +17,11 @@ react {
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
     // cliFile = file("../../node_modules/react-native/cli.js")
 
+    def fdroidNode = file("../../.fdroid-node/bin/node")
+    if (fdroidNode.exists()) {
+        nodeExecutableAndArgs = [fdroidNode.absolutePath]
+    }
+
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
@@ -72,6 +77,11 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def releaseKeystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+def releaseKeystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+def releaseKeyAlias = System.getenv("ANDROID_KEY_ALIAS")
+def hasReleaseSigning = releaseKeystorePath && releaseKeystorePassword && releaseKeyAlias
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -92,11 +102,13 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
-        release {
-            storeFile file(System.getenv("ANDROID_KEYSTORE_PATH") ?: "debug.keystore")
-            storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD") ?: "android"
-            keyAlias System.getenv("ANDROID_KEY_ALIAS") ?: "androiddebugkey"
-            keyPassword System.getenv("ANDROID_KEYSTORE_PASSWORD") ?: "android"
+        if (hasReleaseSigning) {
+            release {
+                storeFile file(releaseKeystorePath)
+                storePassword releaseKeystorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeystorePassword
+            }
         }
     }
     buildTypes {
@@ -104,7 +116,9 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
-            signingConfig signingConfigs.release
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             crunchPngs false

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.nfc" android:required="true" />

--- a/assets/gapsign-icon-qr-card.svg
+++ b/assets/gapsign-icon-qr-card.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <defs>
+    <linearGradient id="cardFace" x1="202" y1="170" x2="822" y2="854" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2d2d2d"/>
+      <stop offset="0.52" stop-color="#1e1e1e"/>
+      <stop offset="1" stop-color="#121212"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="260" y1="234" x2="764" y2="790" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#e2e2e2"/>
+    </linearGradient>
+    <linearGradient id="edge" x1="188" y1="188" x2="836" y2="836" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff8a3d"/>
+      <stop offset="1" stop-color="#ff6400"/>
+    </linearGradient>
+    <filter id="shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="30" stdDeviation="30" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="132" y="158" width="760" height="708" rx="128" fill="url(#cardFace)" stroke="url(#edge)" stroke-width="34"/>
+    <rect x="502" y="226" width="20" height="572" rx="10" fill="#ff6400" opacity="0.9"/>
+  </g>
+
+  <g fill="url(#accent)">
+    <path d="M604 226h170v170H604V226Zm52 52v66h66v-66h-66Z" fill-rule="evenodd"/>
+    <path d="M250 620h170v170H250V620Zm52 52v66h66v-66h-66Z" fill-rule="evenodd"/>
+    <rect x="250" y="438" width="54" height="54" rx="11"/>
+    <rect x="316" y="438" width="54" height="54" rx="11" opacity="0.45"/>
+    <rect x="250" y="506" width="54" height="54" rx="11"/>
+    <rect x="316" y="506" width="108" height="54" rx="11"/>
+    <rect x="604" y="438" width="54" height="54" rx="11"/>
+    <rect x="670" y="438" width="108" height="54" rx="11"/>
+    <rect x="604" y="506" width="54" height="54" rx="11"/>
+    <rect x="724" y="506" width="54" height="54" rx="11"/>
+    <rect x="604" y="574" width="54" height="54" rx="11"/>
+    <rect x="670" y="574" width="54" height="54" rx="11" opacity="0.45"/>
+    <rect x="670" y="642" width="108" height="54" rx="11"/>
+    <rect x="604" y="710" width="54" height="54" rx="11"/>
+    <rect x="724" y="710" width="54" height="54" rx="11"/>
+  </g>
+
+  <g transform="translate(250 226) rotate(45 85 85)" fill="none" stroke="#ff6400" stroke-width="30" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="52" cy="85" r="34"/>
+    <path d="M86 85h112"/>
+    <path d="M162 85v40"/>
+    <path d="M198 85v30"/>
+  </g>
+</svg>

--- a/fastlane/metadata/android/en-US/changelogs/100.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100.txt
@@ -1,0 +1,1 @@
+Initial release. Scan Ethereum wallet QR requests, sign transactions with Keycard, and show the signed result as a QR code for scanning back into the wallet.

--- a/fastlane/metadata/android/en-US/changelogs/200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/200.txt
@@ -1,0 +1,1 @@
+Add software wallet connection flow with extended public key export over QR.

--- a/fastlane/metadata/android/en-US/changelogs/300.txt
+++ b/fastlane/metadata/android/en-US/changelogs/300.txt
@@ -1,0 +1,1 @@
+Add Keycard initialization and factory reset flows.

--- a/fastlane/metadata/android/en-US/changelogs/400.txt
+++ b/fastlane/metadata/android/en-US/changelogs/400.txt
@@ -1,0 +1,1 @@
+Add Keycard keypair generation flow.

--- a/fastlane/metadata/android/en-US/changelogs/500.txt
+++ b/fastlane/metadata/android/en-US/changelogs/500.txt
@@ -1,0 +1,1 @@
+Add address list and refresh the app UI design across screens.

--- a/fastlane/metadata/android/en-US/changelogs/600.txt
+++ b/fastlane/metadata/android/en-US/changelogs/600.txt
@@ -1,0 +1,1 @@
+Add genuine Keycard verification, recovery phrase import with optional BIP39 passphrase, clearer wrong-PIN feedback, and NFC disconnect guidance. Fix address menu spacing and improve address list rendering performance.

--- a/fastlane/metadata/android/en-US/changelogs/700.txt
+++ b/fastlane/metadata/android/en-US/changelogs/700.txt
@@ -1,0 +1,1 @@
+Add Change Secrets flow for updating Keycard PIN, PUK, and pairing password.

--- a/fastlane/metadata/android/en-US/changelogs/800.txt
+++ b/fastlane/metadata/android/en-US/changelogs/800.txt
@@ -1,0 +1,1 @@
+Add Bitcoin PSBT and BIP-322 message signing. Add Bitget multi-account export, EIP-2930 Ethereum transaction signing, and decoded EIP-712 review. Fix Rabby crypto-hdkey exports, SIWE/personal_sign hashing, malformed Ethereum sign request validation, scanner camera focus handling, and Android PIN pad spacing.

--- a/fastlane/metadata/android/en-US/changelogs/900.txt
+++ b/fastlane/metadata/android/en-US/changelogs/900.txt
@@ -1,0 +1,1 @@
+Add Ledger Live and Ledger Legacy export. Add mnemonic verification plus SLIP39 share generation, import, and verification. Centralize theme colors, move exported key parsing to keycard-sdk BIP32 helpers, update deprecated dependencies, and reject unsupported Bitcoin sign request data types.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,17 @@
+GapSign is an air-gapped hardware wallet companion app that works with a Keycard NFC smart card to sign Ethereum and Bitcoin transactions without ever connecting to the internet.
+
+Requires a Keycard hardware smart card (keycard.tech). The app communicates with the card over NFC — no USB, no Bluetooth, no internet.
+
+All communication happens through animated QR codes — your private keys never touch a networked device.
+
+Features:
+- Sign Ethereum transactions (legacy, EIP-1559, EIP-2930)
+- Sign EIP-712 typed data with decoded preview before approval
+- Sign personal messages (EIP-191 / SIWE)
+- Sign Bitcoin transactions via PSBT
+- Sign Bitcoin messages (BIP-322)
+- Export wallet keys to MetaMask, Rabby, Sparrow, BlueWallet, and Bitget via UR QR codes
+- Communicate with Keycard via NFC
+- Fully air-gapped — no internet permission, no network calls, no telemetry
+
+GapSign is free and open-source software.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Air-gapped hardware wallet companion for Ethereum and Bitcoin signing

--- a/fdroiddata-com.gapsign.yml
+++ b/fdroiddata-com.gapsign.yml
@@ -1,0 +1,62 @@
+# F-Droid metadata file for GapSign
+# Place this file at metadata/com.gapsign.yml in a fork of:
+# https://gitlab.com/fdroid/fdroiddata
+# Then open a merge request.
+
+Categories:
+  - Security
+
+License: MIT
+
+AuthorName: Mladen Milankovic
+AuthorWebSite: https://github.com/mmlado
+
+SourceCode: https://github.com/mmlado/GapSign
+IssueTracker: https://github.com/mmlado/GapSign/issues
+
+Summary: Air-gapped hardware wallet companion for Ethereum and Bitcoin signing
+Description: |-
+  GapSign works with a Keycard NFC smart card to sign Ethereum and Bitcoin
+  transactions without ever connecting to the internet.
+
+  Requires a Keycard hardware smart card (keycard.tech). The app communicates
+  with the card over NFC — no USB, no Bluetooth, no internet.
+
+  All communication with a watch-only wallet happens through animated QR codes.
+  Your private keys never touch a networked device.
+
+  Features:
+
+  * Sign Ethereum transactions (legacy, EIP-1559, EIP-2930)
+  * Sign EIP-712 typed data with decoded preview before approval
+  * Sign personal messages (EIP-191 / SIWE)
+  * Sign Bitcoin transactions via PSBT
+  * Sign Bitcoin messages (BIP-322)
+  * Export wallet keys to MetaMask, Rabby, Sparrow, BlueWallet, and Bitget
+  * Fully air-gapped — no internet permission, no network calls, no telemetry
+
+RepoType: git
+Repo: https://github.com/mmlado/GapSign
+
+Builds:
+  - versionName: 0.9.0
+    versionCode: 900
+    commit: v0.9.0
+    subdir: android/app
+    sudo:
+      - apt-get install -y openjdk-17-jdk
+    init:
+      - curl -fsSL https://nodejs.org/dist/v20.19.0/node-v20.19.0-linux-x64.tar.xz -o node.tar.xz
+      - echo "b4e336584d62abefad31baecff7af167268be9bb7dd11f1297112e6eed3ca0d5  node.tar.xz" | sha256sum -c
+      - mkdir -p .fdroid-node
+      - tar -xJf node.tar.xz -C .fdroid-node --strip-components=1
+      - .fdroid-node/bin/npm ci
+    scandelete:
+      - node_modules/
+    gradle:
+      - yes
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+CurrentVersion: 0.9.0
+CurrentVersionCode: 900

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -56,6 +56,20 @@ fs.writeFileSync(
 );
 
 // ---------------------------------------------------------------------------
+// package-lock.json
+// ---------------------------------------------------------------------------
+
+const lockPath = path.join(ROOT, 'package-lock.json');
+if (fs.existsSync(lockPath)) {
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  lock.version = newVersion;
+  if (lock.packages && lock.packages['']) {
+    lock.packages[''].version = newVersion;
+  }
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
+}
+
+// ---------------------------------------------------------------------------
 // android/app/build.gradle
 // ---------------------------------------------------------------------------
 
@@ -89,6 +103,16 @@ let changelog = fs.readFileSync(changelogPath, 'utf8');
 
 const prevMatch = changelog.match(/## \[(\d+\.\d+\.\d+)\]/);
 const prev = prevMatch ? prevMatch[1] : null;
+const unreleasedMatch = changelog.match(
+  /## \[Unreleased\]\n([\s\S]*?)(?=\n## \[\d+\.\d+\.\d+\])/,
+);
+const releaseNotes =
+  unreleasedMatch?.[1]
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('- '))
+    .map(line => line.replace(/^- /, ''))
+    .join(' ') || `Release ${newVersion}.`;
 
 changelog = changelog.replace(
   /^## \[Unreleased\]\n/m,
@@ -105,13 +129,39 @@ if (prev) {
 fs.writeFileSync(changelogPath, changelog);
 
 // ---------------------------------------------------------------------------
+// F-Droid metadata and Fastlane changelog
+// ---------------------------------------------------------------------------
+
+const fdroidMetadataPath = path.join(ROOT, 'fdroiddata-com.gapsign.yml');
+if (fs.existsSync(fdroidMetadataPath)) {
+  let fdroidMetadata = fs.readFileSync(fdroidMetadataPath, 'utf8');
+  fdroidMetadata = fdroidMetadata
+    .replace(/versionName: \d+\.\d+\.\d+/, `versionName: ${newVersion}`)
+    .replace(/versionCode: \d+/, `versionCode: ${versionCode}`)
+    .replace(/commit: v\d+\.\d+\.\d+/, `commit: v${newVersion}`)
+    .replace(/CurrentVersion: \d+\.\d+\.\d+/, `CurrentVersion: ${newVersion}`)
+    .replace(/CurrentVersionCode: \d+/, `CurrentVersionCode: ${versionCode}`);
+  fs.writeFileSync(fdroidMetadataPath, fdroidMetadata);
+}
+
+const fastlaneChangelogDir = path.join(
+  ROOT,
+  'fastlane/metadata/android/en-US/changelogs',
+);
+fs.mkdirSync(fastlaneChangelogDir, { recursive: true });
+fs.writeFileSync(
+  path.join(fastlaneChangelogDir, `${versionCode}.txt`),
+  `${releaseNotes}\n`,
+);
+
+// ---------------------------------------------------------------------------
 // Commit and push branch
 // ---------------------------------------------------------------------------
 
 const branch = `release/v${newVersion}`;
 execSync(`git checkout -b ${branch}`, { stdio: 'inherit' });
 execSync(
-  'git add package.json android/app/build.gradle ios/GapSign.xcodeproj/project.pbxproj CHANGELOG.md',
+  'git add package.json package-lock.json android/app/build.gradle ios/GapSign.xcodeproj/project.pbxproj CHANGELOG.md fdroiddata-com.gapsign.yml fastlane/metadata/android/en-US/changelogs',
   { stdio: 'inherit' },
 );
 execSync(`git commit -m "chore: bump version to ${newVersion}"`, {


### PR DESCRIPTION
## Summary

Prepare GapSign for F-Droid packaging and submission.

## Changes

- Add F-Droid/Fastlane Android metadata:
  - short description
  - full description
  - app icon
  - per-version changelogs for versionCodes 100-900
- Add draft `fdroiddata` recipe for `metadata/com.gapsign.yml`
- Remove `INTERNET` permission from release builds
- Keep `INTERNET` only for debug builds so React Native Metro development still works
- Make release signing optional so unsigned release APKs can be produced for F-Droid/reproducibility workflows
- Update Android release workflow to upload an unsigned release APK artifact
- Update `bump-version.js` to keep F-Droid metadata and Fastlane changelogs aligned with future version bumps
- Document F-Droid packaging conventions in `AGENTS.md`

## Notes

GapSign does not currently need network access. Release/F-Droid builds should remain air-gapped and request no `INTERNET` permission.