### PR TITLE
chore: split release APK by ABI

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -73,11 +73,11 @@ jobs:
       - name: Build unsigned release APK
         run: cd android && ./gradlew assembleRelease --no-daemon
 
-      - name: Upload unsigned release APK artifact
+      - name: Upload unsigned release APK artifacts
         uses: actions/upload-artifact@v4
         with:
           name: gapsign-unsigned-${{ steps.ver.outputs.tag }}
-          path: android/app/build/outputs/apk/release/app-release-unsigned.apk
+          path: android/app/build/outputs/apk/release/app-*-release-unsigned.apk
 
       - name: Decode keystore
         run: |
@@ -90,9 +90,9 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
         run: cd android && ./gradlew clean assembleRelease --no-daemon
 
-      - name: Create GitHub Release and upload APK
+      - name: Create GitHub Release and upload APKs
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
-          files: android/app/build/outputs/apk/release/app-release.apk
+          files: android/app/build/outputs/apk/release/app-*-release.apk
           generate_release_notes: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,6 +111,15 @@ android {
             }
         }
     }
+    splits {
+        abi {
+            enable true
+            reset()
+            include "arm64-v8a", "armeabi-v7a", "x86_64", "x86"
+            universalApk false
+        }
+    }
+
     buildTypes {
         debug {
             signingConfig signingConfigs.debug


### PR DESCRIPTION
Adds ABI splits to build.gradle so the release build produces separate APKs for arm64-v8a, armeabi-v7a, x86_64, and x86 instead of a single universal APK. Updates the CI workflow to upload and publish all four variants.