### PR TITLE
feat: decode ERC-20 calldata in transaction review UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review UI; show unlimited approval warning
+
 ## [1.0.3] - 2026-04-27
 
 ### Changed

--- a/__tests__/AddressDetailScreen.test.tsx
+++ b/__tests__/AddressDetailScreen.test.tsx
@@ -107,7 +107,11 @@ describe('AddressDetailScreen', () => {
             {
               key: 'AddressDetail',
               name: 'AddressDetail',
-              params: { address: ETH_ADDRESS, index: 0, title: 'Ethereum donation' },
+              params: {
+                address: ETH_ADDRESS,
+                index: 0,
+                title: 'Ethereum donation',
+              },
             } as any
           }
         />,

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -1,6 +1,6 @@
 import { RLP } from '@ethereumjs/rlp';
 
-import { getTxLabel, parseTx } from '../src/utils/txParser';
+import { decodeCalldata, getTxLabel, parseTx } from '../src/utils/txParser';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -210,5 +210,83 @@ describe('getTxLabel', () => {
 
   it('returns fallback for unknown dataType', () => {
     expect(getTxLabel('deadbeef', 99)).toBe('Unknown (99)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeCalldata
+// ---------------------------------------------------------------------------
+
+describe('decodeCalldata', () => {
+  const RECIPIENT = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+  const SPENDER = '0x1111111111111111111111111111111111111111';
+  const FROM = '0x2222222222222222222222222222222222222222';
+
+  const TRANSFER_HEX =
+    '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240';
+  const APPROVE_UNLIMITED_HEX =
+    '0x095ea7b30000000000000000000000001111111111111111111111111111111111111111ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+  const TRANSFER_FROM_HEX =
+    '0x23b872dd0000000000000000000000002222222222222222222222222222222222222222000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000001f4';
+
+  it('decodes ERC-20 transfer', () => {
+    const result = decodeCalldata(TRANSFER_HEX);
+    expect(result).toEqual({
+      kind: 'erc20-transfer',
+      to: RECIPIENT,
+      amount: 1000000n,
+    });
+  });
+
+  it('decodes ERC-20 transferFrom', () => {
+    const result = decodeCalldata(TRANSFER_FROM_HEX);
+    expect(result).toEqual({
+      kind: 'erc20-transferFrom',
+      from: FROM,
+      to: RECIPIENT,
+      amount: 500n,
+    });
+  });
+
+  it('decodes ERC-20 approve with unlimited allowance', () => {
+    const result = decodeCalldata(APPROVE_UNLIMITED_HEX);
+    expect(result).toEqual({
+      kind: 'erc20-approve',
+      spender: SPENDER,
+      amount: 2n ** 256n - 1n,
+    });
+  });
+
+  it('returns unknown-call with raw selector for unrecognised calldata', () => {
+    const result = decodeCalldata('0xdeadbeef' + '00'.repeat(32));
+    expect(result).toEqual({ kind: 'unknown-call', selector: '0xdeadbeef' });
+  });
+
+  it('returns null for empty calldata', () => {
+    expect(decodeCalldata('0x')).toBeNull();
+    expect(decodeCalldata('')).toBeNull();
+  });
+
+  it('parseTx includes decodedCall for ERC-20 transfer in legacy tx', () => {
+    // Build a legacy tx with ERC-20 transfer calldata
+    const toContract = Buffer.from(
+      'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      'hex',
+    );
+    const calldata = Buffer.from(TRANSFER_HEX.replace('0x', ''), 'hex');
+    const encoded = RLP.encode([
+      Buffer.from([0x01]), // nonce
+      Buffer.from([0x09, 0xc4]), // gasPrice
+      Buffer.from([0x52, 0x08]), // gasLimit
+      toContract,
+      Buffer.alloc(0), // value = 0
+      calldata,
+    ]);
+    const tx = parseTx(Buffer.from(encoded).toString('hex'), 1);
+    expect(tx?.decodedCall).toEqual({
+      kind: 'erc20-transfer',
+      to: RECIPIENT,
+      amount: 1000000n,
+    });
   });
 });

--- a/src/components/DecodedCallSection.tsx
+++ b/src/components/DecodedCallSection.tsx
@@ -1,0 +1,126 @@
+import { StyleSheet, View } from 'react-native';
+import { Icon, Text } from 'react-native-paper';
+
+import theme from '../theme';
+import InfoRow from './InfoRow';
+import { DecodedCall } from '../utils/txParser';
+
+const UINT256_MAX = 2n ** 256n - 1n;
+
+export default function DecodedCallSection({
+  call,
+  tokenContract,
+}: {
+  call: DecodedCall;
+  tokenContract?: string;
+}) {
+  if (call.kind === 'erc20-transfer') {
+    return (
+      <>
+        <View style={styles.sectionHeader}>
+          <Text variant="labelMedium" style={styles.sectionHeaderText}>
+            ERC-20 Transfer
+          </Text>
+        </View>
+        {tokenContract && (
+          <View style={styles.row}>
+            <InfoRow label="Token contract" value={tokenContract} />
+          </View>
+        )}
+        <View style={styles.row}>
+          <InfoRow label="Recipient" value={call.to} />
+        </View>
+        <View style={styles.row}>
+          <InfoRow label="Amount (raw units)" value={call.amount.toString()} />
+        </View>
+      </>
+    );
+  }
+  if (call.kind === 'erc20-transferFrom') {
+    return (
+      <>
+        <View style={styles.sectionHeader}>
+          <Text variant="labelMedium" style={styles.sectionHeaderText}>
+            ERC-20 Transfer From
+          </Text>
+        </View>
+        {tokenContract && (
+          <View style={styles.row}>
+            <InfoRow label="Token contract" value={tokenContract} />
+          </View>
+        )}
+        <View style={styles.row}>
+          <InfoRow label="From" value={call.from} />
+        </View>
+        <View style={styles.row}>
+          <InfoRow label="Recipient" value={call.to} />
+        </View>
+        <View style={styles.row}>
+          <InfoRow label="Amount (raw units)" value={call.amount.toString()} />
+        </View>
+      </>
+    );
+  }
+  if (call.kind === 'erc20-approve') {
+    const isUnlimited = call.amount === UINT256_MAX;
+    return (
+      <>
+        <View style={styles.sectionHeader}>
+          <Text variant="labelMedium" style={styles.sectionHeaderText}>
+            ERC-20 Approve
+          </Text>
+        </View>
+        {tokenContract && (
+          <View style={styles.row}>
+            <InfoRow label="Token contract" value={tokenContract} />
+          </View>
+        )}
+        <View style={styles.row}>
+          <InfoRow label="Spender" value={call.spender} />
+        </View>
+        <View style={styles.row}>
+          <InfoRow
+            label="Allowance"
+            value={isUnlimited ? 'Unlimited' : call.amount.toString()}
+          />
+        </View>
+        {isUnlimited && (
+          <View style={styles.warningRow}>
+            <Icon source="alert" size={16} color={theme.colors.negative} />
+            <Text variant="labelSmall" style={styles.warningText}>
+              Unlimited approval — spender can transfer all tokens of this type
+            </Text>
+          </View>
+        )}
+      </>
+    );
+  }
+  return (
+    <View style={styles.row}>
+      <InfoRow label="Contract call" value={call.selector} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    paddingVertical: 8,
+  },
+  sectionHeader: {
+    paddingTop: 8,
+  },
+  sectionHeaderText: {
+    color: theme.colors.onSurfaceVariant,
+  },
+  warningRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+  },
+  warningText: {
+    color: theme.colors.negative,
+    flexShrink: 1,
+  },
+});

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -3,6 +3,7 @@ import { Icon, Text } from 'react-native-paper';
 
 import type { EthSignRequest } from '../types';
 import theme from '../theme';
+import DecodedCallSection from './DecodedCallSection';
 import InfoRow from './InfoRow';
 import { parseEip712Summary } from '../utils/eip712';
 import { getTxLabel, parseTx } from '../utils/txParser';
@@ -68,7 +69,7 @@ export default function EthSignRequestDetail({
         </View>
       )}
 
-      {tx?.to && (
+      {tx?.to && !tx.decodedCall && (
         <View style={styles.row}>
           <InfoRow label="To" value={tx.to} />
         </View>
@@ -80,10 +81,14 @@ export default function EthSignRequestDetail({
         </View>
       )}
 
-      {tx?.value !== undefined && (
+      {tx?.value !== undefined && (tx.value !== '0' || !tx.decodedCall) && (
         <View style={styles.row}>
           <InfoRow label="Amount" value={tx.value} />
         </View>
+      )}
+
+      {tx?.decodedCall && (
+        <DecodedCallSection call={tx.decodedCall} tokenContract={tx.to} />
       )}
 
       {tx?.fees.kind === 'legacy' && (
@@ -137,12 +142,14 @@ export default function EthSignRequestDetail({
         </>
       )}
 
-      <View style={styles.row}>
-        <InfoRow
-          label="Data"
-          value={eip712?.rawJson ?? tx?.data ?? request.signData}
-        />
-      </View>
+      {(!tx?.decodedCall || tx.decodedCall.kind === 'unknown-call') && (
+        <View style={styles.row}>
+          <InfoRow
+            label="Data"
+            value={eip712?.rawJson ?? tx?.data ?? request.signData}
+          />
+        </View>
+      )}
 
       {request.origin && (
         <View style={styles.row}>

--- a/src/components/about/DonationList.tsx
+++ b/src/components/about/DonationList.tsx
@@ -38,7 +38,11 @@ export default function DonationList({ onShowQR }: DonationListProps) {
               accessibilityRole="button"
               accessibilityLabel={`Copy ${label} donation address`}
             >
-              <Icons.copy width={20} height={20} color={theme.colors.onSurface} />
+              <Icons.copy
+                width={20}
+                height={20}
+                color={theme.colors.onSurface}
+              />
             </Pressable>
             <Pressable
               style={styles.iconButton}

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -1,12 +1,56 @@
 import { RLP } from '@ethereumjs/rlp';
-import { formatEther, formatGwei } from 'viem';
+import { decodeFunctionData, erc20Abi, formatEther, formatGwei } from 'viem';
 
 import { DATA_TYPE_LABELS } from '../types';
+
+export type DecodedCall =
+  | { kind: 'erc20-transfer'; to: string; amount: bigint }
+  | { kind: 'erc20-transferFrom'; from: string; to: string; amount: bigint }
+  | { kind: 'erc20-approve'; spender: string; amount: bigint }
+  | { kind: 'unknown-call'; selector: string };
+
+export function decodeCalldata(dataHex: string): DecodedCall | null {
+  if (!dataHex || dataHex === '0x' || dataHex.replace('0x', '').length < 8) {
+    return null;
+  }
+  try {
+    const { functionName, args } = decodeFunctionData({
+      abi: erc20Abi,
+      data: dataHex as `0x${string}`,
+    });
+    if (functionName === 'transfer') {
+      return {
+        kind: 'erc20-transfer',
+        to: args[0] as string,
+        amount: args[1] as bigint,
+      };
+    }
+    if (functionName === 'transferFrom') {
+      return {
+        kind: 'erc20-transferFrom',
+        from: args[0] as string,
+        to: args[1] as string,
+        amount: args[2] as bigint,
+      };
+    }
+    if (functionName === 'approve') {
+      return {
+        kind: 'erc20-approve',
+        spender: args[0] as string,
+        amount: args[1] as bigint,
+      };
+    }
+  } catch {
+    // not an ERC-20 call
+  }
+  return { kind: 'unknown-call', selector: dataHex.slice(0, 10) };
+}
 
 export type ParsedTx = {
   to?: string;
   value?: string; // in ETH, e.g. "0.01"
   data?: string; // hex calldata
+  decodedCall?: DecodedCall;
   nonce?: number;
   fees: ParsedFees;
 };
@@ -88,14 +132,16 @@ function parseLegacy(bytes: Buffer): ParsedTx {
     );
   }
   const [nonce, gasPrice, gasLimit, to, value, data] = decoded;
+  const dataHex =
+    assertBytes(data, 'data').length > 0
+      ? bufToHex(assertBytes(data, 'data'))
+      : undefined;
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
-    data:
-      assertBytes(data, 'data').length > 0
-        ? bufToHex(assertBytes(data, 'data'))
-        : undefined,
+    data: dataHex,
+    decodedCall: dataHex ? decodeCalldata(dataHex) ?? undefined : undefined,
     fees: {
       kind: 'legacy',
       gasPrice: weiToGwei(bufToBigInt(assertBytes(gasPrice, 'gasPrice'))),
@@ -130,14 +176,18 @@ function parseEIP1559(bytes: Buffer): ParsedTx {
     accessList,
   ] = decoded;
   assertList(accessList, 'accessList');
+  const dataHexEip1559 =
+    assertBytes(data, 'data').length > 0
+      ? bufToHex(assertBytes(data, 'data'))
+      : undefined;
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
-    data:
-      assertBytes(data, 'data').length > 0
-        ? bufToHex(assertBytes(data, 'data'))
-        : undefined,
+    data: dataHexEip1559,
+    decodedCall: dataHexEip1559
+      ? decodeCalldata(dataHexEip1559) ?? undefined
+      : undefined,
     fees: {
       kind: 'eip1559',
       maxFeePerGas: weiToGwei(
@@ -165,14 +215,18 @@ function parseEIP2930(bytes: Buffer): ParsedTx {
   }
   const [, nonce, gasPrice, gasLimit, to, value, data, accessList] = decoded;
   assertList(accessList, 'accessList');
+  const dataHexEip2930 =
+    assertBytes(data, 'data').length > 0
+      ? bufToHex(assertBytes(data, 'data'))
+      : undefined;
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
-    data:
-      assertBytes(data, 'data').length > 0
-        ? bufToHex(assertBytes(data, 'data'))
-        : undefined,
+    data: dataHexEip2930,
+    decodedCall: dataHexEip2930
+      ? decodeCalldata(dataHexEip2930) ?? undefined
+      : undefined,
     fees: {
       kind: 'legacy',
       gasPrice: weiToGwei(bufToBigInt(assertBytes(gasPrice, 'gasPrice'))),


### PR DESCRIPTION
## Summary

- Decode ERC-20 `transfer`, `transferFrom`, and `approve` calldata using viem's built-in `erc20Abi`
- Show token contract, recipient/spender, and raw amount instead of raw hex
- Hide misleading `0 ETH` amount row when calldata is present
- Show unlimited approval warning when `approve` amount is `uint256.max`
- Fall back to raw 4-byte selector for unrecognised calldata (no regression)
- Extract `DecodedCallSection` into its own component