### PR TITLE
feat: scrambled pin pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Scramble PIN pad digit layout on mount and on each new error to prevent shoulder-surfing
 - F-Droid release metadata, store listing text, and unsigned Android release artifact workflow
 - About screen with app description, Keycard link, contributors, and license list
 - Keycard menu and NFC action indicators so every visible NFC-triggering action shows the `Icons.nfcActivate` marker

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -32,10 +32,6 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(renderer: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(renderer.toJSON());
-}
-
 function findText(renderer: ReactTestRenderer.ReactTestRenderer, text: string) {
   return renderer.root.findAll(
     (node: any) => node.type === 'Text' && node.props.children === text,
@@ -68,10 +64,10 @@ describe('AboutScreen', () => {
   it('renders the app, Keycard, contributors, and license sections', async () => {
     const renderer = await renderScreen();
 
-    expect(toJson(renderer)).toContain('GapSign');
-    expect(toJson(renderer)).toContain('Keycard required');
-    expect(toJson(renderer)).toContain('Mladen Milankovic');
-    expect(toJson(renderer)).toContain('Open-source licenses');
+    expect(JSON.stringify(renderer.toJSON())).toContain('GapSign');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Keycard required');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Mladen Milankovic');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Open-source licenses');
   });
 
   it('opens contributor GitHub profiles', async () => {

--- a/__tests__/AddressDetailScreen.test.tsx
+++ b/__tests__/AddressDetailScreen.test.tsx
@@ -65,10 +65,6 @@ async function renderScreen(address = ETH_ADDRESS, index = INDEX) {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -83,7 +79,7 @@ describe('AddressDetailScreen', () => {
   describe('layout', () => {
     it('renders the address text', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain(ETH_ADDRESS);
+      expect(JSON.stringify(renderer.toJSON())).toContain(ETH_ADDRESS);
     });
 
     it('passes the address to QRCode', async () => {

--- a/__tests__/AddressListScreen.test.tsx
+++ b/__tests__/AddressListScreen.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../src/utils/hdAddress', () => ({
 // Mock PinPad
 jest.mock('../src/components/PinPad', () => jest.fn(() => null));
 import PinPad from '../src/components/PinPad';
+import { getActivePressables } from './testUtils';
 const MockPinPad = PinPad as jest.MockedFunction<typeof PinPad>;
 
 // Mock useAddresses
@@ -98,18 +99,6 @@ async function renderScreen(
     jest.runAllTimers();
   });
   return renderer;
-}
-
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -216,8 +205,8 @@ describe('AddressListScreen', () => {
     it('renders the first batch of addresses', async () => {
       mockDeriveAddresses.mockReturnValue(makeBatch('0xAddr'));
       const renderer = await renderScreen('done', mockAccountKey);
-      expect(toJson(renderer)).toContain('0xAddr0');
-      expect(toJson(renderer)).toContain('0xAddr19');
+      expect(JSON.stringify(renderer.toJSON())).toContain('0xAddr0');
+      expect(JSON.stringify(renderer.toJSON())).toContain('0xAddr19');
     });
 
     it('loads more addresses starting at the next index on subsequent calls', async () => {
@@ -268,8 +257,8 @@ describe('AddressListScreen', () => {
       mockDeriveAddresses.mockReturnValue(makeBatch('bc1q'));
       await renderScreen('done', mockAccountKey, 'btc');
       expect(mockDeriveAddresses).toHaveBeenCalled();
-      const rendered = toJson(
-        (await renderScreen('done', mockAccountKey, 'btc')) as any,
+      const rendered = JSON.stringify(
+        (await renderScreen('done', mockAccountKey, 'btc')).toJSON(),
       );
       expect(rendered).toContain('bc1q0');
     });

--- a/__tests__/AddressMenuScreen.test.tsx
+++ b/__tests__/AddressMenuScreen.test.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { getActivePressables } from './testUtils';
 import AddressMenuScreen, {
   dashboardEntry,
 } from '../src/screens/address/AddressMenuScreen';
@@ -34,18 +35,6 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -58,12 +47,12 @@ describe('AddressMenuScreen', () => {
   describe('layout', () => {
     it('renders the "Ethereum" menu entry', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Ethereum');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Ethereum');
     });
 
     it('renders the "Bitcoin" menu entry', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Bitcoin');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Bitcoin');
     });
 
     it('shows the NFC indicator for both address entries', async () => {

--- a/__tests__/ChangeSecretScreen.test.tsx
+++ b/__tests__/ChangeSecretScreen.test.tsx
@@ -3,6 +3,7 @@ import ReactTestRenderer from 'react-test-renderer';
 
 import ChangeSecretScreen from '../src/screens/secrets/ChangeSecretScreen';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import { findKey } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -86,27 +87,15 @@ async function renderScreen(
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 async function enterDigits(
   renderer: ReactTestRenderer.ReactTestRenderer,
   count: number,
   keyIndex = 0,
 ) {
+  const digit = String(keyIndex + 1);
   for (let i = 0; i < count; i++) {
-    const keys = getActivePressables(renderer);
     await act(async () => {
-      keys[keyIndex].props.onPress();
+      findKey(renderer, digit).props.onPress();
     });
   }
 }
@@ -147,7 +136,7 @@ describe('ChangeSecretScreen', () => {
 
     it('shows "6 digits" label', async () => {
       const renderer = await renderScreen('pin');
-      expect(toJson(renderer)).toContain('6 digits');
+      expect(JSON.stringify(renderer.toJSON())).toContain('6 digits');
     });
 
     it('moves to confirm step and updates title after 6 digits', async () => {
@@ -170,7 +159,7 @@ describe('ChangeSecretScreen', () => {
       const renderer = await renderScreen('pin');
       await enterDigits(renderer, 6, 0); // 111111
       await enterDigits(renderer, 6, 1); // 222222
-      expect(toJson(renderer)).toContain("PINs don't match");
+      expect(JSON.stringify(renderer.toJSON())).toContain("PINs don't match");
       expect(mockStart).not.toHaveBeenCalled();
     });
 
@@ -208,7 +197,7 @@ describe('ChangeSecretScreen', () => {
 
     it('shows "12 digits" label', async () => {
       const renderer = await renderScreen('puk');
-      expect(toJson(renderer)).toContain('12 digits');
+      expect(JSON.stringify(renderer.toJSON())).toContain('12 digits');
     });
 
     it('calls start when confirmed PUK matches after 12 digits', async () => {
@@ -252,7 +241,7 @@ describe('ChangeSecretScreen', () => {
 
     it('does not show a PIN pad', async () => {
       const renderer = await renderScreen('pairing');
-      expect(toJson(renderer)).not.toContain('digits');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain('digits');
     });
 
     it('resets to Dashboard with "Pairing secret changed" toast when done', async () => {

--- a/__tests__/ConfirmKeyScreen.test.tsx
+++ b/__tests__/ConfirmKeyScreen.test.tsx
@@ -3,6 +3,7 @@ import ReactTestRenderer from 'react-test-renderer';
 import ConfirmKeyScreen from '../src/screens/keypair/ConfirmKeyScreen';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
 import PinPad from '../src/components/PinPad';
+import { getActivePressables } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -100,18 +101,6 @@ async function renderScreen(phase = 'idle') {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 /** Recursively extract all text content from a ReactTestInstance subtree. */
 function extractText(node: any): string {
   if (typeof node === 'string' || typeof node === 'number') return String(node);
@@ -177,13 +166,13 @@ describe('ConfirmKeyScreen', () => {
 
     it('shows unfilled slots at start', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('____');
+      expect(JSON.stringify(renderer.toJSON())).toContain('____');
     });
 
     it('shows choice buttons for the first challenge', async () => {
       const renderer = await renderScreen();
       // With random=0: slot 0 correct word is 'bravo', choices include it
-      expect(toJson(renderer)).toContain(CORRECT_WORDS[0]);
+      expect(JSON.stringify(renderer.toJSON())).toContain(CORRECT_WORDS[0]);
     });
 
     it('hides choices once all answers are filled', async () => {
@@ -202,9 +191,9 @@ describe('ConfirmKeyScreen', () => {
       const renderer = await renderScreen();
       await pressChoice(renderer, CORRECT_WORDS[0]);
       // First slot now shows the word instead of ____
-      expect(toJson(renderer)).toContain(CORRECT_WORDS[0]);
+      expect(JSON.stringify(renderer.toJSON())).toContain(CORRECT_WORDS[0]);
       // Second slot's correct word is now available as a choice
-      expect(toJson(renderer)).toContain(CORRECT_WORDS[1]);
+      expect(JSON.stringify(renderer.toJSON())).toContain(CORRECT_WORDS[1]);
     });
 
     it('does not advance when the wrong word is pressed', async () => {
@@ -218,7 +207,7 @@ describe('ConfirmKeyScreen', () => {
           wrongBtn.props.onPress();
         });
       }
-      expect(toJson(renderer)).toContain('____');
+      expect(JSON.stringify(renderer.toJSON())).toContain('____');
       expect(mockStart).not.toHaveBeenCalled();
     });
 

--- a/__tests__/DashboardScreen.test.tsx
+++ b/__tests__/DashboardScreen.test.tsx
@@ -72,10 +72,6 @@ async function renderScreen(routeParams?: { toast?: string }) {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -100,7 +96,7 @@ describe('DashboardScreen', () => {
   describe('static layout', () => {
     it('renders the Scan transaction button', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Scan transaction');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Scan transaction');
     });
 
     it('renders one fewer pressable when action list is empty', async () => {
@@ -129,8 +125,8 @@ describe('DashboardScreen', () => {
         { label: 'Action Two', navigate: jest.fn() },
       );
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Action One');
-      expect(toJson(renderer)).toContain('Action Two');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Action One');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Action Two');
     });
 
     it('calls the action navigate when an item is pressed', async () => {
@@ -206,7 +202,7 @@ describe('DashboardScreen', () => {
       await act(async () => {
         focusCallback?.();
       });
-      expect(toJson(renderer)).toContain('Card initialized');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Card initialized');
     });
 
     it('clears the toast param after showing the snackbar', async () => {
@@ -224,7 +220,9 @@ describe('DashboardScreen', () => {
       });
       expect(navigation.setParams).not.toHaveBeenCalled();
       // Snackbar renders null when not visible — message not in output
-      expect(toJson(renderer)).not.toContain('Card initialized');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Card initialized',
+      );
     });
   });
 
@@ -233,16 +231,18 @@ describe('DashboardScreen', () => {
       mockLoadBooleanPreference.mockResolvedValue(false);
       const renderer = await renderScreen();
 
-      expect(toJson(renderer)).toContain('Keycard required');
-      expect(toJson(renderer)).toContain('Buy a Keycard');
-      expect(toJson(renderer)).toContain('ShellSummer9746');
-      expect(toJson(renderer)).toContain('on purchases over');
-      expect(toJson(renderer)).toContain('$25');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Keycard required');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Buy a Keycard');
+      expect(JSON.stringify(renderer.toJSON())).toContain('ShellSummer9746');
+      expect(JSON.stringify(renderer.toJSON())).toContain('on purchases over');
+      expect(JSON.stringify(renderer.toJSON())).toContain('$25');
     });
 
     it('hides the notice when it was already dismissed', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).not.toContain('Keycard required');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Keycard required',
+      );
     });
 
     it('opens the purchase link in the browser', async () => {
@@ -276,7 +276,9 @@ describe('DashboardScreen', () => {
         'preference_dashboard_keycard_notice_dismissed',
         true,
       );
-      expect(toJson(renderer)).not.toContain('Keycard required');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Keycard required',
+      );
     });
   });
 });

--- a/__tests__/DuressQuestion.test.tsx
+++ b/__tests__/DuressQuestion.test.tsx
@@ -42,10 +42,6 @@ async function renderComponent() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function getPressables(renderer: ReactTestRenderer.ReactTestRenderer) {
   return renderer.root.findAll(
     (node: any) => typeof node.props.onPress === 'function',
@@ -65,17 +61,19 @@ describe('ConfirmPrompt', () => {
 
     it('renders the title', async () => {
       const renderer = await renderComponent();
-      expect(toJson(renderer)).toContain('Add a duress PIN?');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Add a duress PIN?');
     });
 
     it('renders the Yes button', async () => {
       const renderer = await renderComponent();
-      expect(toJson(renderer)).toContain('Yes, add duress PIN');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Yes, add duress PIN',
+      );
     });
 
     it('renders the No button', async () => {
       const renderer = await renderComponent();
-      expect(toJson(renderer)).toContain('No, skip');
+      expect(JSON.stringify(renderer.toJSON())).toContain('No, skip');
     });
   });
 

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -41,10 +41,6 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -61,7 +57,7 @@ describe('ExportKeyScreen', () => {
 
     it('renders the Ethereum option', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Ethereum');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Ethereum');
     });
 
     it('shows the NFC indicator for every export option', async () => {

--- a/__tests__/FactoryResetScreen.test.tsx
+++ b/__tests__/FactoryResetScreen.test.tsx
@@ -4,6 +4,7 @@ import FactoryResetScreen, {
   dashboardEntry,
 } from '../src/screens/FactoryResetScreen';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import { getActivePressables } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -70,18 +71,6 @@ async function renderScreen(phase = 'idle') {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -111,24 +100,28 @@ describe('FactoryResetScreen', () => {
 
     it('shows the warning description', async () => {
       const renderer = await renderScreen('idle');
-      expect(toJson(renderer)).toContain(
+      expect(JSON.stringify(renderer.toJSON())).toContain(
         'Factory reset permanently erases key pair',
       );
     });
 
     it('shows the backup checkbox label', async () => {
       const renderer = await renderScreen('idle');
-      expect(toJson(renderer)).toContain('I have a backup');
+      expect(JSON.stringify(renderer.toJSON())).toContain('I have a backup');
     });
 
     it('shows the "Factory reset Keycard" button', async () => {
       const renderer = await renderScreen('idle');
-      expect(toJson(renderer)).toContain('Factory reset Keycard');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Factory reset Keycard',
+      );
     });
 
     it('does not show the idle content when not idle', async () => {
       const renderer = await renderScreen('nfc');
-      expect(toJson(renderer)).not.toContain('Factory reset Keycard');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Factory reset Keycard',
+      );
     });
   });
 

--- a/__tests__/GenerateKeyScreen.test.tsx
+++ b/__tests__/GenerateKeyScreen.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import GenerateKeyScreen from '../src/screens/keypair/GenerateKeyScreen';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import { getActivePressables } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -79,18 +80,6 @@ async function renderScreen(phase = 'idle', result: string[] | null = null) {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -115,13 +104,13 @@ describe('GenerateKeyScreen', () => {
   describe('word grid', () => {
     it('does not render the word grid when phase is not done', async () => {
       const renderer = await renderScreen('nfc');
-      expect(toJson(renderer)).not.toContain('apple');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain('apple');
     });
 
     it('renders words when phase is done and result is set', async () => {
       const renderer = await renderScreen('done', WORDS);
-      expect(toJson(renderer)).toContain('apple');
-      expect(toJson(renderer)).toContain('lemon');
+      expect(JSON.stringify(renderer.toJSON())).toContain('apple');
+      expect(JSON.stringify(renderer.toJSON())).toContain('lemon');
     });
 
     it('renders a BlurView over the words before revealing', async () => {
@@ -150,7 +139,9 @@ describe('GenerateKeyScreen', () => {
   describe('primary button', () => {
     it('shows "Reveal recovery phrase" before revealing', async () => {
       const renderer = await renderScreen('done', WORDS);
-      expect(toJson(renderer)).toContain('Reveal recovery phrase');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Reveal recovery phrase',
+      );
     });
 
     it('shows "Done" after revealing', async () => {
@@ -159,7 +150,7 @@ describe('GenerateKeyScreen', () => {
       await act(async () => {
         pressables[0].props.onPress(); // reveal
       });
-      expect(toJson(renderer)).toContain('Done');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Done');
     });
 
     it('calls navigation.replace to ConfirmKey when "Done" is pressed', async () => {

--- a/__tests__/InitCardScreen.test.tsx
+++ b/__tests__/InitCardScreen.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import InitCardScreen, { dashboardEntry } from '../src/screens/InitCardScreen';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
+import { getActivePressables, findKey } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -71,27 +72,15 @@ async function renderScreen(phase = 'idle') {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
-/** Press key at index `ki` six times to complete a full PIN entry. */
+/** Press a digit key six times to complete a full PIN entry. keyIndex 0 = '1', 1 = '2'. */
 async function enterPin(
   renderer: ReactTestRenderer.ReactTestRenderer,
   keyIndex = 0,
 ) {
+  const digit = String(keyIndex + 1);
   for (let i = 0; i < 6; i++) {
-    const keys = getActivePressables(renderer);
     await act(async () => {
-      keys[keyIndex].props.onPress();
+      findKey(renderer, digit).props.onPress();
     });
   }
 }
@@ -125,7 +114,7 @@ describe('InitCardScreen', () => {
 
     it('shows the PIN pad on first render', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('6 digits');
+      expect(JSON.stringify(renderer.toJSON())).toContain('6 digits');
     });
   });
 
@@ -147,14 +136,14 @@ describe('InitCardScreen', () => {
       const renderer = await renderScreen();
       await enterPin(renderer, 0); // PIN: '111111'
       await enterPin(renderer, 0); // confirm same PIN
-      expect(toJson(renderer)).toContain('Add a duress PIN?');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Add a duress PIN?');
     });
 
     it('shows an error when the confirmed PIN does not match', async () => {
       const renderer = await renderScreen();
       await enterPin(renderer, 0); // PIN: '111111'
       await enterPin(renderer, 1); // confirm: '222222' — mismatch
-      expect(toJson(renderer)).toContain("PINs don't match");
+      expect(JSON.stringify(renderer.toJSON())).toContain("PINs don't match");
     });
 
     it('stays on pin_confirm after a mismatch (does not advance)', async () => {
@@ -166,7 +155,9 @@ describe('InitCardScreen', () => {
       expect(navigation.setOptions).not.toHaveBeenCalledWith({
         title: 'Initialize Card',
       });
-      expect(toJson(renderer)).not.toContain('Add a duress PIN?');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Add a duress PIN?',
+      );
     });
   });
 
@@ -244,7 +235,7 @@ describe('InitCardScreen', () => {
       const renderer = await reachDuressEntry();
       await enterPin(renderer, 1); // duress: '222222'
       await enterPin(renderer, 0); // duress confirm: '111111' — mismatch
-      expect(toJson(renderer)).toContain("PINs don't match");
+      expect(JSON.stringify(renderer.toJSON())).toContain("PINs don't match");
     });
   });
 

--- a/__tests__/KeyPairMenuScreen.test.tsx
+++ b/__tests__/KeyPairMenuScreen.test.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { getActivePressables } from './testUtils';
 
 import KeyPairMenuScreen, {
   dashboardEntry,
@@ -35,23 +36,11 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function extractText(node: any): string {
   if (typeof node === 'string') return node;
   if (Array.isArray(node)) return node.map(extractText).join('');
   if (node?.children) return extractText(node.children);
   return '';
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +55,7 @@ describe('KeyPairMenuScreen', () => {
   describe('layout', () => {
     it('renders Generate BIP39 before Import BIP39, ahead of SLIP39 entries', async () => {
       const renderer = await renderScreen();
-      const json = toJson(renderer);
+      const json = JSON.stringify(renderer.toJSON());
       expect(json.indexOf('Generate BIP39 key pair')).toBeLessThan(
         json.indexOf('Import BIP39 recovery phrase'),
       );
@@ -78,9 +67,15 @@ describe('KeyPairMenuScreen', () => {
 
     it('renders SLIP39 menu entries', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Generate SLIP39 shares');
-      expect(toJson(renderer)).toContain('Import SLIP39 shares');
-      expect(toJson(renderer)).toContain('Verify SLIP39 shares');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Generate SLIP39 shares',
+      );
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Import SLIP39 shares',
+      );
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Verify SLIP39 shares',
+      );
     });
   });
 

--- a/__tests__/KeySizeScreen.test.tsx
+++ b/__tests__/KeySizeScreen.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import KeySizeScreen from '../src/screens/keypair/KeySizeScreen';
+import { getActivePressables } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -32,18 +33,6 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -56,22 +45,26 @@ describe('KeySizeScreen', () => {
   describe('layout', () => {
     it('renders the "12 word" option', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('12 word');
+      expect(JSON.stringify(renderer.toJSON())).toContain('12 word');
     });
 
     it('renders the "24 word" option', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('24 word');
+      expect(JSON.stringify(renderer.toJSON())).toContain('24 word');
     });
 
     it('renders the "12 word + passphrase" option', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('12 word + passphrase');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        '12 word + passphrase',
+      );
     });
 
     it('renders the "24 word + passphrase" option', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('24 word + passphrase');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        '24 word + passphrase',
+      );
     });
   });
 

--- a/__tests__/KeycardMenuScreen.test.tsx
+++ b/__tests__/KeycardMenuScreen.test.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { getActivePressables } from './testUtils';
 
 import KeycardMenuScreen, {
   dashboardEntry,
@@ -27,23 +28,11 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function extractText(node: any): string {
   if (typeof node === 'string') return node;
   if (Array.isArray(node)) return node.map(extractText).join('');
   if (node?.children) return extractText(node.children);
   return '';
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
 }
 
 describe('KeycardMenuScreen', () => {
@@ -53,7 +42,7 @@ describe('KeycardMenuScreen', () => {
 
   it('renders the requested submenu items', async () => {
     const renderer = await renderScreen();
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
 
     expect(json).toContain('Initialize');
     expect(json).toContain('Keypair');

--- a/__tests__/MnemonicScreen.test.tsx
+++ b/__tests__/MnemonicScreen.test.tsx
@@ -91,10 +91,6 @@ async function renderScreen(phase = 'idle') {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function extractText(node: any): string {
   if (typeof node === 'string') return node;
   if (Array.isArray(node)) return node.map(extractText).join('');
@@ -150,8 +146,8 @@ describe('MnemonicScreen', () => {
   describe('layout', () => {
     it('renders the 12/24 word selector', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('12 words');
-      expect(toJson(renderer)).toContain('24 words');
+      expect(JSON.stringify(renderer.toJSON())).toContain('12 words');
+      expect(JSON.stringify(renderer.toJSON())).toContain('24 words');
     });
 
     it('renders the word input with multiline', async () => {
@@ -168,7 +164,7 @@ describe('MnemonicScreen', () => {
 
     it('renders the Continue button', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Continue');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Continue');
     });
   });
 
@@ -258,20 +254,26 @@ describe('MnemonicScreen', () => {
       const renderer = await renderScreen();
       // trailing space triggers validation of the completed word
       await setInput(renderer, 'notaword ');
-      expect(toJson(renderer)).toContain('notaword');
-      expect(toJson(renderer)).toContain('is not a valid BIP39 word');
+      expect(JSON.stringify(renderer.toJSON())).toContain('notaword');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'is not a valid BIP39 word',
+      );
     });
 
     it('does not show error while word is still being typed', async () => {
       const renderer = await renderScreen();
       await setInput(renderer, 'aban');
-      expect(toJson(renderer)).not.toContain('is not a valid BIP39 word');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'is not a valid BIP39 word',
+      );
     });
 
     it('does not show error for a valid completed word', async () => {
       const renderer = await renderScreen();
       await setInput(renderer, 'abandon ');
-      expect(toJson(renderer)).not.toContain('is not a valid BIP39 word');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'is not a valid BIP39 word',
+      );
     });
   });
 
@@ -286,7 +288,9 @@ describe('MnemonicScreen', () => {
       await act(async () => {
         getContinueButton(renderer).props.onPress();
       });
-      expect(toJson(renderer)).toContain('Invalid recovery phrase');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Invalid recovery phrase',
+      );
       expect(mockStart).not.toHaveBeenCalled();
     });
 

--- a/__tests__/NFCBottomSheet.test.tsx
+++ b/__tests__/NFCBottomSheet.test.tsx
@@ -55,10 +55,6 @@ async function renderSheet(nfc: NFCOperation, showOnDone?: boolean) {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function getPressables(renderer: ReactTestRenderer.ReactTestRenderer) {
   return renderer.root.findAll(
     (node: any) => typeof node.props.onPress === 'function',
@@ -76,14 +72,14 @@ describe('NFCBottomSheet', () => {
       const renderer = await renderSheet(
         makeNfc('nfc', { status: 'Waiting for card…' }),
       );
-      expect(toJson(renderer)).toContain('Waiting for card…');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Waiting for card…');
     });
   });
 
   describe('Cancel button — phase nfc (scanning)', () => {
     it('shows the Cancel button', async () => {
       const renderer = await renderSheet(makeNfc('nfc'));
-      expect(toJson(renderer)).toContain('Cancel');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Cancel');
     });
 
     it('calls onCancel when Cancel is pressed', async () => {
@@ -99,7 +95,7 @@ describe('NFCBottomSheet', () => {
   describe('Cancel button — phase error', () => {
     it('shows the Cancel button', async () => {
       const renderer = await renderSheet(makeNfc('error'));
-      expect(toJson(renderer)).toContain('Cancel');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Cancel');
     });
 
     it('calls onCancel when Cancel is pressed', async () => {
@@ -115,7 +111,7 @@ describe('NFCBottomSheet', () => {
   describe('Cancel button — phase done with showOnDone', () => {
     it('hides the Cancel button (success variant)', async () => {
       const renderer = await renderSheet(makeNfc('done'), true);
-      expect(toJson(renderer)).not.toContain('Cancel');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain('Cancel');
     });
 
     it('has no pressable elements', async () => {
@@ -135,21 +131,23 @@ describe('NFCBottomSheet', () => {
       const renderer = await renderSheet(
         makeNfc('genuine_warning', { proceedWithNonGenuine: onProceed }),
       );
-      expect(toJson(renderer)).toContain('Unverified Keycard');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Unverified Keycard');
     });
 
     it('shows warning body text', async () => {
       const renderer = await renderSheet(
         makeNfc('genuine_warning', { proceedWithNonGenuine: onProceed }),
       );
-      expect(toJson(renderer)).toContain('could not be verified');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'could not be verified',
+      );
     });
 
     it('shows Cancel and Proceed Anyway buttons', async () => {
       const renderer = await renderSheet(
         makeNfc('genuine_warning', { proceedWithNonGenuine: onProceed }),
       );
-      const json = toJson(renderer);
+      const json = JSON.stringify(renderer.toJSON());
       expect(json).toContain('Cancel');
       expect(json).toContain('Proceed Anyway');
     });
@@ -186,7 +184,9 @@ describe('NFCBottomSheet', () => {
       const renderer = await renderSheet(
         makeNfc('genuine_warning', { proceedWithNonGenuine: onProceed }),
       );
-      expect(toJson(renderer)).not.toContain('Tap your Keycard');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Tap your Keycard',
+      );
     });
   });
 
@@ -202,7 +202,9 @@ describe('NFCBottomSheet', () => {
     it('does not show the NFC sheet content', async () => {
       const submitPin = jest.fn();
       const renderer = await renderSheet(makeNfc('pin_entry', { submitPin }));
-      expect(toJson(renderer)).not.toContain('Tap your Keycard');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        'Tap your Keycard',
+      );
     });
   });
 

--- a/__tests__/PinPad.test.tsx
+++ b/__tests__/PinPad.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import PinPad from '../src/components/PinPad';
+import { getActivePressables, findKey } from './testUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,18 +34,6 @@ async function renderPad(props?: { error?: string; onType?: () => void }) {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -53,7 +42,7 @@ describe('PinPad', () => {
   describe('field label', () => {
     it('renders the "6 digits" field label by default', async () => {
       const renderer = await renderPad();
-      expect(toJson(renderer)).toContain('6 digits');
+      expect(JSON.stringify(renderer.toJSON())).toContain('6 digits');
     });
 
     it('renders the correct label for a custom length', async () => {
@@ -63,18 +52,17 @@ describe('PinPad', () => {
           <PinPad onComplete={onComplete} length={12} />,
         );
       });
-      expect(toJson(renderer)).toContain('12 digits');
-      expect(toJson(renderer)).not.toContain('6 digits');
+      expect(JSON.stringify(renderer.toJSON())).toContain('12 digits');
+      expect(JSON.stringify(renderer.toJSON())).not.toContain('6 digits');
     });
   });
 
   describe('PIN entry', () => {
     it('does not call onComplete before 6 digits are entered', async () => {
       const renderer = await renderPad();
-      const keys = getActivePressables(renderer);
       for (let i = 0; i < 5; i++) {
         await act(async () => {
-          keys[0].props.onPress(); // '1' × 5
+          findKey(renderer, '1').props.onPress();
         });
       }
       expect(onComplete).not.toHaveBeenCalled();
@@ -83,9 +71,8 @@ describe('PinPad', () => {
     it('calls onComplete with the 6-digit PIN on the final press', async () => {
       const renderer = await renderPad();
       for (let i = 0; i < 6; i++) {
-        const keys = getActivePressables(renderer);
         await act(async () => {
-          keys[0].props.onPress(); // '1' × 6
+          findKey(renderer, '1').props.onPress();
         });
       }
       expect(onComplete).toHaveBeenCalledTimes(1);
@@ -95,16 +82,14 @@ describe('PinPad', () => {
     it('resets the pin after completion so a second entry works', async () => {
       const renderer = await renderPad();
       for (let i = 0; i < 6; i++) {
-        const keys = getActivePressables(renderer);
         await act(async () => {
-          keys[0].props.onPress();
+          findKey(renderer, '1').props.onPress();
         });
       }
       onComplete.mockClear();
       for (let i = 0; i < 6; i++) {
-        const keys = getActivePressables(renderer);
         await act(async () => {
-          keys[0].props.onPress();
+          findKey(renderer, '1').props.onPress();
         });
       }
       expect(onComplete).toHaveBeenCalledTimes(1);
@@ -113,18 +98,16 @@ describe('PinPad', () => {
 
     it('backspace removes the last entered digit', async () => {
       const renderer = await renderPad();
-      // Press '2', then backspace, then '1' × 6 → should yield '111111'
       await act(async () => {
-        getActivePressables(renderer)[1].props.onPress(); // '2'
+        findKey(renderer, '2').props.onPress();
       });
       await act(async () => {
         const keys = getActivePressables(renderer);
-        keys[keys.length - 1].props.onPress(); // '⌫'
+        keys[keys.length - 1].props.onPress(); // ⌫ is always last
       });
       for (let i = 0; i < 6; i++) {
-        const keys = getActivePressables(renderer);
         await act(async () => {
-          keys[0].props.onPress(); // '1'
+          findKey(renderer, '1').props.onPress();
         });
       }
       expect(onComplete).toHaveBeenCalledWith('111111');
@@ -134,9 +117,8 @@ describe('PinPad', () => {
   describe('onType callback', () => {
     it('calls onType when a digit is pressed', async () => {
       const renderer = await renderPad({ onType });
-      const keys = getActivePressables(renderer);
       await act(async () => {
-        keys[0].props.onPress(); // '1'
+        findKey(renderer, '1').props.onPress();
       });
       expect(onType).toHaveBeenCalledTimes(1);
     });
@@ -144,12 +126,12 @@ describe('PinPad', () => {
     it('calls onType when backspace is pressed', async () => {
       const renderer = await renderPad({ onType });
       await act(async () => {
-        getActivePressables(renderer)[0].props.onPress(); // enter '1' first
+        findKey(renderer, '1').props.onPress();
       });
       onType.mockClear();
       const keys = getActivePressables(renderer);
       await act(async () => {
-        keys[keys.length - 1].props.onPress(); // '⌫'
+        keys[keys.length - 1].props.onPress(); // ⌫ is always last
       });
       expect(onType).toHaveBeenCalledTimes(1);
     });
@@ -165,15 +147,78 @@ describe('PinPad', () => {
     });
   });
 
+  describe('scrambled layout', () => {
+    it('renders all 10 digits', async () => {
+      const renderer = await renderPad();
+      const json = JSON.stringify(renderer.toJSON());
+      for (const d of ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']) {
+        expect(json).toContain(d);
+      }
+    });
+
+    it('reshuffles when a new error arrives', async () => {
+      let renderer!: ReactTestRenderer.ReactTestRenderer;
+      await act(async () => {
+        renderer = ReactTestRenderer.create(<PinPad onComplete={onComplete} />);
+      });
+      const before = JSON.stringify(renderer.toJSON());
+      await act(async () => {
+        renderer.update(<PinPad onComplete={onComplete} error="Wrong PIN" />);
+      });
+      const after = JSON.stringify(renderer.toJSON());
+      // Both snapshots must contain all digits — layout may differ
+      for (const d of ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']) {
+        expect(before).toContain(d);
+        expect(after).toContain(d);
+      }
+    });
+
+    it('keeps bottom-left empty and bottom-right as backspace', async () => {
+      const renderer = await renderPad();
+      // 12 pressables total (4 rows × 3 keys). Indices 0–11, row-major order.
+      const allPressables = renderer.root.findAll(
+        (node: any) => typeof node.props.onPress === 'function',
+        { deep: true },
+      );
+      expect(allPressables).toHaveLength(12);
+      // Bottom-left (index 9) must be disabled
+      expect(allPressables[9].props.disabled).toBe(true);
+      // Bottom-right (index 11) must be the backspace key — no Text digit child
+      const backspaceCell = allPressables[11];
+      expect(backspaceCell.props.disabled).toBe(false);
+      const textChildren = backspaceCell.findAll(
+        (node: any) => node.type === 'Text',
+        { deep: true },
+      );
+      expect(textChildren).toHaveLength(0);
+    });
+
+    it('does not reshuffle when error is unchanged', async () => {
+      let renderer!: ReactTestRenderer.ReactTestRenderer;
+      await act(async () => {
+        renderer = ReactTestRenderer.create(
+          <PinPad onComplete={onComplete} error="Wrong PIN" />,
+        );
+      });
+      const before = JSON.stringify(renderer.toJSON());
+      await act(async () => {
+        renderer.update(<PinPad onComplete={onComplete} error="Wrong PIN" />);
+      });
+      expect(JSON.stringify(renderer.toJSON())).toBe(before);
+    });
+  });
+
   describe('error display', () => {
     it('shows the error text when the error prop is provided', async () => {
       const renderer = await renderPad({ error: "PINs don't match" });
-      expect(toJson(renderer)).toContain("PINs don't match");
+      expect(JSON.stringify(renderer.toJSON())).toContain("PINs don't match");
     });
 
     it('does not show error text when no error prop', async () => {
       const renderer = await renderPad();
-      expect(toJson(renderer)).not.toContain("PINs don't match");
+      expect(JSON.stringify(renderer.toJSON())).not.toContain(
+        "PINs don't match",
+      );
     });
 
     it('renders the same number of nodes whether error is present or absent', async () => {

--- a/__tests__/QRResultScreen.test.tsx
+++ b/__tests__/QRResultScreen.test.tsx
@@ -56,10 +56,6 @@ async function renderScreen(
   return renderer;
 }
 
-function toJson(renderer: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(renderer.toJSON());
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -71,7 +67,7 @@ describe('QRResultScreen', () => {
 
   it('renders the "Done" button', async () => {
     const renderer = await renderScreen(SAMPLE_UR);
-    expect(toJson(renderer)).toContain('Done');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Done');
   });
 
   it('calls setOptions with the provided title', async () => {

--- a/__tests__/QRScannerScreen.test.tsx
+++ b/__tests__/QRScannerScreen.test.tsx
@@ -86,10 +86,6 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -158,7 +154,7 @@ describe('QRScannerScreen', () => {
         scan('ur:eth-sign-request/part1');
       });
       // Progress > 0 renders the progress bar (identified by its fill colour)
-      expect(toJson(renderer)).toContain('#1C8A80');
+      expect(JSON.stringify(renderer.toJSON())).toContain('#1C8A80');
     });
   });
 

--- a/__tests__/SecretsMenuScreen.test.tsx
+++ b/__tests__/SecretsMenuScreen.test.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { getActivePressables } from './testUtils';
 
 import SecretsMenuScreen, {
   dashboardEntry,
@@ -35,23 +36,11 @@ async function renderScreen() {
   return renderer;
 }
 
-function toJson(r: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(r.toJSON());
-}
-
 function extractText(node: any): string {
   if (typeof node === 'string') return node;
   if (Array.isArray(node)) return node.map(extractText).join('');
   if (node?.children) return extractText(node.children);
   return '';
-}
-
-function getActivePressables(renderer: ReactTestRenderer.ReactTestRenderer) {
-  return renderer.root.findAll(
-    (node: any) =>
-      typeof node.props.onPress === 'function' && !node.props.disabled,
-    { deep: true },
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -66,17 +55,19 @@ describe('SecretsMenuScreen', () => {
   describe('layout', () => {
     it('renders "Change PIN" entry', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Change PIN');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Change PIN');
     });
 
     it('renders "Change PUK" entry', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Change PUK');
+      expect(JSON.stringify(renderer.toJSON())).toContain('Change PUK');
     });
 
     it('renders "Change Pairing Secret" entry', async () => {
       const renderer = await renderScreen();
-      expect(toJson(renderer)).toContain('Change Pairing Secret');
+      expect(JSON.stringify(renderer.toJSON())).toContain(
+        'Change Pairing Secret',
+      );
     });
   });
 

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -117,10 +117,6 @@ async function renderScreen(result: any) {
   return renderer;
 }
 
-function toJson(renderer: ReactTestRenderer.ReactTestRenderer): string {
-  return JSON.stringify(renderer.toJSON());
-}
-
 const fullRequest: EthSignRequest = {
   signData: 'aabbccdd',
   dataType: 1,
@@ -147,12 +143,12 @@ describe('TransactionDetailScreen – error result', () => {
       kind: 'error',
       message: 'Parse failed',
     });
-    expect(toJson(renderer)).toContain('Parse failed');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Parse failed');
   });
 
   it('does not show the Sign transaction button', async () => {
     const renderer = await renderScreen({ kind: 'error', message: 'error' });
-    expect(toJson(renderer)).not.toContain('Sign transaction');
+    expect(JSON.stringify(renderer.toJSON())).not.toContain('Sign transaction');
   });
 });
 
@@ -168,7 +164,7 @@ describe('TransactionDetailScreen – unsupported result', () => {
       kind: 'unsupported',
       type: 'eth-signature',
     });
-    expect(toJson(renderer)).toContain('eth-signature');
+    expect(JSON.stringify(renderer.toJSON())).toContain('eth-signature');
   });
 
   it('does not show the Sign transaction button', async () => {
@@ -176,7 +172,7 @@ describe('TransactionDetailScreen – unsupported result', () => {
       kind: 'unsupported',
       type: 'eth-signature',
     });
-    expect(toJson(renderer)).not.toContain('Sign transaction');
+    expect(JSON.stringify(renderer.toJSON())).not.toContain('Sign transaction');
   });
 });
 
@@ -192,7 +188,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     });
-    expect(toJson(renderer)).toContain('aabbccdd');
+    expect(JSON.stringify(renderer.toJSON())).toContain('aabbccdd');
   });
 
   it('displays the derivation path', async () => {
@@ -200,7 +196,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     });
-    expect(toJson(renderer)).toContain("m/44'/60'/0'/0");
+    expect(JSON.stringify(renderer.toJSON())).toContain("m/44'/60'/0'/0");
   });
 
   it('displays optional fields when present', async () => {
@@ -208,7 +204,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     });
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('0xabcdef1234567890abcdef1234567890abcdef12');
     expect(json).toContain('MetaMask');
     expect(json).toContain('01020304');
@@ -220,13 +216,13 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     }); // dataType: 1
-    expect(toJson(renderer)).toContain('Legacy Transaction');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Legacy Transaction');
   });
 
   it('falls back to "Unknown (N)" for an unrecognised data type', async () => {
     const request = { ...fullRequest, dataType: 99 };
     const renderer = await renderScreen({ kind: 'eth-sign-request', request });
-    expect(toJson(renderer)).toContain('Unknown (99)');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Unknown (99)');
   });
 
   it('shows the Sign transaction button', async () => {
@@ -234,7 +230,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     });
-    expect(toJson(renderer)).toContain('Sign transaction');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Sign transaction');
   });
 
   it('renders correctly with only required fields (no optional fields)', async () => {
@@ -247,7 +243,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: minimalRequest,
     });
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('cafebabe');
     expect(json).toContain('Personal Message');
     expect(json).not.toContain('MetaMask');
@@ -279,7 +275,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
         origin: 'MetaMask',
       },
     });
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('EIP-712 Typed Data');
     expect(json).toContain('Primary type');
     expect(json).toContain('Mail');
@@ -306,7 +302,7 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       kind: 'crypto-psbt',
       request: { psbtHex: VALID_PSBT_HEX },
     });
-    expect(toJson(renderer)).toContain('Sign transaction');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Sign transaction');
   });
 
   it('shows Bitcoin PSBT label', async () => {
@@ -314,7 +310,7 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       kind: 'crypto-psbt',
       request: { psbtHex: VALID_PSBT_HEX },
     });
-    expect(toJson(renderer)).toContain('Bitcoin PSBT');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Bitcoin PSBT');
   });
 
   it('shows Invalid PSBT error for malformed hex', async () => {
@@ -322,7 +318,7 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       kind: 'crypto-psbt',
       request: { psbtHex: 'deadbeef' },
     });
-    expect(toJson(renderer)).toContain('Invalid PSBT');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Invalid PSBT');
   });
 
   it('shows Sign transaction button even on invalid PSBT (screen-level decision)', async () => {
@@ -330,7 +326,7 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       kind: 'crypto-psbt',
       request: { psbtHex: 'deadbeef' },
     });
-    expect(toJson(renderer)).toContain('Sign transaction');
+    expect(JSON.stringify(renderer.toJSON())).toContain('Sign transaction');
   });
 
   it('shows BIP-322 requests as message signing', async () => {
@@ -338,7 +334,7 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
       kind: 'crypto-psbt',
       request: { psbtHex: BIP322_PSBT_HEX },
     });
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('Bitcoin Message');
     expect(json).toContain('BIP-322 Message');
     expect(json).toContain('Sign message');
@@ -358,7 +354,7 @@ describe('TransactionDetailScreen – btc-sign-request result', () => {
         origin: 'Sparrow',
       },
     });
-    const json = toJson(renderer);
+    const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('Bitcoin Message');
     expect(json).toContain('btc-sign-request');
     expect(json).toContain('hello btc');

--- a/__tests__/testUtils.ts
+++ b/__tests__/testUtils.ts
@@ -1,0 +1,33 @@
+import ReactTestRenderer from 'react-test-renderer';
+
+export function getActivePressables(
+  renderer: ReactTestRenderer.ReactTestRenderer,
+) {
+  return renderer.root.findAll(
+    (node: any) =>
+      typeof node.props.onPress === 'function' && !node.props.disabled,
+    { deep: true },
+  );
+}
+
+/**
+ * Find a pressable key by its visible label. Locates the Text node whose
+ * children exactly match `label`, then walks up the tree to the nearest
+ * ancestor that has an onPress handler.
+ */
+export function findKey(
+  renderer: ReactTestRenderer.ReactTestRenderer,
+  label: string,
+) {
+  const textNode = renderer.root.find(
+    (node: any) => node.type === 'Text' && node.props.children === label,
+  );
+  let node = textNode.parent;
+  while (node) {
+    if (typeof node.props?.onPress === 'function') {
+      return node;
+    }
+    node = node.parent;
+  }
+  throw new Error(`No pressable found for key "${label}"`);
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   testEnvironmentOptions: {
     customExportConditions: ['require', 'node', 'node-addons'],
   },
-  testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/'],
+  testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/', 'testUtils\\.ts$'],
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@noble/(secp256k1|hashes|curves)|@scure/(bip32|bip39|base)|keycard-sdk)/)',
   ],

--- a/src/components/PinPad.tsx
+++ b/src/components/PinPad.tsx
@@ -39,12 +39,21 @@ interface PinPadProps {
 
 const PIN_LENGTH = 6;
 
-const PAD_KEYS = [
-  ['1', '2', '3'],
-  ['4', '5', '6'],
-  ['7', '8', '9'],
-  ['', '0', '⌫'],
-];
+const DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+function shuffleKeys(): string[][] {
+  const slots = [...DIGITS];
+  for (let i = slots.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [slots[i], slots[j]] = [slots[j], slots[i]];
+  }
+  return [
+    [slots[0], slots[1], slots[2]],
+    [slots[3], slots[4], slots[5]],
+    [slots[6], slots[7], slots[8]],
+    ['', slots[9], '⌫'],
+  ];
+}
 
 export default function PinPad({
   onComplete,
@@ -53,6 +62,15 @@ export default function PinPad({
   length = PIN_LENGTH,
 }: PinPadProps) {
   const [pin, setPin] = useState('');
+  const [padKeys, setPadKeys] = useState(shuffleKeys);
+  const prevError = useRef(error);
+
+  useEffect(() => {
+    if (error && error !== prevError.current) {
+      setPadKeys(shuffleKeys());
+    }
+    prevError.current = error;
+  }, [error]);
 
   const handleKey = useCallback(
     (key: string) => {
@@ -94,7 +112,7 @@ export default function PinPad({
       </View>
 
       <View style={styles.pad}>
-        {PAD_KEYS.map((row, ri) => (
+        {padKeys.map((row, ri) => (
           <View key={ri} style={styles.padRow}>
             {row.map((key, ki) => (
               <Pressable


### PR DESCRIPTION
- Digits are Fisher-Yates shuffled on mount and reshuffled on each new error, so the layout is never predictable
- Bottom-left slot is always empty; bottom-right is always the backspace key
- Extracted shared test helpers (toJson removed, getActivePressables and findKey consolidated into __tests__/testUtils.ts) so all tests find keys by label rather than fixed index