### PR TITLE
feat: add full and offline Android build flavors

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -74,25 +74,26 @@ jobs:
         run: |
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.keystore
 
-      - name: Build release APK
+      - name: Build release APKs
         env:
           ANDROID_KEYSTORE_PATH: release.keystore
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-        run: cd android && ./gradlew clean assembleRelease -PreactNativeArchitectures=arm64-v8a,armeabi-v7a --no-daemon
+        run: cd android && ./gradlew clean assembleFullRelease assembleOfflineRelease -PreactNativeArchitectures=arm64-v8a,armeabi-v7a --no-daemon
 
       - name: Generate APK checksums
         run: |
-          cd android/app/build/outputs/apk/release
-          sha256sum app-*-release.apk > SHA256SUMS.txt
+          mkdir -p android/app/build/outputs/apk/release
+          find android/app/build/outputs/apk -name "app-*-release.apk" \
+            | sort | xargs sha256sum > android/app/build/outputs/apk/release/SHA256SUMS.txt
           {
             echo "## APK SHA256 checksums"
             echo
             echo '```text'
-            cat SHA256SUMS.txt
+            cat android/app/build/outputs/apk/release/SHA256SUMS.txt
             echo '```'
             echo
-          } > RELEASE_NOTES.md
+          } > android/app/build/outputs/apk/release/RELEASE_NOTES.md
 
       - name: Create GitHub Release and upload APKs
         uses: softprops/action-gh-release@v2
@@ -100,6 +101,7 @@ jobs:
           tag_name: ${{ steps.ver.outputs.tag }}
           body_path: android/app/build/outputs/apk/release/RELEASE_NOTES.md
           files: |
-            android/app/build/outputs/apk/release/app-*-release.apk
+            android/app/build/outputs/apk/full/release/app-*-release.apk
+            android/app/build/outputs/apk/offline/release/app-*-release.apk
             android/app/build/outputs/apk/release/SHA256SUMS.txt
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review UI; show unlimited approval warning
 - Detect and label pre-hashed EIP-712 payloads (`0x1901` prefix) with domain separator and message hash
+- Add `full` and `offline` Android build flavors; `tech.gapsign` (GapSign) enables internet, `tech.gapsign.offline` (GapSign Offline) is permanently air-gapped
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@
 
 GapSign is an air-gapped Android companion app for [Status Keycard](https://keycard.tech). It lets you sign Ethereum and Bitcoin transactions over NFC, so your private keys never touch an internet-connected device.
 
-All communication with your watch-only wallet happens through animated QR codes using the [Blockchain Commons UR](https://github.com/BlockchainCommons/bc-ur) standard. There is no internet permission, no network calls, and no telemetry.
+All communication with your watch-only wallet happens through animated QR codes using the [Blockchain Commons UR](https://github.com/BlockchainCommons/bc-ur) standard. No telemetry.
+
+GapSign comes in two variants:
+
+| Variant | Package ID | Internet |
+|---------|-----------|----------|
+| **GapSign** | `tech.gapsign` | Optional — for future opt-in security features (ENS, simulation) |
+| **GapSign Offline** | `tech.gapsign.offline` | Never — `INTERNET` permission is absent from the manifest |
+
+Both variants are fully functional for signing and key management. GapSign Offline is the right choice if you want a hard, manifest-level guarantee of no network access.
 
 ## Screenshots
 
@@ -47,7 +56,7 @@ All communication with your watch-only wallet happens through animated QR codes 
 - Import a recovery phrase (BIP-39, 12 or 24 words, with optional passphrase)
 - Import SLIP-39 Shamir Secret Sharing shares
 - Genuine Keycard verification before first pairing
-- Fully air-gapped: no internet permission, no network calls, no telemetry
+- Two variants: GapSign Offline (no internet, manifest-level guarantee) and GapSign (optional internet for future security features)
 
 ## Requirements
 
@@ -71,7 +80,7 @@ For most users, install the universal APK. ABI-specific split APKs are also atta
 
 ### Verification info
 
-- Package ID: `tech.gapsign`
+- Package ID: `tech.gapsign` (GapSign) / `tech.gapsign.offline` (GapSign Offline)
 - SHA-256 hash of signing certificate: `A8:3C:11:4B:1F:42:01:DA:FB:D0:3E:22:1F:1C:29:28:EC:B5:2B:78:BD:A5:E9:3F:29:6F:ED:F2:29:8E:54:6B`
 - `SHA256SUMS.txt` is attached to each GitHub Release to verify APK file hashes.
 
@@ -82,7 +91,7 @@ For most users, install the universal APK. ABI-specific split APKs are also atta
 3. Use GitHub Releases as the update source.
 4. Select the universal APK from the latest release.
 
-> The APK is built automatically by GitHub Actions on every version tag. F-Droid distribution is coming.
+> The APK is built automatically by GitHub Actions on every version tag. A self-hosted F-Droid repository is planned.
 
 ## Building from source
 
@@ -108,7 +117,8 @@ npm run android  # Terminal 2: build and install
 ### Release build
 
 ```sh
-cd android && ./gradlew assembleRelease
+cd android && ./gradlew assembleFullRelease      # GapSign (tech.gapsign)
+cd android && ./gradlew assembleOfflineRelease   # GapSign Offline (tech.gapsign.offline)
 ```
 
 ## Development
@@ -130,7 +140,7 @@ If GapSign is useful to you, voluntary donations help support ongoing open-sourc
 - Pairing data is stored in encrypted storage backed by the Android Keystore
 - Private keys never leave the Keycard; only the signature result is returned to the app
 - QR codes use [Blockchain Commons UR](https://github.com/BlockchainCommons/bc-ur) for structured binary encoding
-- No internet permission in release builds
+- GapSign Offline (`tech.gapsign.offline`) has no `INTERNET` permission at the manifest level — no runtime flag can enable networking
 
 ## License
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ react {
     //   The list of variants to that are debuggable. For those we're going to
     //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-    // debuggableVariants = ["liteDebug", "prodDebug"]
+    debuggableVariants = ["fullDebug", "offlineDebug"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
@@ -94,6 +94,26 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 10003
         versionName "1.0.3"
+    }
+    flavorDimensions "distribution"
+    productFlavors {
+        full {
+            dimension "distribution"
+            applicationId "tech.gapsign"
+            // BuildConfig.INTERNET_ENABLED == true
+            // Usage in Java/Kotlin: if (BuildConfig.INTERNET_ENABLED) { ... }
+            // Usage in JS: expose via a NativeModule when the first internet feature lands
+            buildConfigField "boolean", "INTERNET_ENABLED", "true"
+        }
+        offline {
+            dimension "distribution"
+            applicationId "tech.gapsign.offline"
+            // BuildConfig.INTERNET_ENABLED == false — INTERNET permission never declared
+            buildConfigField "boolean", "INTERNET_ENABLED", "false"
+        }
+    }
+    buildFeatures {
+        buildConfig true
     }
     signingConfigs {
         debug {

--- a/android/app/src/full/AndroidManifest.xml
+++ b/android/app/src/full/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/android/app/src/offline/res/values/strings.xml
+++ b/android/app/src/offline/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">GapSign Offline</string>
+</resources>


### PR DESCRIPTION
## Summary

- Add `full` (`tech.gapsign`) and `offline` (`tech.gapsign.offline`) Android product flavors
- `full` release includes `INTERNET` permission for future opt-in security features; `offline` manifest never declares it
- `BuildConfig.INTERNET_ENABLED` boolean gates internet features at runtime; expose via NativeModule when the first feature lands
- `GapSign Offline` app name override via flavor-specific `strings.xml`
- Update CI workflow to build both flavors and collect APKs from flavor-specific output dirs
- Update README with variant table, corrected release commands, and self-hosted F-Droid note