### PR TITLE
ci: upload Jest coverage to Codecov (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,12 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run tests
-        run: npm test -- --watchAll=false
+      - name: Run tests with coverage
+        run: npm test -- --watchAll=false --coverage --coverageReporters=lcov --coverageReporters=text-summary
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          flags: jest
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Codecov coverage upload in CI and a live README coverage badge
 - Decode ERC-20 calldata (`transfer`, `transferFrom`, `approve`) in transaction review; show unlimited approval warning
 - Detect and label pre-hashed EIP-712 payloads (`0x1901`) with domain separator and message hash
 - `full` (`tech.gapsign`) and `offline` (`tech.gapsign.offline`) Android build flavors

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/mmlado/GapSign/actions/workflows/ci.yml"><img src="https://github.com/mmlado/GapSign/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/mmlado/GapSign/actions/workflows/android-release.yml"><img src="https://github.com/mmlado/GapSign/actions/workflows/android-release.yml/badge.svg" alt="Build & Release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
-  <img src="https://img.shields.io/badge/coverage-84%25-brightgreen.svg" alt="Test coverage" />
+  <a href="https://codecov.io/gh/mmlado/GapSign"><img src="https://codecov.io/gh/mmlado/GapSign/branch/main/graph/badge.svg" alt="Test coverage" /></a>
   <a href="https://developer.android.com"><img src="https://img.shields.io/badge/platform-Android-green.svg" alt="Platform" /></a>
   <a href="https://reactnative.dev"><img src="https://img.shields.io/badge/React%20Native-0.83-blue.svg" alt="React Native" /></a>
   <a href="https://github.com/mmlado/GapSign/releases/latest"><img src="https://img.shields.io/github/v/release/mmlado/GapSign" alt="GitHub release" /></a>


### PR DESCRIPTION
## Summary

- run Jest with coverage in CI
- upload `coverage/lcov.info` to Codecov using `CODECOV_TOKEN`
- replace the static README coverage badge with the live Codecov badge