### PR TITLE
fix: fix EIP-712 JSON decode and improve transaction review UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
 - Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review UI; show unlimited approval warning
+- Detect and label pre-hashed EIP-712 payloads (`0x1901` prefix) with domain separator and message hash
+
+### Fixed
+
+- Fix EIP-712 JSON decode for wallets that send minified or non-round-tripping UTF-8 payloads; prettify JSON display
 
 ## [1.0.3] - 2026-04-27
 
@@ -16,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Reduce release APK size with minification, resource shrinking, and ARM-only release splits
 
 ## [1.0.2] - 2026-04-27
+
+### Changed
 
 - Downgrade @react-native-async-storage/async-storage to 1.24.0 to remove local maven repo incompatible with F-Droid build server
 

--- a/__tests__/eip712.test.ts
+++ b/__tests__/eip712.test.ts
@@ -1,4 +1,4 @@
-import { parseEip712Summary } from '../src/utils/eip712';
+import { parseEip712Prehashed, parseEip712Summary } from '../src/utils/eip712';
 
 describe('parseEip712Summary', () => {
   it('parses utf8 JSON typed data into domain and message summaries', () => {
@@ -31,7 +31,7 @@ describe('parseEip712Summary', () => {
     ).toString('hex');
 
     expect(parseEip712Summary(signDataHex)).toEqual({
-      rawJson: expect.stringContaining('"primaryType":"Mail"'),
+      rawJson: expect.stringContaining('"primaryType": "Mail"'),
       primaryType: 'Mail',
       domain: {
         chainId: '1',
@@ -47,7 +47,60 @@ describe('parseEip712Summary', () => {
     });
   });
 
+  it('returns prettified JSON in rawJson regardless of input formatting', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [{ name: 'name', type: 'string' }],
+        Message: [{ name: 'content', type: 'string' }],
+      },
+      primaryType: 'Message',
+      domain: { name: 'Test' },
+      message: { content: 'hello' },
+    };
+    const minified = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+    const result = parseEip712Summary(minified);
+    expect(result?.rawJson).toBe(JSON.stringify(payload, null, 2));
+  });
+
   it('returns null for non-json data', () => {
     expect(parseEip712Summary('deadbeef')).toBeNull();
+  });
+});
+
+describe('parseEip712Prehashed', () => {
+  const DOMAIN_HASH = 'a'.repeat(64);
+  const MESSAGE_HASH = 'b'.repeat(64);
+  const PREHASHED_HEX = '1901' + DOMAIN_HASH + MESSAGE_HASH;
+
+  it('parses a valid 0x1901-prefixed payload', () => {
+    const result = parseEip712Prehashed(PREHASHED_HEX);
+    expect(result).toEqual({
+      domainSeparatorHash: '0x' + DOMAIN_HASH,
+      messageHash: '0x' + MESSAGE_HASH,
+    });
+  });
+
+  it('accepts 0x-prefixed input', () => {
+    const result = parseEip712Prehashed('0x' + PREHASHED_HEX);
+    expect(result).toEqual({
+      domainSeparatorHash: '0x' + DOMAIN_HASH,
+      messageHash: '0x' + MESSAGE_HASH,
+    });
+  });
+
+  it('returns null for wrong prefix', () => {
+    expect(
+      parseEip712Prehashed('1900' + DOMAIN_HASH + MESSAGE_HASH),
+    ).toBeNull();
+  });
+
+  it('returns null for wrong length', () => {
+    expect(parseEip712Prehashed('1901' + DOMAIN_HASH)).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseEip712Prehashed('')).toBeNull();
   });
 });

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -5,7 +5,7 @@ import type { EthSignRequest } from '../types';
 import theme from '../theme';
 import DecodedCallSection from './DecodedCallSection';
 import InfoRow from './InfoRow';
-import { parseEip712Summary } from '../utils/eip712';
+import { parseEip712Prehashed, parseEip712Summary } from '../utils/eip712';
 import { getTxLabel, parseTx } from '../utils/txParser';
 
 const CHAIN_NAMES: Record<number, string> = {
@@ -40,6 +40,10 @@ export default function EthSignRequestDetail({
   const tx = parseTx(request.signData, request.dataType);
   const eip712 =
     request.dataType === 2 ? parseEip712Summary(request.signData) : null;
+  const eip712Prehashed =
+    request.dataType === 2 && !eip712
+      ? parseEip712Prehashed(request.signData)
+      : null;
 
   return (
     <>
@@ -142,14 +146,34 @@ export default function EthSignRequestDetail({
         </>
       )}
 
-      {(!tx?.decodedCall || tx.decodedCall.kind === 'unknown-call') && (
-        <View style={styles.row}>
-          <InfoRow
-            label="Data"
-            value={eip712?.rawJson ?? tx?.data ?? request.signData}
-          />
-        </View>
+      {eip712Prehashed && (
+        <>
+          <View style={styles.sectionHeader}>
+            <Text variant="labelMedium" style={styles.sectionHeaderText}>
+              EIP-712 (pre-hashed)
+            </Text>
+          </View>
+          <View style={styles.row}>
+            <InfoRow
+              label="Domain separator"
+              value={eip712Prehashed.domainSeparatorHash}
+            />
+          </View>
+          <View style={styles.row}>
+            <InfoRow label="Message hash" value={eip712Prehashed.messageHash} />
+          </View>
+        </>
       )}
+
+      {!eip712Prehashed &&
+        (!tx?.decodedCall || tx.decodedCall.kind === 'unknown-call') && (
+          <View style={styles.row}>
+            <InfoRow
+              label="Data"
+              value={eip712?.rawJson ?? tx?.data ?? request.signData}
+            />
+          </View>
+        )}
 
       {request.origin && (
         <View style={styles.row}>

--- a/src/utils/eip712.ts
+++ b/src/utils/eip712.ts
@@ -1,4 +1,4 @@
-import { hexToString, stringToHex, validateTypedData } from 'viem';
+import { validateTypedData } from 'viem';
 
 import { ensureHexPrefix } from './hex';
 
@@ -19,18 +19,35 @@ export type Eip712Summary = {
   message: Record<string, string>;
 };
 
+export type Eip712Prehashed = {
+  domainSeparatorHash: string;
+  messageHash: string;
+};
+
+// \x19\x01 prefix + 32-byte domain separator + 32-byte message hash = 66 bytes
+const PREHASHED_PREFIX = '1901';
+const PREHASHED_BYTE_LENGTH = 66;
+
+export function parseEip712Prehashed(
+  signDataHex: string,
+): Eip712Prehashed | null {
+  const hex = signDataHex.replace(/^0x/, '');
+  if (hex.length !== PREHASHED_BYTE_LENGTH * 2) return null;
+  if (!hex.startsWith(PREHASHED_PREFIX)) return null;
+  return {
+    domainSeparatorHash: '0x' + hex.slice(4, 68),
+    messageHash: '0x' + hex.slice(68),
+  };
+}
+
 function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function decodeUtf8(hex: string): string | null {
   try {
-    const normalizedHex = ensureHexPrefix(hex);
-    const text = hexToString(normalizedHex);
-    if (stringToHex(text).toLowerCase() !== normalizedHex.toLowerCase()) {
-      return null;
-    }
-    return text;
+    const stripped = ensureHexPrefix(hex).replace(/^0x/, '');
+    return Buffer.from(stripped, 'hex').toString('utf8');
   } catch {
     return null;
   }
@@ -85,7 +102,7 @@ export function parseEip712Summary(signDataHex: string): Eip712Summary | null {
     });
 
     return {
-      rawJson: json,
+      rawJson: JSON.stringify(parsed, null, 2),
       primaryType:
         typeof parsed.primaryType === 'string' ? parsed.primaryType : undefined,
       domain: toDisplayMap(parsed.domain),


### PR DESCRIPTION
## Summary

- Fix EIP-712 JSON decode: replace viem round-trip check with `Buffer.from` — wallets sending minified or non-normalized UTF-8 payloads now decode correctly
- Prettify EIP-712 JSON in the Data field (2-space indent)
- Detect pre-hashed EIP-712 payloads (`0x1901` prefix) and label domain separator and message hash instead of showing raw 66-byte hex