### PR TITLE
ci: move release checksums to notes footer

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -86,14 +86,38 @@ jobs:
           mkdir -p android/app/build/outputs/apk/release
           find android/app/build/outputs/apk -name "app-*-release.apk" \
             | sort | xargs sha256sum > android/app/build/outputs/apk/release/SHA256SUMS.txt
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NOTES_FILE=android/app/build/outputs/apk/release/RELEASE_NOTES.md
+          CURRENT_TAG="${{ steps.ver.outputs.tag }}"
+          PREV_TAG=$(git tag --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${CURRENT_TAG}$" \
+            | sed -n '1p')
+
+          if [ -n "$PREV_TAG" ]; then
+            gh api "repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="$CURRENT_TAG" \
+              -f previous_tag_name="$PREV_TAG" \
+              --jq .body > "$NOTES_FILE"
+          else
+            gh api "repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="$CURRENT_TAG" \
+              --jq .body > "$NOTES_FILE"
+          fi
+
           {
+            echo
             echo "## APK SHA256 checksums"
             echo
             echo '```text'
             cat android/app/build/outputs/apk/release/SHA256SUMS.txt
             echo '```'
             echo
-          } > android/app/build/outputs/apk/release/RELEASE_NOTES.md
+          } >> "$NOTES_FILE"
 
       - name: Create GitHub Release and upload APKs
         uses: softprops/action-gh-release@v2
@@ -104,4 +128,3 @@ jobs:
             android/app/build/outputs/apk/full/release/app-*-release.apk
             android/app/build/outputs/apk/offline/release/app-*-release.apk
             android/app/build/outputs/apk/release/SHA256SUMS.txt
-          generate_release_notes: true


### PR DESCRIPTION
## Summary

- generate GitHub release notes before creating the release
- append the APK SHA256 checksum block after the generated changelog
- remove `generate_release_notes: true` so the checksum summary no longer appears above the release notes
