### PR TITLE
test: expand coverage for signing and workflow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Expanded Jest coverage for signing utilities and wallet workflow screens
+
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -137,10 +137,18 @@ describe('AboutScreen', () => {
 
   it('shows QR for a contributor profile', () => {
     renderScreen();
-    fireEvent.press(screen.getByLabelText('Show QR code for mmlado'));
+    fireEvent.press(screen.getByLabelText(/Show QR code for .+/));
     expect(mockUseNavigationNavigate).toHaveBeenCalledWith('UrlQR', {
-      url: 'https://github.com/mmlado',
+      url: expect.stringContaining('github.com'),
       title: expect.any(String),
     });
+  });
+
+  it('opens a contributor profile in the browser', () => {
+    renderScreen();
+    fireEvent.press(screen.getByLabelText(/Open .* GitHub profile/));
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      expect.stringContaining('github.com'),
+    );
   });
 });

--- a/__tests__/ChangeSecretScreen.test.tsx
+++ b/__tests__/ChangeSecretScreen.test.tsx
@@ -1,4 +1,5 @@
 import React, { act } from 'react';
+import { TextInput } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import ChangeSecretScreen from '../src/screens/secrets/ChangeSecretScreen';
@@ -77,6 +78,14 @@ async function renderScreen(
   return render(
     <ChangeSecretScreen navigation={navigation} route={routeFor(secretType)} />,
   );
+}
+
+function lastBeforeRemoveHandler() {
+  const call = navigation.addListener.mock.calls
+    .slice()
+    .reverse()
+    .find(([event]: [string]) => event === 'beforeRemove');
+  return call?.[1];
 }
 
 async function enterDigits(count: number, keyIndex = 0) {
@@ -222,6 +231,34 @@ describe('ChangeSecretScreen', () => {
       expect(screen.queryByText(/digits/)).toBeNull();
     });
 
+    it('calls start when pairing secret confirmation matches', async () => {
+      await renderScreen('pairing');
+      fireEvent.changeText(
+        screen.UNSAFE_getByType(TextInput),
+        'pairing-secret',
+      );
+      fireEvent.press(screen.getByText('Continue'));
+      fireEvent.changeText(
+        screen.UNSAFE_getByType(TextInput),
+        'pairing-secret',
+      );
+      fireEvent.press(screen.getByText('Continue'));
+      expect(mockStart).toHaveBeenCalledWith('pairing-secret');
+    });
+
+    it('shows an error when pairing secret confirmation does not match', async () => {
+      await renderScreen('pairing');
+      fireEvent.changeText(
+        screen.UNSAFE_getByType(TextInput),
+        'pairing-secret',
+      );
+      fireEvent.press(screen.getByText('Continue'));
+      fireEvent.changeText(screen.UNSAFE_getByType(TextInput), 'other-secret');
+      fireEvent.press(screen.getByText('Continue'));
+      expect(screen.getByText("PINs don't match")).toBeTruthy();
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+
     it('resets to Dashboard with "Pairing secret changed" toast when done', async () => {
       mockUseChangeSecret.mockReturnValue({
         ...hookMock('done'),
@@ -260,6 +297,36 @@ describe('ChangeSecretScreen', () => {
     it('showOnDone is true', async () => {
       await renderScreen('pin');
       expect(lastProps().showOnDone).toBe(true);
+    });
+
+    it('cancels and goes back when NFC sheet is cancelled', async () => {
+      await renderScreen('pin');
+      lastProps().onCancel();
+      expect(mockCancel).toHaveBeenCalled();
+      expect(navigation.goBack).toHaveBeenCalled();
+    });
+  });
+
+  describe('beforeRemove guard', () => {
+    it('cancels NFC when leaving during NFC phase', async () => {
+      await renderScreen('pin', 'nfc');
+      lastBeforeRemoveHandler()?.({ preventDefault: jest.fn() });
+      expect(mockCancel).toHaveBeenCalled();
+    });
+
+    it('returns from confirm step to entry step before leaving', async () => {
+      await renderScreen('pin');
+      await enterDigits(6, 0);
+      const event = { preventDefault: jest.fn() };
+
+      await act(async () => {
+        lastBeforeRemoveHandler()?.(event);
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(navigation.setOptions).toHaveBeenCalledWith({
+        title: 'Enter new PIN',
+      });
     });
   });
 });

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -87,6 +87,33 @@ describe('ExportKeyScreen', () => {
       });
     });
 
+    it('navigates to Keycard with Bitcoin export path when Bitcoin is pressed', () => {
+      renderScreen();
+      fireEvent.press(screen.getByText('Bitcoin'));
+      expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+        operation: 'export_key',
+        derivationPath: "m/84'/0'/0'",
+      });
+    });
+
+    it('navigates to Keycard with multisig export path when Bitcoin Multisig is pressed', () => {
+      renderScreen();
+      fireEvent.press(screen.getByText('Bitcoin Multisig'));
+      expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+        operation: 'export_key',
+        derivationPath: "m/48'/0'/0'/2'",
+      });
+    });
+
+    it('navigates to Keycard with testnet export path when Bitcoin Testnet is pressed', () => {
+      renderScreen();
+      fireEvent.press(screen.getByText('Bitcoin Testnet'));
+      expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+        operation: 'export_key',
+        derivationPath: "m/84'/1'/0'",
+      });
+    });
+
     it('navigates to Keycard with source "account.ledger_live" when Ledger Live is pressed', () => {
       renderScreen();
       fireEvent.press(screen.getByText('Ledger Live'));

--- a/__tests__/InitCardScreen.test.tsx
+++ b/__tests__/InitCardScreen.test.tsx
@@ -66,6 +66,14 @@ function renderScreen(phase = 'idle') {
   return render(<InitCardScreen navigation={navigation} route={route} />);
 }
 
+function lastBeforeRemoveHandler() {
+  const call = navigation.addListener.mock.calls
+    .slice()
+    .reverse()
+    .find(([event]: [string]) => event === 'beforeRemove');
+  return call?.[1];
+}
+
 /** Press a digit key six times to complete a full PIN entry. keyIndex 0 = '1', 1 = '2'. */
 async function enterPin(keyIndex = 0) {
   const digit = String(keyIndex + 1);
@@ -97,7 +105,7 @@ describe('InitCardScreen', () => {
 
   describe('initial render', () => {
     it('sets header title to "Create a PIN" on first render', async () => {
-      await renderScreen();
+      renderScreen();
       expect(navigation.setOptions).toHaveBeenCalledWith({
         title: 'Create a PIN',
       });
@@ -234,22 +242,22 @@ describe('InitCardScreen', () => {
     }
 
     it('nfc.phase is idle when phase is idle', async () => {
-      await renderScreen('idle');
+      renderScreen('idle');
       expect(lastProps().nfc.phase).toBe('idle');
     });
 
     it('nfc.phase is nfc when phase is nfc', async () => {
-      await renderScreen('nfc');
+      renderScreen('nfc');
       expect(lastProps().nfc.phase).toBe('nfc');
     });
 
     it('nfc.phase is error when phase is error', async () => {
-      await renderScreen('error');
+      renderScreen('error');
       expect(lastProps().nfc.phase).toBe('error');
     });
 
     it('nfc.phase is done and showOnDone is true when phase is done', async () => {
-      await renderScreen('done');
+      renderScreen('done');
       expect(lastProps().nfc.phase).toBe('done');
       expect(lastProps().showOnDone).toBe(true);
     });
@@ -273,8 +281,48 @@ describe('InitCardScreen', () => {
     });
 
     it('does not navigate when phase is done but result is null', async () => {
-      await renderScreen('done'); // result is null in hookMock
+      renderScreen('done'); // result is null in hookMock
       expect(navigation.reset).not.toHaveBeenCalled();
+    });
+
+    it('cancels NFC when leaving during NFC phase', async () => {
+      renderScreen('nfc');
+      const handler = lastBeforeRemoveHandler();
+      handler?.({ preventDefault: jest.fn() });
+      expect(mockCancel).toHaveBeenCalled();
+    });
+
+    it('returns from duress question to PIN confirmation before leaving', async () => {
+      renderScreen();
+      await enterPin(0);
+      await enterPin(0);
+      const event = { preventDefault: jest.fn() };
+
+      await act(async () => {
+        lastBeforeRemoveHandler()?.(event);
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(navigation.setOptions).toHaveBeenCalledWith({
+        title: 'Confirm your PIN',
+      });
+    });
+
+    it('returns from duress setup to the duress question before leaving', async () => {
+      renderScreen();
+      await enterPin(0);
+      await enterPin(0);
+      await act(async () => {
+        fireEvent.press(screen.getByText('Yes, add duress PIN'));
+      });
+      const event = { preventDefault: jest.fn() };
+
+      await act(async () => {
+        lastBeforeRemoveHandler()?.(event);
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(screen.getByText('Add a duress PIN?')).toBeTruthy();
     });
   });
 

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import TransactionDetailScreen from '../src/screens/TransactionDetailScreen';
 import type { EthSignRequest } from '../src/types';
@@ -100,7 +100,8 @@ jest.mock('react-native-paper', () => {
 // ---------------------------------------------------------------------------
 
 function renderScreen(result: any) {
-  return render(
+  const navigation = { navigate: jest.fn() } as any;
+  const view = render(
     <TransactionDetailScreen
       route={
         {
@@ -109,9 +110,10 @@ function renderScreen(result: any) {
           name: 'TransactionDetail',
         } as any
       }
-      navigation={{ navigate: jest.fn() } as any}
+      navigation={navigation}
     />,
   );
+  return { ...view, navigation };
 }
 
 const fullRequest: EthSignRequest = {
@@ -231,6 +233,23 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
     expect(screen.getByText('Sign transaction')).toBeTruthy();
   });
 
+  it('navigates to Keycard with Ethereum signing params', async () => {
+    const { navigation } = renderScreen({
+      kind: 'eth-sign-request',
+      request: fullRequest,
+    });
+    fireEvent.press(screen.getByText('Sign transaction'));
+    expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+      operation: 'sign',
+      signMode: 'eth',
+      signData: fullRequest.signData,
+      derivationPath: fullRequest.derivationPath,
+      chainId: fullRequest.chainId,
+      requestId: fullRequest.requestId,
+      dataType: fullRequest.dataType,
+    });
+  });
+
   it('renders correctly with only required fields (no optional fields)', async () => {
     const minimalRequest: EthSignRequest = {
       signData: 'cafebabe',
@@ -301,6 +320,19 @@ describe('TransactionDetailScreen – crypto-psbt result', () => {
     expect(screen.getByText('Sign transaction')).toBeTruthy();
   });
 
+  it('navigates to Keycard with PSBT signing params', async () => {
+    const { navigation } = renderScreen({
+      kind: 'crypto-psbt',
+      request: { psbtHex: VALID_PSBT_HEX },
+    });
+    fireEvent.press(screen.getByText('Sign transaction'));
+    expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+      operation: 'sign',
+      signMode: 'btc',
+      psbtHex: VALID_PSBT_HEX,
+    });
+  });
+
   it('shows Bitcoin PSBT label', async () => {
     renderScreen({
       kind: 'crypto-psbt',
@@ -353,5 +385,30 @@ describe('TransactionDetailScreen – btc-sign-request result', () => {
     expect(screen.getByText('btc-sign-request')).toBeTruthy();
     expect(screen.getByText('hello btc')).toBeTruthy();
     expect(screen.getByText('Sign message')).toBeTruthy();
+  });
+
+  it('navigates to Keycard with Bitcoin message signing params', async () => {
+    const request = {
+      requestId: '00112233445566778899aabbccddeeff',
+      signDataHex: Buffer.from('hello btc', 'utf8').toString('hex'),
+      dataType: 1,
+      derivationPath: "m/84'/0'/0'/0/3",
+      address: 'bc1qexampleaddress',
+      origin: 'Sparrow',
+    };
+    const { navigation } = renderScreen({
+      kind: 'btc-sign-request',
+      request,
+    });
+    fireEvent.press(screen.getByText('Sign message'));
+    expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
+      operation: 'sign',
+      signMode: 'btc-message',
+      requestId: request.requestId,
+      signDataHex: request.signDataHex,
+      derivationPath: request.derivationPath,
+      address: request.address,
+      origin: request.origin,
+    });
   });
 });

--- a/__tests__/btcMessage.test.ts
+++ b/__tests__/btcMessage.test.ts
@@ -1,12 +1,21 @@
 /* eslint-disable no-bitwise */
 import * as secp from '@noble/secp256k1';
+import {
+  CryptoKeypath,
+  DataItem,
+  PathComponent,
+  RegistryTypes,
+  encodeDataItem,
+} from '@keystonehq/bc-ur-registry';
 import { URDecoder } from '@ngraveio/bc-ur';
 import CBOR from 'cbor-sync';
 
 import {
   buildBtcSignatureUR,
   hashBitcoinMessage,
+  inspectBtcSignRequest,
   parseKeycardBtcMessageSignature,
+  parseBtcSignRequest,
 } from '../src/utils/btcMessage';
 
 function tlvEncode(tag: number, value: Uint8Array): Uint8Array {
@@ -67,10 +76,156 @@ function decodeUR(urString: string): Record<number, any> {
   return CBOR.decode(decoder.resultUR().cbor);
 }
 
+function buildBtcSignRequestCbor(
+  message: Uint8Array,
+  hdPath: string,
+  opts: {
+    uuid?: string;
+    dataType?: number;
+    address?: string;
+    origin?: string;
+    malformedKeypath?: boolean;
+  } = {},
+): Buffer {
+  const keypathItem = opts.malformedKeypath
+    ? new DataItem(Buffer.from('not-a-keypath'), RegistryTypes.UUID.getTag())
+    : (() => {
+        const components = hdPath
+          .replace(/^m\//, '')
+          .split('/')
+          .map(component => {
+            const hardened = component.endsWith("'");
+            const index = Number.parseInt(component.replace(/'/g, ''), 10);
+            return new PathComponent({ index, hardened });
+          });
+        return new CryptoKeypath(
+          components,
+          Buffer.from('deadbeef', 'hex'),
+        ).toDataItem();
+      })();
+  if (!opts.malformedKeypath) {
+    keypathItem.setTag(RegistryTypes.CRYPTO_KEYPATH.getTag());
+  }
+
+  const map: Record<number, any> = {
+    1: new DataItem(
+      Buffer.from(
+        (opts.uuid ?? '00112233-4455-6677-8899-aabbccddeeff').replace(/-/g, ''),
+        'hex',
+      ),
+      RegistryTypes.UUID.getTag(),
+    ),
+    2: Buffer.from(message),
+    3: opts.dataType ?? 1,
+    4: [keypathItem],
+  };
+
+  if (opts.address) {
+    map[5] = [opts.address];
+  }
+  if (opts.origin) {
+    map[6] = opts.origin;
+  }
+
+  return encodeDataItem(new DataItem(map));
+}
+
 const PRIV_KEY = new Uint8Array(32);
 PRIV_KEY[31] = 1;
 
 describe('btcMessage', () => {
+  describe('parseBtcSignRequest', () => {
+    it('parses request id, message, key path, address, and origin', () => {
+      const cbor = buildBtcSignRequestCbor(
+        Buffer.from('hello btc', 'utf8'),
+        "m/84'/0'/0'/0/3",
+        {
+          address: 'bc1qexampleaddress',
+          origin: 'Sparrow',
+        },
+      );
+
+      expect(parseBtcSignRequest(cbor)).toEqual({
+        requestId: '00112233445566778899aabbccddeeff',
+        signDataHex: Buffer.from('hello btc', 'utf8').toString('hex'),
+        dataType: 1,
+        derivationPath: "m/84'/0'/0'/0/3",
+        address: 'bc1qexampleaddress',
+        origin: 'Sparrow',
+      });
+    });
+
+    it('defaults missing dataType to Bitcoin message signing', () => {
+      const cbor = encodeDataItem(
+        new DataItem({
+          1: Buffer.from('00112233445566778899aabbccddeeff', 'hex'),
+          2: Buffer.from('hello btc', 'utf8'),
+          4: [
+            (() => {
+              const item = new CryptoKeypath([
+                new PathComponent({ index: 84, hardened: true }),
+              ]).toDataItem();
+              item.setTag(RegistryTypes.CRYPTO_KEYPATH.getTag());
+              return item;
+            })(),
+          ],
+        }),
+      );
+
+      const request = parseBtcSignRequest(cbor);
+      expect(request.dataType).toBe(1);
+      expect(request.requestId).toBe('00112233445566778899aabbccddeeff');
+    });
+
+    it('rejects malformed key path tags', () => {
+      const cbor = buildBtcSignRequestCbor(
+        Buffer.from('hello btc', 'utf8'),
+        "m/84'/0'/0'/0/3",
+        { malformedKeypath: true },
+      );
+
+      expect(() => parseBtcSignRequest(cbor)).toThrow(
+        'Malformed btc-sign-request derivation path.',
+      );
+    });
+
+    it('rejects unsupported data types', () => {
+      const cbor = buildBtcSignRequestCbor(
+        Buffer.from('hello btc', 'utf8'),
+        "m/84'/0'/0'/0/3",
+        { dataType: 2 },
+      );
+
+      expect(() => parseBtcSignRequest(cbor)).toThrow(
+        'Unsupported btc-sign-request data type.',
+      );
+    });
+  });
+
+  describe('inspectBtcSignRequest', () => {
+    it('returns utf8 message text when the payload is valid UTF-8', () => {
+      expect(
+        inspectBtcSignRequest({
+          requestId: '00',
+          signDataHex: Buffer.from('hello btc', 'utf8').toString('hex'),
+          dataType: 1,
+          derivationPath: "m/84'/0'/0'/0/0",
+        }),
+      ).toEqual({ message: 'hello btc', isUtf8: true });
+    });
+
+    it('falls back to hex when the payload is not valid UTF-8', () => {
+      expect(
+        inspectBtcSignRequest({
+          requestId: '00',
+          signDataHex: 'fffe',
+          dataType: 1,
+          derivationPath: "m/84'/0'/0'/0/0",
+        }),
+      ).toEqual({ message: 'fffe', isUtf8: false });
+    });
+  });
+
   it('hashes legacy Bitcoin messages with the shell-compatible prefix', () => {
     const hash = hashBitcoinMessage(
       Buffer.from('hello btc', 'utf8').toString('hex'),
@@ -79,6 +234,18 @@ describe('btcMessage', () => {
     expect(Buffer.from(hash).toString('hex')).toBe(
       'f43270780f43a66bd855d3640d581d2621589f760eadc69a282d0e37d4f77783',
     );
+  });
+
+  it('hashes messages with compact-size uint16 lengths', () => {
+    const hash = hashBitcoinMessage(Buffer.alloc(253, 0x61).toString('hex'));
+    expect(hash).toHaveLength(32);
+  });
+
+  it('hashes messages with compact-size uint32 lengths', () => {
+    const hash = hashBitcoinMessage(
+      Buffer.alloc(0x10000, 0x61).toString('hex'),
+    );
+    expect(hash).toHaveLength(32);
   });
 
   it('converts a Keycard recoverable signature into compact Bitcoin message format', async () => {

--- a/__tests__/btcPsbt.test.ts
+++ b/__tests__/btcPsbt.test.ts
@@ -1,6 +1,27 @@
 import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
 
-import { inspectBtcPsbt, parseCryptoPsbtRequest } from '../src/utils/btcPsbt';
+import {
+  BtcSigningSession,
+  inspectBtcPsbt,
+  parseCryptoPsbtRequest,
+} from '../src/utils/btcPsbt';
+
+jest.mock('keycard-sdk', () => ({
+  __esModule: true,
+  default: {
+    BERTLV: jest.fn().mockImplementation(() => ({
+      enterConstructed: jest.fn(),
+      readPrimitive: jest.fn(() => new Uint8Array([2, ...Array(32).fill(1)])),
+    })),
+    CryptoUtils: {
+      compressPublicKey: jest.fn(key => key),
+    },
+  },
+}));
+
+jest.mock('../src/utils/cryptoAccount', () => ({
+  pubKeyFingerprint: jest.fn(() => 0xdeadbeef),
+}));
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -227,5 +248,87 @@ describe('inspectBtcPsbt', () => {
   it('returns unknown network when no derivation path present', () => {
     const summary = inspectBtcPsbt(MINIMAL_PSBT_HEX);
     expect(summary.network).toBe('unknown');
+  });
+
+  it('falls back to script hex when an output script is not an address', () => {
+    const { Psbt, networks } = require('bitcoinjs-lib');
+    const fakePubkey = Buffer.alloc(33, 0x02);
+    const psbt = new Psbt({ network: networks.testnet });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xcc),
+      index: 0,
+      bip32Derivation: [
+        {
+          masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+          path: "m/84'/1'/0'/0/0",
+          pubkey: fakePubkey,
+        },
+      ],
+    });
+    psbt.addOutput({ script: Buffer.from([0x51]), value: 12_345 });
+
+    const summary = inspectBtcPsbt(psbt.toBuffer().toString('hex'));
+    expect(summary.outputs[0].address).toBe('51');
+  });
+});
+
+describe('BtcSigningSession', () => {
+  const { pubKeyFingerprint } = require('../src/utils/cryptoAccount');
+  const cmdSet = {
+    exportKey: jest.fn(() => ({
+      checkOK: jest.fn(),
+      data: new Uint8Array([1, 2, 3]),
+    })),
+    signWithPath: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    cmdSet.exportKey.mockClear();
+    cmdSet.signWithPath.mockClear();
+    pubKeyFingerprint.mockReturnValue(0xdeadbeef);
+  });
+
+  it('throws when the Keycard fingerprint matches no inputs', async () => {
+    pubKeyFingerprint.mockReturnValue(0x12345678);
+    const session = new BtcSigningSession(TESTNET_WPKH_PSBT_HEX);
+
+    await expect(session.signWithKeycard(cmdSet)).rejects.toThrow(
+      'This Keycard cannot sign any inputs in this transaction.',
+    );
+  });
+
+  it('rejects taproot inputs before signing', async () => {
+    const { Psbt, payments, networks } = require('bitcoinjs-lib');
+    const fakePubkey = Buffer.alloc(33, 0x02);
+    const tapInternalKey = Buffer.alloc(32, 0x03);
+    const { output } = payments.p2wpkh({
+      pubkey: fakePubkey,
+      network: networks.testnet,
+    });
+    const psbt = new Psbt({ network: networks.testnet });
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0xdd),
+      index: 0,
+      witnessUtxo: {
+        script: output!,
+        value: 50_000,
+      },
+      tapInternalKey,
+      tapBip32Derivation: [
+        {
+          masterFingerprint: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+          path: "m/86'/1'/0'/0/0",
+          pubkey: tapInternalKey,
+          leafHashes: [],
+        },
+      ],
+    });
+    psbt.addOutput({ script: output!, value: 40_000 });
+    const session = new BtcSigningSession(psbt.toBuffer().toString('hex'));
+
+    await expect(session.signWithKeycard(cmdSet)).rejects.toThrow(
+      'Taproot inputs are not supported yet.',
+    );
+    expect(cmdSet.signWithPath).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/cryptoAccount.test.ts
+++ b/__tests__/cryptoAccount.test.ts
@@ -1,5 +1,8 @@
 import { URRegistryDecoder } from '@keystonehq/bc-ur-registry';
-import { buildCryptoAccountUR } from '../src/utils/cryptoAccount';
+import {
+  buildCryptoAccountUR,
+  pubKeyFingerprint,
+} from '../src/utils/cryptoAccount';
 
 /* eslint-disable no-bitwise */
 // Mock keycard-sdk so tests work with synthetic (non-curve-valid) public keys
@@ -124,5 +127,47 @@ describe('buildCryptoAccountUR', () => {
       expect.stringContaining('sh(wpkh('),
       expect.stringContaining('pkh('),
     ]);
+  });
+
+  it('encodes multisig descriptor script expressions', () => {
+    const ur = buildCryptoAccountUR({
+      masterFingerprint: 0xaabbccdd,
+      descriptors: [
+        {
+          derivationPath: "m/48'/0'/0'/2'",
+          exportRespData: EXPORT_DATA,
+          parentFingerprint: 0x11223344,
+          scriptType: 'wsh',
+        },
+        {
+          derivationPath: "m/48'/0'/0'/1'",
+          exportRespData: EXPORT_DATA,
+          parentFingerprint: 0x55667788,
+          scriptType: 'sh-wsh',
+        },
+        {
+          derivationPath: "m/45'",
+          exportRespData: EXPORT_DATA,
+          parentFingerprint: 0x99aabbcc,
+          scriptType: 'sh',
+        },
+      ],
+    });
+
+    const decoder = new URRegistryDecoder();
+    decoder.receivePart(ur);
+    const cryptoAccount = decoder.resultRegistryType() as any;
+
+    expect(
+      cryptoAccount.getOutputDescriptors().map((item: any) => item.toString()),
+    ).toEqual([
+      expect.stringContaining('wsh('),
+      expect.stringContaining('sh(wsh('),
+      expect.stringContaining('sh('),
+    ]);
+  });
+
+  it('computes a public-key fingerprint', () => {
+    expect(pubKeyFingerprint(PUB_KEY_UNCOMPRESSED)).toBe(0xe01b06b9);
   });
 });

--- a/__tests__/eip712.test.ts
+++ b/__tests__/eip712.test.ts
@@ -67,6 +67,55 @@ describe('parseEip712Summary', () => {
   it('returns null for non-json data', () => {
     expect(parseEip712Summary('deadbeef')).toBeNull();
   });
+
+  it('returns null for JSON that is not an object', () => {
+    const signDataHex = Buffer.from('[]', 'utf8').toString('hex');
+    expect(parseEip712Summary(signDataHex)).toBeNull();
+  });
+
+  it('uses empty domain and message maps when those fields are not objects', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [],
+      },
+      domain: 'not-an-object',
+      message: ['not', 'an', 'object'],
+    };
+    const signDataHex = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+
+    expect(parseEip712Summary(signDataHex)).toEqual({
+      rawJson: JSON.stringify(payload, null, 2),
+      primaryType: undefined,
+      domain: {},
+      message: {},
+    });
+  });
+
+  it('stringifies primitive domain and message values for display', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [],
+      },
+      primaryType: 'EIP712Domain',
+      domain: {
+        chainId: 1,
+        verified: true,
+        salt: null,
+      },
+      message: {},
+    };
+    const signDataHex = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+
+    expect(parseEip712Summary(signDataHex)?.domain).toEqual({
+      chainId: '1',
+      salt: 'null',
+      verified: 'true',
+    });
+  });
 });
 
 describe('parseEip712Prehashed', () => {

--- a/__tests__/ethSignature.test.ts
+++ b/__tests__/ethSignature.test.ts
@@ -117,6 +117,26 @@ describe('buildEthSignatureUR', () => {
       expect(sig[sig.length - 1]).toBe(37 + recId);
     });
 
+    it('encodes multi-byte legacy v values', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 111, undefined);
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig.subarray(64)).toEqual(Buffer.from([0x01, 0x01 + recId]));
+    });
+
+    it('encodes three-byte legacy v values', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 40_000, undefined);
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig.subarray(64)).toHaveLength(3);
+      expect(sig.readUIntBE(64, 3)).toBe(80_035 + recId);
+    });
+
+    it('encodes four-byte legacy v values', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 9_000_000, undefined);
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig.subarray(64)).toHaveLength(4);
+      expect(sig.readUInt32BE(64)).toBe(18_000_035 + recId);
+    });
+
     it('EIP-712 (dataType=2): v = 27 + recId', () => {
       const ur = buildEthSignatureUR(tlvHex, HASH, 2, undefined, undefined);
       const sig: Buffer = decodeUR(ur)[2];

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -1,8 +1,19 @@
 import { keccak_256 } from '@noble/hashes/sha3.js';
 
-import { buildExportUr, prepareSignHash } from '../src/utils/keycardExport';
+import {
+  buildExportUr,
+  exportKeyForWallet,
+  prepareSignHash,
+} from '../src/utils/keycardExport';
 
-jest.mock('keycard-sdk', () => ({ __esModule: true, default: {} }));
+jest.mock('keycard-sdk', () => ({
+  __esModule: true,
+  default: {
+    BIP32KeyPair: {
+      fromTLV: jest.fn(() => ({ publicKey: new Uint8Array([9, 9, 9]) })),
+    },
+  },
+}));
 
 jest.mock('../src/utils/cryptoHdKey', () => ({
   buildCryptoHdKeyUR: jest.fn(() => 'ur:crypto-hdkey/mock'),
@@ -111,5 +122,115 @@ describe('buildExportUr', () => {
     const result = buildExportUr(btcResult, "m/84'/0'/0'");
     expect(buildCryptoAccountUR).toHaveBeenCalledWith(btcResult);
     expect(result).toBe('ur:crypto-account/mock');
+  });
+});
+
+describe('exportKeyForWallet', () => {
+  const { pubKeyFingerprint } = require('../src/utils/cryptoAccount');
+  const { exportKeysForBitget } = require('../src/utils/cryptoMultiAccounts');
+
+  const response = (data: number[]) => ({
+    checkOK: jest.fn(),
+    data: new Uint8Array(data),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pubKeyFingerprint.mockReturnValue(0xdeadbeef);
+  });
+
+  it('delegates Bitget exports to exportKeysForBitget', async () => {
+    const bitgetResult = { keys: [{ path: "m/44'/60'/0'/0/0" }] };
+    exportKeysForBitget.mockResolvedValue(bitgetResult);
+    const cmdSet = {} as any;
+    const setStatus = jest.fn();
+
+    await expect(exportKeyForWallet(cmdSet, 'bitget', setStatus)).resolves.toBe(
+      bitgetResult,
+    );
+    expect(exportKeysForBitget).toHaveBeenCalledWith(cmdSet, setStatus);
+  });
+
+  it('exports an Ethereum hdkey with the parent fingerprint', async () => {
+    const parentResp = response([1, 2, 3]);
+    const extendedResp = response([4, 5, 6]);
+    const cmdSet = {
+      exportKey: jest.fn().mockResolvedValue(parentResp),
+      exportExtendedKey: jest.fn().mockResolvedValue(extendedResp),
+    } as any;
+
+    const result = await exportKeyForWallet(cmdSet, "m/44'/60'/0'/0/0");
+
+    expect(cmdSet.exportKey).toHaveBeenCalledWith(
+      0,
+      true,
+      "m/44'/60'/0'/0",
+      false,
+    );
+    expect(cmdSet.exportExtendedKey).toHaveBeenCalledWith(
+      0,
+      "m/44'/60'/0'/0/0",
+      false,
+    );
+    expect(parentResp.checkOK).toHaveBeenCalled();
+    expect(extendedResp.checkOK).toHaveBeenCalled();
+    expect(result).toEqual({
+      exportRespData: new Uint8Array([4, 5, 6]),
+      sourceFingerprint: 0xdeadbeef,
+    });
+  });
+
+  it('builds Bitcoin descriptor exports for single-sig paths', async () => {
+    const cmdSet = {
+      exportKey: jest
+        .fn()
+        .mockResolvedValueOnce(response([0]))
+        .mockResolvedValueOnce(response([1]))
+        .mockResolvedValueOnce(response([2]))
+        .mockResolvedValueOnce(response([3])),
+      exportExtendedKey: jest
+        .fn()
+        .mockResolvedValueOnce(response([10]))
+        .mockResolvedValueOnce(response([20]))
+        .mockResolvedValueOnce(response([30])),
+    } as any;
+
+    const result = await exportKeyForWallet(cmdSet, "m/84'/0'/0'");
+
+    expect(result).toMatchObject({
+      masterFingerprint: 0xdeadbeef,
+      descriptors: [
+        { derivationPath: "m/84'/0'/0'", scriptType: 'wpkh' },
+        { derivationPath: "m/49'/0'/0'", scriptType: 'sh-wpkh' },
+        { derivationPath: "m/44'/0'/0'", scriptType: 'pkh' },
+      ],
+    });
+    expect(cmdSet.exportExtendedKey).toHaveBeenCalledTimes(3);
+  });
+
+  it('builds Bitcoin descriptor exports for multisig paths', async () => {
+    const cmdSet = {
+      exportKey: jest
+        .fn()
+        .mockResolvedValueOnce(response([0]))
+        .mockResolvedValueOnce(response([1]))
+        .mockResolvedValueOnce(response([2]))
+        .mockResolvedValueOnce(response([3])),
+      exportExtendedKey: jest
+        .fn()
+        .mockResolvedValueOnce(response([10]))
+        .mockResolvedValueOnce(response([20]))
+        .mockResolvedValueOnce(response([30])),
+    } as any;
+
+    const result = await exportKeyForWallet(cmdSet, "m/48'/0'/0'/2'");
+
+    expect(result).toMatchObject({
+      descriptors: [
+        { derivationPath: "m/48'/0'/0'/2'", scriptType: 'wsh' },
+        { derivationPath: "m/48'/0'/0'/1'", scriptType: 'sh-wsh' },
+        { derivationPath: "m/45'", scriptType: 'sh' },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add coverage for Bitcoin message parsing, PSBT inspection, Ethereum signature encoding, wallet export, EIP-712 parsing, and crypto-account helpers
- cover more workflow behavior in About, Change Secret, Init Card, Export Key, and Transaction Detail screens