### PR TITLE
feat: show QR code for external links (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review UI; show unlimited approval warning
-- Detect and label pre-hashed EIP-712 payloads (`0x1901` prefix) with domain separator and message hash
-- Add `full` and `offline` Android build flavors; `tech.gapsign` (GapSign) enables internet, `tech.gapsign.offline` (GapSign Offline) is permanently air-gapped
+- Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review; show unlimited approval warning
+- Detect and label pre-hashed EIP-712 payloads (`0x1901`) with domain separator and message hash
+- `full` (`tech.gapsign`) and `offline` (`tech.gapsign.offline`) Android build flavors
+- QR code fallback for external links so air-gapped users can scan URLs on another device
 
 ### Fixed
 
-- Fix EIP-712 JSON decode for wallets that send minified or non-round-tripping UTF-8 payloads; prettify JSON display
+- EIP-712 JSON decode for minified or non-round-tripping UTF-8 payloads; prettify JSON display
 
 ## [1.0.3] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/mmlado/GapSign/actions/workflows/ci.yml"><img src="https://github.com/mmlado/GapSign/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/mmlado/GapSign/actions/workflows/android-release.yml"><img src="https://github.com/mmlado/GapSign/actions/workflows/android-release.yml/badge.svg" alt="Build & Release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
+  <img src="https://img.shields.io/badge/coverage-84%25-brightgreen.svg" alt="Test coverage" />
   <a href="https://developer.android.com"><img src="https://img.shields.io/badge/platform-Android-green.svg" alt="Platform" /></a>
   <a href="https://reactnative.dev"><img src="https://img.shields.io/badge/React%20Native-0.83-blue.svg" alt="React Native" /></a>
   <a href="https://github.com/mmlado/GapSign/releases/latest"><img src="https://img.shields.io/github/v/release/mmlado/GapSign" alt="GitHub release" /></a>

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -8,6 +8,11 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+const mockUseNavigationNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockUseNavigationNavigate }),
+}));
+
 jest.mock('react-native-paper', () => {
   const { Text } = require('react-native');
   return {
@@ -52,6 +57,7 @@ function renderScreen() {
 describe('AboutScreen', () => {
   beforeEach(() => {
     navigation.navigate.mockClear();
+    mockUseNavigationNavigate.mockClear();
     mockSetString.mockClear();
     jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
   });
@@ -117,6 +123,24 @@ describe('AboutScreen', () => {
     expect(navigation.navigate).toHaveBeenCalledWith('LicenseDetail', {
       packageName: '@ethereumjs/rlp',
       licenseType: 'MPL-2.0',
+    });
+  });
+
+  it('shows QR for the GitHub project link', () => {
+    renderScreen();
+    fireEvent.press(screen.getByLabelText('Show GitHub project QR code'));
+    expect(navigation.navigate).toHaveBeenCalledWith('UrlQR', {
+      url: 'https://github.com/mmlado/GapSign',
+      title: 'GitHub project',
+    });
+  });
+
+  it('shows QR for a contributor profile', () => {
+    renderScreen();
+    fireEvent.press(screen.getByLabelText('Show QR code for mmlado'));
+    expect(mockUseNavigationNavigate).toHaveBeenCalledWith('UrlQR', {
+      url: 'https://github.com/mmlado',
+      title: expect.any(String),
     });
   });
 });

--- a/__tests__/DashboardScreen.test.tsx
+++ b/__tests__/DashboardScreen.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../src/assets/icons', () => {
       close: Icon,
       nfcActivate: Icon,
       openInBrowser: Icon,
+      qr: Icon,
       scan: Icon,
     },
   };
@@ -42,6 +43,7 @@ jest.mock('@react-navigation/native', () => ({
   useFocusEffect: (cb: () => void) => {
     focusCallback = cb;
   },
+  useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
 const mockDashboardActions: { label: string; navigate: (nav: any) => void }[] =

--- a/__tests__/DecodedCallSection.test.tsx
+++ b/__tests__/DecodedCallSection.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+
+import DecodedCallSection from '../src/components/DecodedCallSection';
+import type { DecodedCall } from '../src/utils/txParser';
+
+jest.mock('react-native-paper', () => {
+  const { Text, View } = require('react-native');
+  return {
+    Text: ({ children, ...props }: any) => <Text {...props}>{children}</Text>,
+    Icon: () => <View />,
+  };
+});
+
+jest.mock('../src/theme', () => ({
+  __esModule: true,
+  default: { colors: { onSurfaceVariant: '#aaa', negative: '#f00' } },
+}));
+
+jest.mock('../src/components/InfoRow', () => {
+  const { Text } = require('react-native');
+  return ({ label, value }: { label: string; value: string }) => (
+    <Text>{`${label}: ${value}`}</Text>
+  );
+});
+
+const ADDR_A = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDR_B = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const UINT256_MAX = 2n ** 256n - 1n;
+
+describe('DecodedCallSection', () => {
+  describe('erc20-transfer', () => {
+    const call: DecodedCall = {
+      kind: 'erc20-transfer',
+      to: ADDR_A,
+      amount: 1000n,
+    };
+
+    it('shows ERC-20 Transfer heading and recipient', () => {
+      render(<DecodedCallSection call={call} />);
+      expect(screen.getByText('ERC-20 Transfer')).toBeTruthy();
+      expect(screen.getByText(`Recipient: ${ADDR_A}`)).toBeTruthy();
+      expect(screen.getByText('Amount (raw units): 1000')).toBeTruthy();
+    });
+
+    it('shows token contract row when provided', () => {
+      render(<DecodedCallSection call={call} tokenContract={ADDR_B} />);
+      expect(screen.getByText(`Token contract: ${ADDR_B}`)).toBeTruthy();
+    });
+
+    it('omits token contract row when not provided', () => {
+      render(<DecodedCallSection call={call} />);
+      expect(screen.queryByText(/Token contract/)).toBeNull();
+    });
+  });
+
+  describe('erc20-transferFrom', () => {
+    const call: DecodedCall = {
+      kind: 'erc20-transferFrom',
+      from: ADDR_A,
+      to: ADDR_B,
+      amount: 500n,
+    };
+
+    it('shows ERC-20 Transfer From heading, from, and recipient', () => {
+      render(<DecodedCallSection call={call} />);
+      expect(screen.getByText('ERC-20 Transfer From')).toBeTruthy();
+      expect(screen.getByText(`From: ${ADDR_A}`)).toBeTruthy();
+      expect(screen.getByText(`Recipient: ${ADDR_B}`)).toBeTruthy();
+      expect(screen.getByText('Amount (raw units): 500')).toBeTruthy();
+    });
+
+    it('shows token contract row when provided', () => {
+      render(<DecodedCallSection call={call} tokenContract={ADDR_A} />);
+      expect(screen.getByText(`Token contract: ${ADDR_A}`)).toBeTruthy();
+    });
+  });
+
+  describe('erc20-approve', () => {
+    it('shows limited approval without warning', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-approve',
+        spender: ADDR_A,
+        amount: 100n,
+      };
+      render(<DecodedCallSection call={call} />);
+      expect(screen.getByText('ERC-20 Approve')).toBeTruthy();
+      expect(screen.getByText(`Spender: ${ADDR_A}`)).toBeTruthy();
+      expect(screen.getByText('Allowance: 100')).toBeTruthy();
+      expect(screen.queryByText(/Unlimited approval/)).toBeNull();
+    });
+
+    it('shows "Unlimited" and warning for max uint256', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-approve',
+        spender: ADDR_A,
+        amount: UINT256_MAX,
+      };
+      render(<DecodedCallSection call={call} />);
+      expect(screen.getByText('Allowance: Unlimited')).toBeTruthy();
+      expect(screen.getByText(/Unlimited approval/)).toBeTruthy();
+    });
+
+    it('shows token contract row when provided', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-approve',
+        spender: ADDR_A,
+        amount: 1n,
+      };
+      render(<DecodedCallSection call={call} tokenContract={ADDR_B} />);
+      expect(screen.getByText(`Token contract: ${ADDR_B}`)).toBeTruthy();
+    });
+  });
+
+  describe('unknown-call', () => {
+    it('shows raw selector', () => {
+      const call: DecodedCall = {
+        kind: 'unknown-call',
+        selector: '0xdeadbeef',
+      };
+      render(<DecodedCallSection call={call} />);
+      expect(screen.getByText('Contract call: 0xdeadbeef')).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/btcPsbt.test.ts
+++ b/__tests__/btcPsbt.test.ts
@@ -166,4 +166,66 @@ describe('inspectBtcPsbt', () => {
     expect(summary.requestType).toBe('bip322-message');
     expect(summary.bip322Address).toMatch(/^tb1/);
   });
+
+  it('detects mainnet from derivation path coin type 0', () => {
+    const { Psbt, payments, networks } = require('bitcoinjs-lib');
+    const fakePubkey = Buffer.alloc(33, 0x02);
+    const { output } = payments.p2wpkh({
+      pubkey: fakePubkey,
+      network: networks.bitcoin,
+    });
+    const psbt = new Psbt({ network: networks.bitcoin });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xbb),
+      index: 0,
+      bip32Derivation: [
+        {
+          masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+          path: "m/84'/0'/0'/0/0",
+          pubkey: fakePubkey,
+        },
+      ],
+    });
+    psbt.addOutput({ script: output!, value: 50_000 });
+    const summary = inspectBtcPsbt(psbt.toBuffer().toString('hex'));
+    expect(summary.network).toBe('mainnet');
+  });
+
+  it('resolves input value from nonWitnessUtxo', () => {
+    const { Psbt, Transaction, payments, networks } = require('bitcoinjs-lib');
+    const fakePubkey = Buffer.alloc(33, 0x02);
+    const { output } = payments.p2pkh({
+      pubkey: fakePubkey,
+      network: networks.bitcoin,
+    });
+
+    const prevTx = new Transaction();
+    prevTx.addInput(Buffer.alloc(32), 0);
+    prevTx.addOutput(output!, 80_000);
+
+    const psbt = new Psbt({ network: networks.bitcoin });
+    psbt.addInput({
+      hash: prevTx.getHash(),
+      index: 0,
+      nonWitnessUtxo: prevTx.toBuffer(),
+      bip32Derivation: [
+        {
+          masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+          path: "m/44'/0'/0'/0/0",
+          pubkey: fakePubkey,
+        },
+      ],
+    });
+    psbt.addOutput({ script: output!, value: 70_000 });
+
+    const summary = inspectBtcPsbt(psbt.toBuffer().toString('hex'));
+    expect(summary.network).toBe('mainnet');
+    expect(summary.inputCount).toBe(1);
+    expect(summary.totalOutputSats).toBe(70_000);
+  });
+
+  it('returns unknown network when no derivation path present', () => {
+    const summary = inspectBtcPsbt(MINIMAL_PSBT_HEX);
+    expect(summary.network).toBe('unknown');
+  });
 });

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -1,8 +1,20 @@
 import { keccak_256 } from '@noble/hashes/sha3.js';
 
-import { prepareSignHash } from '../src/utils/keycardExport';
+import { buildExportUr, prepareSignHash } from '../src/utils/keycardExport';
 
 jest.mock('keycard-sdk', () => ({ __esModule: true, default: {} }));
+
+jest.mock('../src/utils/cryptoHdKey', () => ({
+  buildCryptoHdKeyUR: jest.fn(() => 'ur:crypto-hdkey/mock'),
+}));
+jest.mock('../src/utils/cryptoAccount', () => ({
+  buildCryptoAccountUR: jest.fn(() => 'ur:crypto-account/mock'),
+  pubKeyFingerprint: jest.fn(() => 0xdeadbeef),
+}));
+jest.mock('../src/utils/cryptoMultiAccounts', () => ({
+  buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
+  exportKeysForBitget: jest.fn(),
+}));
 
 function hex(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('hex');
@@ -52,5 +64,52 @@ describe('prepareSignHash', () => {
     const hash32Hex = 'cd'.repeat(32);
     const result = prepareSignHash(hash32Hex, undefined);
     expect(hex(result)).toBe(hash32Hex);
+  });
+});
+
+describe('buildExportUr', () => {
+  const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey');
+  const { buildCryptoAccountUR } = require('../src/utils/cryptoAccount');
+  const {
+    buildCryptoMultiAccountsUR,
+  } = require('../src/utils/cryptoMultiAccounts');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildCryptoHdKeyUR.mockReturnValue('ur:crypto-hdkey/mock');
+    buildCryptoAccountUR.mockReturnValue('ur:crypto-account/mock');
+    buildCryptoMultiAccountsUR.mockReturnValue('ur:crypto-multi-accounts/mock');
+  });
+
+  it('calls buildCryptoHdKeyUR when result has exportRespData', () => {
+    const result = buildExportUr(
+      {
+        exportRespData: new Uint8Array([1, 2, 3]),
+        sourceFingerprint: 0xdeadbeef,
+      },
+      "m/44'/60'/0'",
+      'MetaMask',
+    );
+    expect(buildCryptoHdKeyUR).toHaveBeenCalledWith(
+      new Uint8Array([1, 2, 3]),
+      "m/44'/60'/0'",
+      0xdeadbeef,
+      'MetaMask',
+    );
+    expect(result).toBe('ur:crypto-hdkey/mock');
+  });
+
+  it('calls buildCryptoMultiAccountsUR when result has keys', () => {
+    const multiResult = { keys: [] } as any;
+    const result = buildExportUr(multiResult, 'bitget');
+    expect(buildCryptoMultiAccountsUR).toHaveBeenCalledWith(multiResult);
+    expect(result).toBe('ur:crypto-multi-accounts/mock');
+  });
+
+  it('calls buildCryptoAccountUR for Bitcoin crypto-account result', () => {
+    const btcResult = { masterFingerprint: 0xdeadbeef, descriptors: [] } as any;
+    const result = buildExportUr(btcResult, "m/84'/0'/0'");
+    expect(buildCryptoAccountUR).toHaveBeenCalledWith(btcResult);
+    expect(result).toBe('ur:crypto-account/mock');
   });
 });

--- a/__tests__/useFactoryReset.test.ts
+++ b/__tests__/useFactoryReset.test.ts
@@ -5,6 +5,7 @@ import { useFactoryReset } from '../src/hooks/keycard/useFactoryReset';
 // RNKeycard mock — captures event callbacks so tests can trigger them
 // ---------------------------------------------------------------------------
 
+let capturedOnConnected: ((...args: any[]) => Promise<void>) | null = null;
 let capturedOnDisconnected: (() => void) | null = null;
 let capturedOnCancelled: (() => void) | null = null;
 let capturedOnTimeout: (() => void) | null = null;
@@ -16,7 +17,10 @@ jest.mock('react-native-keycard', () => ({
   __esModule: true,
   default: {
     Core: {
-      onKeycardConnected: (_cb: () => Promise<void>) => ({ remove: jest.fn() }),
+      onKeycardConnected: (cb: (...args: any[]) => Promise<void>) => {
+        capturedOnConnected = cb;
+        return { remove: jest.fn() };
+      },
       onKeycardDisconnected: (cb: () => void) => {
         capturedOnDisconnected = cb;
         return { remove: jest.fn() };
@@ -36,9 +40,21 @@ jest.mock('react-native-keycard', () => ({
   },
 }));
 
+const mockFactoryReset = jest.fn();
+const mockSelect = jest.fn();
+const mockCmdSet = {
+  select: mockSelect,
+  applicationInfo: { initializedCard: true } as {
+    initializedCard: boolean;
+  } | null,
+  factoryReset: mockFactoryReset,
+};
+
 jest.mock('keycard-sdk', () => ({
   __esModule: true,
-  default: { Commandset: class {} },
+  default: {
+    Commandset: jest.fn().mockImplementation(() => mockCmdSet),
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -49,8 +65,14 @@ describe('useFactoryReset', () => {
   beforeEach(() => {
     mockStartNFC.mockResolvedValue(undefined);
     mockStopNFC.mockResolvedValue(undefined);
+    mockSelect.mockResolvedValue({ sw: 0x9000 });
+    mockFactoryReset.mockResolvedValue(undefined);
     mockStartNFC.mockClear();
     mockStopNFC.mockClear();
+    mockSelect.mockClear();
+    mockFactoryReset.mockClear();
+    mockCmdSet.applicationInfo = { initializedCard: true };
+    capturedOnConnected = null;
     capturedOnDisconnected = null;
     capturedOnCancelled = null;
     capturedOnTimeout = null;
@@ -162,6 +184,36 @@ describe('useFactoryReset', () => {
       });
       expect(result.current.phase).toBe('idle');
       expect(result.current.status).toBe('');
+    });
+  });
+
+  describe('NFC operation body', () => {
+    it('throws when card is not initialized', async () => {
+      mockCmdSet.applicationInfo = { initializedCard: false };
+      const { result } = renderHook(() => useFactoryReset());
+      await act(async () => {
+        result.current.start();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(mockFactoryReset).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toMatch(/already empty/);
+    });
+
+    it('calls factoryReset when card is initialized', async () => {
+      const { result } = renderHook(() => useFactoryReset());
+      await act(async () => {
+        result.current.start();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(mockFactoryReset).toHaveBeenCalled();
+      expect(result.current.phase).toBe('done');
     });
   });
 });

--- a/__tests__/useInitCard.test.ts
+++ b/__tests__/useInitCard.test.ts
@@ -5,6 +5,7 @@ import { useInitCard } from '../src/hooks/keycard/useInitCard';
 // RNKeycard mock — captures event callbacks so tests can trigger them
 // ---------------------------------------------------------------------------
 
+let capturedOnConnected: ((...args: any[]) => Promise<void>) | null = null;
 let capturedOnDisconnected: (() => void) | null = null;
 let capturedOnCancelled: (() => void) | null = null;
 let capturedOnTimeout: (() => void) | null = null;
@@ -16,7 +17,10 @@ jest.mock('react-native-keycard', () => ({
   __esModule: true,
   default: {
     Core: {
-      onKeycardConnected: (_cb: () => Promise<void>) => ({ remove: jest.fn() }),
+      onKeycardConnected: (cb: (...args: any[]) => Promise<void>) => {
+        capturedOnConnected = cb;
+        return { remove: jest.fn() };
+      },
       onKeycardDisconnected: (cb: () => void) => {
         capturedOnDisconnected = cb;
         return { remove: jest.fn() };
@@ -36,9 +40,21 @@ jest.mock('react-native-keycard', () => ({
   },
 }));
 
+const mockInit = jest.fn();
+const mockSelect = jest.fn();
+const mockCmdSet = {
+  select: mockSelect,
+  applicationInfo: { initializedCard: false } as {
+    initializedCard: boolean;
+  } | null,
+  init: mockInit,
+};
+
 jest.mock('keycard-sdk', () => ({
   __esModule: true,
-  default: { Commandset: class {} },
+  default: {
+    Commandset: jest.fn().mockImplementation(() => mockCmdSet),
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -49,8 +65,14 @@ describe('useInitCard', () => {
   beforeEach(() => {
     mockStartNFC.mockResolvedValue(undefined);
     mockStopNFC.mockResolvedValue(undefined);
+    mockSelect.mockResolvedValue({ sw: 0x9000 });
+    mockInit.mockResolvedValue(undefined);
     mockStartNFC.mockClear();
     mockStopNFC.mockClear();
+    mockSelect.mockClear();
+    mockInit.mockClear();
+    mockCmdSet.applicationInfo = { initializedCard: false };
+    capturedOnConnected = null;
     capturedOnDisconnected = null;
     capturedOnCancelled = null;
     capturedOnTimeout = null;
@@ -164,6 +186,59 @@ describe('useInitCard', () => {
       });
       expect(result.current.phase).toBe('idle');
       expect(result.current.status).toBe('');
+    });
+  });
+
+  describe('NFC operation body', () => {
+    it('throws when card is already initialized', async () => {
+      mockCmdSet.applicationInfo = { initializedCard: true };
+      const { result } = renderHook(() => useInitCard());
+      await act(async () => {
+        result.current.start('123456');
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(mockInit).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toMatch(/already set up/);
+    });
+
+    it('calls init with pin and pairing password when card is blank', async () => {
+      const { result } = renderHook(() => useInitCard());
+      await act(async () => {
+        result.current.start('123456');
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(mockInit).toHaveBeenCalledWith(
+        '123456',
+        expect.stringMatching(/^\d{12}$/),
+        expect.anything(),
+        undefined,
+      );
+      expect(result.current.phase).toBe('done');
+      expect(result.current.result).toMatch(/^\d{12}$/);
+    });
+
+    it('passes duress pin when provided', async () => {
+      const { result } = renderHook(() => useInitCard());
+      await act(async () => {
+        result.current.start('123456', '000000');
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(mockInit).toHaveBeenCalledWith(
+        '123456',
+        expect.stringMatching(/^\d{12}$/),
+        expect.anything(),
+        '000000',
+      );
     });
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/', 'testUtils\\.ts$'],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@noble/(secp256k1|hashes|curves)|@scure/(bip32|bip39|base)|keycard-sdk)/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@react-navigation|@noble/(secp256k1|hashes|curves)|@scure/(bip32|bip39|base)|keycard-sdk)/)',
   ],
   setupFilesAfterEnv: ['./jest.setup.js'],
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.3",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
+    "android": "react-native run-android --mode fullDebug",
+    "android:offline": "react-native run-android --mode offlineDebug",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",

--- a/src/components/DashboardKeycardNotice.tsx
+++ b/src/components/DashboardKeycardNotice.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
 
+import type { RootStackParamList } from '../navigation/types';
 import {
   loadBooleanPreference,
   preferenceKeys,
@@ -9,7 +12,10 @@ import {
 
 import KeycardPurchaseCard from './KeycardPurchaseCard';
 
+import { KEYCARD_PURCHASE_URL } from '../constants/keycard';
+
 export default function DashboardKeycardNotice() {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [visible, setVisible] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
@@ -46,6 +52,12 @@ export default function DashboardKeycardNotice() {
     <View style={styles.noticeWrapper}>
       <KeycardPurchaseCard
         onClose={handleClose}
+        onShowQR={() =>
+          navigation.navigate('UrlQR', {
+            url: KEYCARD_PURCHASE_URL,
+            title: 'Buy a Keycard',
+          })
+        }
         buttonTestID="dashboard-keycard-purchase-link"
         closeButtonTestID="dashboard-keycard-notice-close"
       />

--- a/src/components/KeycardPurchaseCard.tsx
+++ b/src/components/KeycardPurchaseCard.tsx
@@ -16,6 +16,7 @@ type KeycardPurchaseCardProps = {
   buttonTestID?: string;
   closeButtonTestID?: string;
   onClose?: () => void;
+  onShowQR?: () => void;
 };
 
 const keycardPurchaseTitle = 'Keycard required';
@@ -26,6 +27,7 @@ export default function KeycardPurchaseCard({
   buttonTestID,
   closeButtonTestID,
   onClose,
+  onShowQR,
 }: KeycardPurchaseCardProps) {
   const handlePressPurchase = useCallback(() => {
     Linking.openURL(KEYCARD_PURCHASE_URL);
@@ -66,6 +68,15 @@ export default function KeycardPurchaseCard({
           icon={Icons.openInBrowser}
           testID={buttonTestID}
         />
+        {onShowQR ? (
+          <Pressable style={styles.qrIconButton} onPress={onShowQR}>
+            <Icons.qr
+              width={22}
+              height={22}
+              color={theme.colors.onSurfaceMuted}
+            />
+          </Pressable>
+        ) : null}
       </View>
     </View>
   );
@@ -111,6 +122,12 @@ const styles = StyleSheet.create({
   },
   button: {
     alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
     marginTop: 8,
+    gap: 8,
+  },
+  qrIconButton: {
+    padding: 8,
   },
 });

--- a/src/components/about/AppIdentityHeader.tsx
+++ b/src/components/about/AppIdentityHeader.tsx
@@ -1,0 +1,49 @@
+import { Image, StyleSheet, Text, View } from 'react-native';
+
+import theme from '../../theme';
+
+import { version as APP_VERSION } from '../../../package.json';
+
+export default function AppIdentityHeader() {
+  return (
+    <View style={styles.header}>
+      <View style={styles.appIdentity}>
+        <Image
+          source={require('../../../fastlane/metadata/android/en-US/images/icon.png')}
+          style={styles.appIcon}
+          accessibilityLabel="GapSign app icon"
+        />
+        <Text style={styles.appName}>GapSign</Text>
+      </View>
+      <Text style={styles.version}>v{APP_VERSION}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    alignItems: 'center',
+    paddingTop: 8,
+    gap: 4,
+  },
+  appIdentity: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  appName: {
+    fontFamily: 'Inter_18pt-SemiBold',
+    fontSize: 28,
+    lineHeight: 34,
+    color: theme.colors.onSurface,
+  },
+  appIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 8,
+  },
+  version: {
+    fontSize: 14,
+    color: theme.colors.onSurfaceMuted,
+  },
+});

--- a/src/components/about/ContributorsList.tsx
+++ b/src/components/about/ContributorsList.tsx
@@ -1,7 +1,10 @@
 import { useCallback } from 'react';
 import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
 
 import { Icons } from '../../assets/icons';
+import type { RootStackParamList } from '../../navigation/types';
 import theme from '../../theme';
 
 import contributors from '../../data/contributors.json';
@@ -9,25 +12,54 @@ import contributors from '../../data/contributors.json';
 type Contributor = { name: string; github: string | null };
 
 function ContributorRow({ contributor }: { contributor: Contributor }) {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
   const handlePress = useCallback(() => {
     if (contributor.github) {
       Linking.openURL(`https://github.com/${contributor.github}`);
     }
   }, [contributor.github]);
 
+  const handleShowQR = useCallback(() => {
+    if (contributor.github) {
+      navigation.navigate('UrlQR', {
+        url: `https://github.com/${contributor.github}`,
+        title: contributor.name,
+      });
+    }
+  }, [contributor.github, contributor.name, navigation]);
+
   return (
     <Pressable
       style={[styles.row, styles.rowBorder]}
-      onPress={contributor.github ? handlePress : undefined}
+      onPress={contributor.github ? handleShowQR : undefined}
       disabled={!contributor.github}
+      accessibilityLabel={
+        contributor.github
+          ? `Show QR code for ${contributor.github}`
+          : contributor.name
+      }
     >
       <Text style={styles.rowLabel}>{contributor.name}</Text>
       {contributor.github ? (
-        <Icons.openInBrowser
-          width={18}
-          height={18}
-          color={theme.colors.onSurfaceMuted}
-        />
+        <View style={styles.icons}>
+          <Pressable
+            style={styles.openIconButton}
+            onPress={handlePress}
+            accessibilityLabel={`Open ${contributor.name} GitHub profile`}
+          >
+            <Icons.openInBrowser
+              width={18}
+              height={18}
+              color={theme.colors.onSurfaceMuted}
+            />
+          </Pressable>
+          <Icons.qr
+            width={18}
+            height={18}
+            color={theme.colors.onSurfaceMuted}
+          />
+        </View>
       ) : null}
     </Pressable>
   );
@@ -62,6 +94,14 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  icons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  openIconButton: {
+    padding: 4,
   },
   rowBorder: {
     borderBottomWidth: 1,

--- a/src/components/about/DonationSection.tsx
+++ b/src/components/about/DonationSection.tsx
@@ -1,0 +1,40 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import theme from '../../theme';
+
+import DonationList from './DonationList';
+
+type DonationSectionProps = {
+  onShowQR: (label: string, address: string) => void;
+};
+
+export default function DonationSection({ onShowQR }: DonationSectionProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Support development</Text>
+      <Text style={styles.description}>
+        Donations help keep GapSign maintained and available as open-source
+        software.
+      </Text>
+      <DonationList onShowQR={onShowQR} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+  },
+  title: {
+    fontFamily: 'Inter_18pt-SemiBold',
+    fontSize: 18,
+    color: theme.colors.onSurface,
+    textAlign: 'center',
+  },
+  description: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -8,6 +8,7 @@ import type { RootStackParamList } from './types';
 import AboutScreen from '../screens/AboutScreen';
 import DashboardScreen from '../screens/DashboardScreen';
 import LicenseDetailScreen from '../screens/LicenseDetailScreen';
+import UrlQRScreen from '../screens/UrlQRScreen';
 import ExportKeyScreen from '../screens/ExportKeyScreen';
 import FactoryResetScreen from '../screens/FactoryResetScreen';
 import InitCardScreen from '../screens/InitCardScreen';
@@ -165,6 +166,11 @@ export const routes: Route[] = [
   {
     name: 'LicenseDetail',
     component: LicenseDetailScreen,
+    options: defaultHeaderOptions,
+  },
+  {
+    name: 'UrlQR',
+    component: UrlQRScreen,
     options: defaultHeaderOptions,
   },
 ];

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -65,6 +65,10 @@ export type RootStackParamList = {
     packageName: string;
     licenseType: string;
   };
+  UrlQR: {
+    url: string;
+    title?: string;
+  };
 };
 
 export type DashboardScreenProps = NativeStackScreenProps<
@@ -175,6 +179,11 @@ export type AboutScreenProps = NativeStackScreenProps<
 export type LicenseDetailScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'LicenseDetail'
+>;
+
+export type UrlQRScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'UrlQR'
 >;
 
 export type DashboardAction = {

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import {
-  Image,
   Linking,
   Pressable,
   ScrollView,
@@ -14,13 +13,14 @@ import { Icons } from '../assets/icons';
 import type { AboutScreenProps, DashboardAction } from '../navigation/types';
 import theme from '../theme';
 
+import AppIdentityHeader from '../components/about/AppIdentityHeader';
 import ContributorsList from '../components/about/ContributorsList';
-import DonationList from '../components/about/DonationList';
+import DonationSection from '../components/about/DonationSection';
 import KeycardPurchaseCard from '../components/KeycardPurchaseCard';
 import LicenseList from '../components/about/LicenseList';
 
+import { KEYCARD_PURCHASE_URL } from '../constants/keycard';
 import type { LicenseEntry } from '../data/licenses';
-import { version as APP_VERSION } from '../../package.json';
 
 const PROJECT_GITHUB_URL = 'https://github.com/mmlado/GapSign';
 
@@ -49,18 +49,7 @@ export default function AboutScreen({ navigation }: AboutScreenProps) {
         { paddingBottom: insets.bottom + 24 },
       ]}
     >
-      {/* App identity */}
-      <View style={styles.header}>
-        <View style={styles.appIdentity}>
-          <Image
-            source={require('../../fastlane/metadata/android/en-US/images/icon.png')}
-            style={styles.appIcon}
-            accessibilityLabel="GapSign app icon"
-          />
-          <Text style={styles.appName}>GapSign</Text>
-        </View>
-        <Text style={styles.version}>v{APP_VERSION}</Text>
-      </View>
+      <AppIdentityHeader />
 
       <Text style={styles.description}>
         GapSign is an open-source air-gapped hardware wallet companion for
@@ -69,28 +58,46 @@ export default function AboutScreen({ navigation }: AboutScreenProps) {
         Bitcoin signing — keeping your private keys offline at all times.
       </Text>
 
-      <Pressable
-        style={styles.projectLink}
-        onPress={() => Linking.openURL(PROJECT_GITHUB_URL)}
-      >
-        <Text style={styles.projectLinkText}>GitHub project</Text>
-        <Icons.openInBrowser
-          width={18}
-          height={18}
-          color={theme.colors.onSurface}
-        />
-      </Pressable>
+      <View style={styles.projectLinkRow}>
+        <Pressable
+          style={styles.projectLink}
+          onPress={() => Linking.openURL(PROJECT_GITHUB_URL)}
+        >
+          <Text style={styles.projectLinkText}>GitHub project</Text>
+          <Icons.openInBrowser
+            width={18}
+            height={18}
+            color={theme.colors.onSurface}
+          />
+        </Pressable>
+        <Pressable
+          style={styles.qrIconButton}
+          accessibilityLabel="Show GitHub project QR code"
+          onPress={() =>
+            navigation.navigate('UrlQR', {
+              url: PROJECT_GITHUB_URL,
+              title: 'GitHub project',
+            })
+          }
+        >
+          <Icons.qr
+            width={20}
+            height={20}
+            color={theme.colors.onSurfaceMuted}
+          />
+        </Pressable>
+      </View>
 
-      {/* Keycard section */}
-      <KeycardPurchaseCard />
+      <KeycardPurchaseCard
+        onShowQR={() =>
+          navigation.navigate('UrlQR', {
+            url: KEYCARD_PURCHASE_URL,
+            title: 'Buy a Keycard',
+          })
+        }
+      />
 
-      {/* Donations */}
-      <Text style={styles.sectionTitle}>Support development</Text>
-      <Text style={styles.sectionDescription}>
-        Donations help keep GapSign maintained and available as open-source
-        software.
-      </Text>
-      <DonationList
+      <DonationSection
         onShowQR={(label, address) =>
           navigation.navigate('AddressDetail', {
             address,
@@ -100,11 +107,9 @@ export default function AboutScreen({ navigation }: AboutScreenProps) {
         }
       />
 
-      {/* Contributors */}
       <Text style={styles.sectionTitle}>Contributors</Text>
       <ContributorsList />
 
-      {/* Licenses */}
       <Text style={styles.sectionTitle}>Open-source licenses</Text>
       <LicenseList onSelectLicense={handleSelectLicense} />
     </ScrollView>
@@ -120,44 +125,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     gap: 16,
   },
-  header: {
-    alignItems: 'center',
-    paddingTop: 8,
-    gap: 4,
-  },
-  appIdentity: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 10,
-  },
-  appName: {
-    fontFamily: 'Inter_18pt-SemiBold',
-    fontSize: 28,
-    lineHeight: 34,
-    color: theme.colors.onSurface,
-  },
-  appIcon: {
-    width: 34,
-    height: 34,
-    borderRadius: 8,
-  },
-  version: {
-    fontSize: 14,
-    color: theme.colors.onSurfaceMuted,
-  },
   description: {
     fontSize: 14,
     lineHeight: 21,
     color: theme.colors.onSurfaceVariant,
     textAlign: 'center',
   },
-  projectLink: {
+  projectLinkRow: {
     alignSelf: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+  },
+  projectLink: {
     alignItems: 'center',
     flexDirection: 'row',
     gap: 8,
     paddingHorizontal: 16,
     paddingVertical: 10,
+  },
+  qrIconButton: {
+    padding: 8,
   },
   projectLinkText: {
     color: theme.colors.onSurface,
@@ -168,12 +156,6 @@ const styles = StyleSheet.create({
     fontFamily: 'Inter_18pt-SemiBold',
     fontSize: 18,
     color: theme.colors.onSurface,
-    textAlign: 'center',
-  },
-  sectionDescription: {
-    color: theme.colors.onSurfaceVariant,
-    fontSize: 14,
-    lineHeight: 20,
     textAlign: 'center',
   },
 });

--- a/src/screens/UrlQRScreen.tsx
+++ b/src/screens/UrlQRScreen.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useLayoutEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
+import QRCode from 'react-native-qrcode-svg';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { UrlQRScreenProps } from '../navigation/types';
+import theme from '../theme';
+
+import { Icons } from '../assets/icons';
+import PrimaryButton from '../components/PrimaryButton';
+
+export default function UrlQRScreen({ route, navigation }: UrlQRScreenProps) {
+  const { url, title } = route.params;
+  const insets = useSafeAreaInsets();
+
+  useLayoutEffect(() => {
+    if (title) {
+      navigation.setOptions({ title });
+    }
+  }, [navigation, title]);
+
+  const handleCopy = useCallback(() => {
+    Clipboard.setString(url);
+  }, [url]);
+
+  return (
+    <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
+      <View style={styles.qrContainer}>
+        <View style={styles.qrWrapper}>
+          <QRCode
+            value={url}
+            size={280}
+            color="#000000"
+            backgroundColor="#ffffff"
+          />
+        </View>
+        <Text selectable style={styles.url}>
+          {url}
+        </Text>
+      </View>
+      <PrimaryButton label="Copy URL" onPress={handleCopy} icon={Icons.copy} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    gap: 24,
+  },
+  qrContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24,
+  },
+  qrWrapper: {
+    padding: 16,
+    backgroundColor: '#ffffff',
+    borderRadius: 8,
+  },
+  url: {
+    color: theme.colors.onSurface,
+    fontFamily: 'monospace',
+    textAlign: 'center',
+    paddingHorizontal: 8,
+  },
+});


### PR DESCRIPTION
## Summary

- New `UrlQRScreen` (full-screen stack push, same layout as address detail) lets air-gapped users scan any external URL on a second device
- Contributor rows: tap row → QR (primary); browser icon is secondary. Other links (GitHub project, Keycard shop): browser primary, QR secondary
- `DashboardKeycardNotice` and `KeycardPurchaseCard` both expose QR for the shop link
- Extracted `AppIdentityHeader` and `DonationSection` components from `AboutScreen`
- Added test coverage for `DecodedCallSection`, `keycardExport.buildExportUr`, `useInitCard` NFC body, `useFactoryReset` NFC body, and `btcPsbt` edge cases (coverage: ~84%)
- Static coverage badge added to README