### PR TITLE
fix: downgrade Gradle wrapper to 8.14.2 for F-Droid build server compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Downgrade Gradle wrapper to 8.14.2 for F-Droid build server compatibility
+
 ## [1.0.0] - 2026-04-27
 
 ### Added

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/fdroiddata-tech.gapsign.yml
+++ b/fdroiddata-tech.gapsign.yml
@@ -14,7 +14,7 @@ AuthorWebSite: https://github.com/mmlado
 SourceCode: https://github.com/mmlado/GapSign
 IssueTracker: https://github.com/mmlado/GapSign/issues
 
-Summary: Air-gapped Ethereum and Bitcoin signing. Requires a Keycard NFC smart card.
+Summary: Air-gapped Ethereum and Bitcoin signing with a Keycard NFC smart card
 Description: |-
   GapSign works with a Keycard NFC smart card to sign Ethereum and Bitcoin
   transactions without ever connecting to the internet.


### PR DESCRIPTION
Downgrade Gradle wrapper to 8.14.2 for F-Droid build server compatibility