### PR TITLE
feat: ERC-20 token metadata with offline-aware logo display (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Expanded Jest coverage for signing utilities and wallet workflow screens
+- Bundled ERC-20 token metadata (1441 tokens, Uniswap default list v20.0.0); ERC-20 review shows symbol, formatted amounts, and token logo (offline flavor skips logo fetch)
 
 ## [1.1.0] - 2026-04-28
 

--- a/__tests__/DecodedCallSection.test.tsx
+++ b/__tests__/DecodedCallSection.test.tsx
@@ -28,6 +28,10 @@ const ADDR_A = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const ADDR_B = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
 const UINT256_MAX = 2n ** 256n - 1n;
 
+// Real addresses from the bundled token list
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const MAINNET = 1;
+
 describe('DecodedCallSection', () => {
   describe('erc20-transfer', () => {
     const call: DecodedCall = {
@@ -120,6 +124,85 @@ describe('DecodedCallSection', () => {
       };
       render(<DecodedCallSection call={call} />);
       expect(screen.getByText('Contract call: 0xdeadbeef')).toBeTruthy();
+    });
+  });
+
+  describe('with token metadata (chainId + known contract)', () => {
+    it('shows symbol and formatted amount for a known ERC-20 transfer', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-transfer',
+        to: ADDR_A,
+        amount: 1_000_000n, // 1.00 USDC
+      };
+      render(
+        <DecodedCallSection
+          call={call}
+          tokenContract={USDC_ADDRESS}
+          chainId={MAINNET}
+        />,
+      );
+      expect(screen.getByText('USDC')).toBeTruthy();
+      expect(screen.getByText('Amount: 1 USDC')).toBeTruthy();
+    });
+
+    it('shows "Unlimited USDC" for max uint256 approve', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-approve',
+        spender: ADDR_A,
+        amount: UINT256_MAX,
+      };
+      render(
+        <DecodedCallSection
+          call={call}
+          tokenContract={USDC_ADDRESS}
+          chainId={MAINNET}
+        />,
+      );
+      expect(screen.getByText('Allowance: Unlimited USDC')).toBeTruthy();
+    });
+
+    it('shows symbol and formatted amount for a known ERC-20 transferFrom', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-transferFrom',
+        from: ADDR_A,
+        to: ADDR_B,
+        amount: 2_000_000n, // 2.00 USDC
+      };
+      render(
+        <DecodedCallSection
+          call={call}
+          tokenContract={USDC_ADDRESS}
+          chainId={MAINNET}
+        />,
+      );
+      expect(screen.getByText('USDC')).toBeTruthy();
+      expect(screen.getByText('Amount: 2 USDC')).toBeTruthy();
+    });
+
+    it('falls back to raw units when chainId is missing', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-transfer',
+        to: ADDR_A,
+        amount: 1_000_000n,
+      };
+      render(<DecodedCallSection call={call} tokenContract={USDC_ADDRESS} />);
+      expect(screen.getByText('Amount (raw units): 1000000')).toBeTruthy();
+    });
+
+    it('falls back to raw units for an unknown contract', () => {
+      const call: DecodedCall = {
+        kind: 'erc20-transfer',
+        to: ADDR_A,
+        amount: 999n,
+      };
+      render(
+        <DecodedCallSection
+          call={call}
+          tokenContract={ADDR_B}
+          chainId={MAINNET}
+        />,
+      );
+      expect(screen.getByText('Amount (raw units): 999')).toBeTruthy();
     });
   });
 });

--- a/__tests__/GenerateKeyScreen.test.tsx
+++ b/__tests__/GenerateKeyScreen.test.tsx
@@ -109,7 +109,7 @@ describe('GenerateKeyScreen', () => {
 
     it('renders a BlurView over the words before revealing', () => {
       renderScreen('done', WORDS);
-      expect(screen.UNSAFE_queryAllByType('BlurView')).toHaveLength(1);
+      expect(screen.UNSAFE_queryAllByType('BlurView' as any)).toHaveLength(1);
     });
 
     it('removes the BlurView after the reveal button is pressed', async () => {
@@ -117,7 +117,7 @@ describe('GenerateKeyScreen', () => {
       await act(async () => {
         fireEvent.press(screen.getByText('Reveal recovery phrase'));
       });
-      expect(screen.UNSAFE_queryAllByType('BlurView')).toHaveLength(0);
+      expect(screen.UNSAFE_queryAllByType('BlurView' as any)).toHaveLength(0);
     });
   });
 

--- a/__tests__/tokenMetadata.test.ts
+++ b/__tests__/tokenMetadata.test.ts
@@ -1,0 +1,78 @@
+import { formatTokenAmount, lookupToken } from '../src/utils/tokenMetadata';
+
+// Real addresses from the bundled token list (lowercased)
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f';
+const MAINNET = 1;
+const POLYGON = 137;
+
+describe('lookupToken', () => {
+  it('resolves a known mainnet token', () => {
+    const token = lookupToken(MAINNET, USDC_ADDRESS);
+    expect(token).not.toBeNull();
+    expect(token!.symbol).toBe('USDC');
+    expect(token!.decimals).toBe(6);
+  });
+
+  it('is case-insensitive for the address', () => {
+    const lower = lookupToken(MAINNET, USDC_ADDRESS.toLowerCase());
+    const upper = lookupToken(MAINNET, USDC_ADDRESS.toUpperCase());
+    expect(lower).not.toBeNull();
+    expect(upper).not.toBeNull();
+    expect(lower!.symbol).toBe(upper!.symbol);
+  });
+
+  it('returns null for an unknown address', () => {
+    expect(lookupToken(MAINNET, '0x' + 'ab'.repeat(20))).toBeNull();
+  });
+
+  it('returns null when the chain does not match', () => {
+    // USDC on mainnet address, wrong chain
+    expect(lookupToken(POLYGON, USDC_ADDRESS)).toBeNull();
+  });
+
+  it('returns null when chainId is undefined', () => {
+    expect(lookupToken(undefined, USDC_ADDRESS)).toBeNull();
+  });
+
+  it('returns null when address is undefined', () => {
+    expect(lookupToken(MAINNET, undefined)).toBeNull();
+  });
+
+  it('includes logoURI when present', () => {
+    const token = lookupToken(MAINNET, USDC_ADDRESS);
+    expect(token!.logoURI).toMatch(/^https:\/\//);
+  });
+});
+
+describe('formatTokenAmount', () => {
+  const usdc = { symbol: 'USDC', decimals: 6 };
+  const dai = { symbol: 'DAI', decimals: 18 };
+
+  it('formats USDC with 6 decimals', () => {
+    expect(formatTokenAmount(1_000_000n, usdc)).toBe('1 USDC');
+  });
+
+  it('formats fractional USDC amount', () => {
+    expect(formatTokenAmount(1_500_000n, usdc)).toBe('1.5 USDC');
+  });
+
+  it('formats zero as "0 SYMBOL"', () => {
+    expect(formatTokenAmount(0n, usdc)).toBe('0 USDC');
+  });
+
+  it('formats DAI with 18 decimals', () => {
+    expect(formatTokenAmount(1_000_000_000_000_000_000n, dai)).toBe('1 DAI');
+  });
+
+  it('formats a small sub-unit amount', () => {
+    const result = formatTokenAmount(1_000n, usdc); // 0.001 USDC
+    expect(result).toBe('0.001 USDC');
+  });
+
+  it('includes the symbol from the token metadata', () => {
+    const token = lookupToken(MAINNET, DAI_ADDRESS)!;
+    const result = formatTokenAmount(5_000_000_000_000_000_000n, token);
+    expect(result).toContain('DAI');
+  });
+});

--- a/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
+++ b/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
@@ -1,0 +1,15 @@
+package tech.gapsign
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise
+
+class BuildConfigModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+  override fun getName() = "BuildConfig"
+
+  override fun getConstants(): Map<String, Any> =
+    mapOf("INTERNET_ENABLED" to BuildConfig.INTERNET_ENABLED)
+}

--- a/android/app/src/main/java/tech/gapsign/BuildConfigPackage.kt
+++ b/android/app/src/main/java/tech/gapsign/BuildConfigPackage.kt
@@ -1,0 +1,14 @@
+package tech.gapsign
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class BuildConfigPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(BuildConfigModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+    emptyList()
+}

--- a/android/app/src/main/java/tech/gapsign/MainApplication.kt
+++ b/android/app/src/main/java/tech/gapsign/MainApplication.kt
@@ -14,8 +14,7 @@ class MainApplication : Application(), ReactApplication {
       context = applicationContext,
       packageList =
         PackageList(this).packages.apply {
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
+          add(BuildConfigPackage())
         },
     )
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ const compat = new FlatCompat({
 module.exports = [
   ...compat.extends('@react-native'),
   {
-    ignores: ['node_modules/**', 'android/**', 'ios/**'],
+    ignores: ['node_modules/**', 'android/**', 'ios/**', 'scripts/**'],
   },
   {
     files: ['**/__tests__/**', '**/*.test.{ts,tsx}', 'jest.setup.js'],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "react-native start",
     "test": "jest",
     "postinstall": "npx react-native-asset",
-    "bump": "node scripts/bump-version.js"
+    "bump": "node scripts/bump-version.js",
+    "generate:tokens": "node scripts/generate-tokens.js"
   },
   "dependencies": {
     "@ethereumjs/rlp": "^10.1.1",

--- a/scripts/generate-tokens.js
+++ b/scripts/generate-tokens.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Fetches the Uniswap Labs Default token list from a pinned npm package version
+ * and writes a trimmed snapshot to src/data/tokens.json.
+ *
+ * Pin: @uniswap/default-token-list@20.0.0
+ * Source: https://unpkg.com/@uniswap/default-token-list@20.0.0/build/uniswap-default.tokenlist.json
+ *
+ * To update: bump PINNED_VERSION, run this script, commit the diff.
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const PINNED_VERSION = '20.0.0';
+const URL = `https://unpkg.com/@uniswap/default-token-list@${PINNED_VERSION}/build/uniswap-default.tokenlist.json`;
+const OUT = path.join(__dirname, '..', 'src', 'data', 'tokens.json');
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        return get(res.headers.location).then(resolve).catch(reject);
+      }
+      if (res.statusCode !== 200) {
+        return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+      }
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => resolve(Buffer.concat(chunks).toString()));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+async function main() {
+  console.log(`Fetching Uniswap default token list v${PINNED_VERSION}...`);
+  const list = JSON.parse(await get(URL));
+
+  const trimmed = {
+    name: list.name,
+    version: list.version,
+    timestamp: list.timestamp,
+    tokens: list.tokens.map(t => {
+      const entry = {
+        chainId: t.chainId,
+        address: t.address.toLowerCase(),
+        symbol: t.symbol,
+        decimals: t.decimals,
+      };
+      if (t.logoURI) entry.logoURI = t.logoURI;
+      return entry;
+    }),
+  };
+
+  fs.writeFileSync(OUT, JSON.stringify(trimmed, null, 2) + '\n');
+  console.log(`Wrote ${trimmed.tokens.length} tokens to ${path.relative(process.cwd(), OUT)}`);
+  console.log(`Version: ${trimmed.version.major}.${trimmed.version.minor}.${trimmed.version.patch}`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/src/components/DecodedCallSection.tsx
+++ b/src/components/DecodedCallSection.tsx
@@ -1,19 +1,43 @@
-import { StyleSheet, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import { Icon, Text } from 'react-native-paper';
 
 import theme from '../theme';
 import InfoRow from './InfoRow';
+import { INTERNET_ENABLED } from '../utils/buildConfig';
 import { DecodedCall } from '../utils/txParser';
+import {
+  formatTokenAmount,
+  lookupToken,
+  TokenMetadata,
+} from '../utils/tokenMetadata';
 
 const UINT256_MAX = 2n ** 256n - 1n;
+
+function TokenLogo({ uri }: { uri: string }) {
+  if (!INTERNET_ENABLED) return null; /* istanbul ignore next */
+  return <Image source={{ uri }} style={styles.tokenLogo} />;
+}
+
+function formatAmount(amount: bigint, token: TokenMetadata | null): string {
+  if (!token) return amount.toString();
+  return formatTokenAmount(amount, token);
+}
+
+function formatUnlimited(token: TokenMetadata | null): string {
+  return token ? `Unlimited ${token.symbol}` : 'Unlimited';
+}
 
 export default function DecodedCallSection({
   call,
   tokenContract,
+  chainId,
 }: {
   call: DecodedCall;
   tokenContract?: string;
+  chainId?: number;
 }) {
+  const token = lookupToken(chainId, tokenContract);
+
   if (call.kind === 'erc20-transfer') {
     return (
       <>
@@ -22,6 +46,14 @@ export default function DecodedCallSection({
             ERC-20 Transfer
           </Text>
         </View>
+        {token && (
+          <View style={[styles.row, styles.tokenRow]}>
+            {token.logoURI && <TokenLogo uri={token.logoURI} />}
+            <Text variant="labelMedium" style={styles.tokenSymbol}>
+              {token.symbol}
+            </Text>
+          </View>
+        )}
         {tokenContract && (
           <View style={styles.row}>
             <InfoRow label="Token contract" value={tokenContract} />
@@ -31,11 +63,15 @@ export default function DecodedCallSection({
           <InfoRow label="Recipient" value={call.to} />
         </View>
         <View style={styles.row}>
-          <InfoRow label="Amount (raw units)" value={call.amount.toString()} />
+          <InfoRow
+            label={token ? 'Amount' : 'Amount (raw units)'}
+            value={formatAmount(call.amount, token)}
+          />
         </View>
       </>
     );
   }
+
   if (call.kind === 'erc20-transferFrom') {
     return (
       <>
@@ -44,6 +80,14 @@ export default function DecodedCallSection({
             ERC-20 Transfer From
           </Text>
         </View>
+        {token && (
+          <View style={[styles.row, styles.tokenRow]}>
+            {token.logoURI && <TokenLogo uri={token.logoURI} />}
+            <Text variant="labelMedium" style={styles.tokenSymbol}>
+              {token.symbol}
+            </Text>
+          </View>
+        )}
         {tokenContract && (
           <View style={styles.row}>
             <InfoRow label="Token contract" value={tokenContract} />
@@ -56,11 +100,15 @@ export default function DecodedCallSection({
           <InfoRow label="Recipient" value={call.to} />
         </View>
         <View style={styles.row}>
-          <InfoRow label="Amount (raw units)" value={call.amount.toString()} />
+          <InfoRow
+            label={token ? 'Amount' : 'Amount (raw units)'}
+            value={formatAmount(call.amount, token)}
+          />
         </View>
       </>
     );
   }
+
   if (call.kind === 'erc20-approve') {
     const isUnlimited = call.amount === UINT256_MAX;
     return (
@@ -70,6 +118,14 @@ export default function DecodedCallSection({
             ERC-20 Approve
           </Text>
         </View>
+        {token && (
+          <View style={[styles.row, styles.tokenRow]}>
+            {token.logoURI && <TokenLogo uri={token.logoURI} />}
+            <Text variant="labelMedium" style={styles.tokenSymbol}>
+              {token.symbol}
+            </Text>
+          </View>
+        )}
         {tokenContract && (
           <View style={styles.row}>
             <InfoRow label="Token contract" value={tokenContract} />
@@ -81,7 +137,11 @@ export default function DecodedCallSection({
         <View style={styles.row}>
           <InfoRow
             label="Allowance"
-            value={isUnlimited ? 'Unlimited' : call.amount.toString()}
+            value={
+              isUnlimited
+                ? formatUnlimited(token)
+                : formatAmount(call.amount, token)
+            }
           />
         </View>
         {isUnlimited && (
@@ -95,6 +155,7 @@ export default function DecodedCallSection({
       </>
     );
   }
+
   return (
     <View style={styles.row}>
       <InfoRow label="Contract call" value={call.selector} />
@@ -111,6 +172,19 @@ const styles = StyleSheet.create({
   },
   sectionHeaderText: {
     color: theme.colors.onSurfaceVariant,
+  },
+  tokenRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  tokenSymbol: {
+    color: theme.colors.onSurfaceVariant,
+  },
+  tokenLogo: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
   },
   warningRow: {
     flexDirection: 'row',

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -92,7 +92,11 @@ export default function EthSignRequestDetail({
       )}
 
       {tx?.decodedCall && (
-        <DecodedCallSection call={tx.decodedCall} tokenContract={tx.to} />
+        <DecodedCallSection
+          call={tx.decodedCall}
+          tokenContract={tx.to}
+          chainId={request.chainId}
+        />
       )}
 
       {tx?.fees.kind === 'legacy' && (

--- a/src/data/tokens.json
+++ b/src/data/tokens.json
@@ -1,0 +1,10096 @@
+{
+  "name": "Uniswap Labs Default",
+  "version": {
+    "major": 20,
+    "minor": 0,
+    "patch": 0
+  },
+  "timestamp": "2026-04-24T21:01:31.013Z",
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3e5a19c91266ad8ce2477b91585d1856b84062df",
+      "symbol": "A8",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/standard/A8_Token-04_200x200.png?1720798300"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb98d4c97425d9908e66e53a6fdf673acca0be986",
+      "symbol": "ABT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+    },
+    {
+      "chainId": 1,
+      "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1599691266"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8b1484d57abbe239bb280661377363b03c89caea",
+      "symbol": "ADI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68846/large/ADI_Token-min.png?1765296433"
+    },
+    {
+      "chainId": 1,
+      "address": "0xade00c28244d5ce17d72e40330b1c318cd12b7c3",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540"
+    },
+    {
+      "chainId": 1,
+      "address": "0x91af0fbb28aba7e31403cb457106ce79397fd4e6",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb528edbef013aff855ac3c50b381f253af13b997",
+      "symbol": "AEVO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/standard/aevo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1a7e4e63778b4f12a199c062f3efdd288afcbce8",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955"
+    },
+    {
+      "chainId": 1,
+      "address": "0x626e8036deb333b408be468f951bdb42433cbf18",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+    },
+    {
+      "chainId": 1,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8408d45b61f5823298f19a09b53b7339c0280489",
+      "symbol": "ALLO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70609/large/allo-token.png?1763451165"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8457ca5040ad67fdebbcc8edce889a335bc0fbfb",
+      "symbol": "ALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/standard/Logomark_200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+      "symbol": "AMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
+      "symbol": "ANT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+      "symbol": "APE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5a9610919f5e81183823a2be4bd1beb2b4da2a20",
+      "symbol": "APR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70220/large/logo-icon-Gradient.png?1761118006"
+    },
+    {
+      "chainId": 1,
+      "address": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
+      "symbol": "APU",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
+    },
+    {
+      "chainId": 1,
+      "address": "0x98a878b1cd98131b271883b390f68d2c90674665",
+      "symbol": "APXUSD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102172243/large/apxUSD.png?1772448502"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://arbitrum.foundation/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/standard/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64d91f12ece7362f91a6f8e7940cd55f05060b92",
+      "symbol": "ASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2565ae0385659badcada1031db704442e1b69982",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
+    },
+    {
+      "chainId": 1,
+      "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_(1).png?1718232706"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
+      "symbol": "AUCTION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4cce605ed955295432958d8951d0b176c10720d5",
+      "symbol": "AUDD",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727"
+    },
+    {
+      "chainId": 1,
+      "address": "0x845576c64f9754cf09d87e45b720e82f3eef522c",
+      "symbol": "AVT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa27ec0006e59f245217ff08cd52a7e8b169e62d2",
+      "symbol": "AZTEC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/70681/large/aztec.png?1763091883"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf0db65d17e30a966c2ae6a21f6bba71cea6e9754",
+      "symbol": "BARD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68404/large/bard.png?1755657543"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f2b33840227ddd0e28da8d4185d6fa07adfed87",
+      "symbol": "BASED1",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71361/large/based-logo-200x200.png?1774599745"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x62d0a8458ed7719fdaf978fe5929c6d342b0bfce",
+      "symbol": "BEAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32417/standard/chain-logo.png?1698114384"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+    },
+    {
+      "chainId": 1,
+      "address": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
+      "symbol": "BIGTIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32251/standard/-6136155493475923781_121.jpg?1696998691"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb1110919016846972056ab995054d65560d5f05e",
+      "symbol": "BILL",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39545.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcb1592591996765ec0efc1f92599a19767ee5ffa",
+      "symbol": "BIO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53022/large/bio.jpg?1735011002"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5",
+      "symbol": "BIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088"
+    },
+    {
+      "chainId": 1,
+      "address": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd8a271974e8edae9d7b58e3370dc1669427503f4",
+      "symbol": "BLEND",
+      "decimals": 18
+    },
+    {
+      "chainId": 1,
+      "address": "0x5283d291dbcf85356a21ba090e6db59121208b44",
+      "symbol": "BLUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+      "symbol": "BNT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc9746f73cc33a36c2cd55b8aefd732586946cedd",
+      "symbol": "BOBBOB",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54720/large/BOB_symbol_colour.png?1741195397"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0391d2021f89dc339f60fff84546ea23e337750f",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+    },
+    {
+      "chainId": 1,
+      "address": "0x086f405146ce90135750bbec9a063a8b20a8bffb",
+      "symbol": "BREV",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71219/large/brevis.png?1766454723"
+    },
+    {
+      "chainId": 1,
+      "address": "0x799ebfabe77a6e34311eeee9825190b9ece32824",
+      "symbol": "BTRST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae12c5930881c53715b369cec7606b70d8eb229f",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+    },
+    {
+      "chainId": 1,
+      "address": "0x152649ea73beab28c5b49b26eb48f7ead6d4c898",
+      "symbol": "CAKE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/standard/cbbtc.webp"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3294395e62f4eb6af3f1fcf89f5602d90fb3ef69",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcccccccccc33d538dbc2ee4feab0a7a1ff4e8a94",
+      "symbol": "CFG",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55913/large/centrifuge.jpg?1747707741"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9126236476efba9ad8ab77855c60eb5bf37586eb",
+      "symbol": "CHECK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69231/large/VgVwfk9E_400x400.png?1761800742"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8a2279d4a90b6fe1c4b30fa660cc9f926797baa2",
+      "symbol": "CHR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+      "symbol": "CHZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540"
+    },
+    {
+      "chainId": 1,
+      "address": "0x80c62fe4487e1351b47ba49809ebd60ed085bf52",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f0c013016e8656bc256f948cd4b79ab25c7b94d",
+      "symbol": "COOK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
+    },
+    {
+      "chainId": 1,
+      "address": "0x44f49ff0da2498bcb1d3dc7c0f999578f67fd8c6",
+      "symbol": "CORN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54471/large/corn.jpg?1739933588"
+    },
+    {
+      "chainId": 1,
+      "address": "0xddb3422497e61e13543bea06989c0789117555c5",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3d658390460295fb963f54dc0899cfb1c30776df",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 1,
+      "address": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
+      "symbol": "CPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd417144312dbf50465b1c641d016962017ef6240",
+      "symbol": "CQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
+      "symbol": "CRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042"
+    },
+    {
+      "chainId": 1,
+      "address": "0x08389495d7456e1951ddf7c3a1314a4bfb646d8b",
+      "symbol": "CRPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
+      "symbol": "CTC",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/10569/large/Creditcoin_Symbol_dark56.png?1737796066"
+    },
+    {
+      "chainId": 1,
+      "address": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 1,
+      "address": "0x321c2fe4446c7c963dc41dd58879af648838f98d",
+      "symbol": "CTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdf801468a808a32656d2ed2d2d80b72a129739f4",
+      "symbol": "CUBE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
+      "symbol": "CXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x081131434f93063751813c619ecca9c4dc7862a3",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3a880652f47bfaa771908c07dd8673a787daed3a",
+      "symbol": "DDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfb7b4564402e5500db5bb6d63ae671302777c75a",
+      "symbol": "DEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
+    },
+    {
+      "chainId": 1,
+      "address": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0abdace70d3790235af448c88547603b945604ea",
+      "symbol": "DNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f81001ef0a83ecce5ccebf63eb302c70a39a654",
+      "symbol": "DOLO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54710/large/DOLO-small.png?1745398535"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2aeabde1ab736c59e9a19bed67681869eef39526",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
+      "symbol": "DPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3ab6ed69ef663bd986ee59205ccad8a20f98b4c2",
+      "symbol": "DREP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb1d1eae60eea9525032a6dcb4c1ce336a1de71be",
+      "symbol": "DRV",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6af487beb661ccecd1d045e9561a0dac9aa5c7db",
+      "symbol": "DUAL",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39819.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x92d6c1e31e14520e676a687f0a93788b716beff5",
+      "symbol": "DYDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360"
+    },
+    {
+      "chainId": 1,
+      "address": "0x961c8c0b1aad0c0b10a51fef6a867e3091bcef17",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb0076de78dc50581770bba1d211ddc0ad4f2a241",
+      "symbol": "EDGEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/markets/images/11726/large/Logo_White_-_Black_BG.png?1727920571"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe6fd75ff38adca4b97fbcd938c86b98772431867",
+      "symbol": "ELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
+    },
+    {
+      "chainId": 1,
+      "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57e114b691db790c35207b2e685d4a43181e6061",
+      "symbol": "ENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/standard/ethena.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe2ad0bf751834f2fbdc62a41014f84d67ca1de2a",
+      "symbol": "ERA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54475/large/Token_Logo.png?1749676251"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbc2ae13b23d715c30720f079fcd9b4a74093505",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6055dc6ff1077eebe5e6d2ba1a1f53d7ef8430de",
+      "symbol": "ES",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54958/large/image_%2832%29.png?1742979704"
+    },
+    {
+      "chainId": 1,
+      "address": "0x031de51f3e8016514bd0963d0b2ab825a591db9a",
+      "symbol": "ESP",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67626/large/espresso.jpg?1753324525"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/standard/etherfi.jpeg"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd9fcd98c322942075a5c3860693e9f4f03aae07b",
+      "symbol": "EUL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
+    },
+    {
+      "chainId": 1,
+      "address": "0x888883b5f5d21fb10dfeb70e8f9722b9fb0e5e51",
+      "symbol": "EUROP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52132/large/europ-symbol-rgb.jpg?1732634862"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8df723295214ea6f21026eeeb4382d475f146f9f",
+      "symbol": "EURQ",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51853/large/EURQ_1000px_Color.png?1732071269"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50753cfaf86c094925bf976f218d043f8791e408",
+      "symbol": "EURR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53720/large/stablreuro-logo.png?1737125898"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7c135549504245b5eae64fc0e99fa5ebabb8e35d",
+      "symbol": "FIDD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102171776/large/FIDD-Green_%28792px%29.png?1769612802"
+    },
+    {
+      "chainId": 1,
+      "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 1,
+      "address": "0x720cd16b011b987da3518fbf38c3071d4f0d1495",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41545f8b9472d758bb669ed8eaeeecd7a9c4ec29",
+      "symbol": "FORT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc770eefad204b5180df6a14ee197d99d808ee52d",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
+    },
+    {
+      "chainId": 1,
+      "address": "0x853d955acef822db058eb8505911ed77f175b99e",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
+      "symbol": "FTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8c15ef5b4b21951d50e53e4fbda8298ffad25057",
+      "symbol": "FX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+      "symbol": "G",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5faa989af96af85384b8a938c2ede4a7378d9875",
+      "symbol": "GAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
+      "symbol": "GALA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/standard/GALA-COINGECKO.png?1696512310"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdab396ccf3d84cf2d07c4454e10c8a6f5b008d2b",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
+      "symbol": "GLM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
+      "symbol": "GODS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 1,
+      "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+    },
+    {
+      "chainId": 1,
+      "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
+      "symbol": "GUSD",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2798b1cc5a993085e8a9d46e80499f1b63f42204",
+      "symbol": "GWEI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71375/large/ethgas_token_200.png?1769055039"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc08512927d12348f6620a698105e1baac6ecd911",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/hashflow-icon-cmc.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf5581dfefd8fb0e4aec526be659cfab1f8c781da",
+      "symbol": "HOPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+      "symbol": "IDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736"
+    },
+    {
+      "chainId": 1,
+      "address": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/ILV.JPG"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb48c6b24f36307c7a1f2a9281e978a9ef2902ba5",
+      "symbol": "IMU",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39429.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
+      "symbol": "IMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
+      "symbol": "INDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+    },
+    {
+      "chainId": 1,
+      "address": "0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68",
+      "symbol": "INV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdef1b2d939edc0e4d35806c59b3166f790175afe",
+      "symbol": "INX",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70868/large/infinex.png?1764322875"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x50f41f589afaca2ef41fdf590fe7b90cd26dee64",
+      "symbol": "IRYS",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/38978.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x23894dc9da6c94ecb439911caf7d337746575a72",
+      "symbol": "JAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
+      "symbol": "JASMY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4b1e80cac91e2216eeb63e29b957eb91ae9c2be8",
+      "symbol": "JUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfb072b42907da2bf7a8e8cb5dcaa790d45fd81a8",
+      "symbol": "K",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67966/large/kick.jpg?1754450296"
+    },
+    {
+      "chainId": 1,
+      "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
+      "symbol": "KEEP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3f80b1c54ae920be41a77f8b902259d48cf24ccf",
+      "symbol": "KERNEL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54326/large/Kernel_token_logo_2x.png?1739827205"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
+      "symbol": "KEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934"
+    },
+    {
+      "chainId": 1,
+      "address": "0x904567252d8f48555b7447c67dca23f0372e16be",
+      "symbol": "KITE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70426/large/KITE-ICON.png?1762328605"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
+      "symbol": "KP3R",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458"
+    },
+    {
+      "chainId": 1,
+      "address": "0x464ebe77c293e473b48cfe96ddcf88fcf7bfdac0",
+      "symbol": "KRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+    },
+    {
+      "chainId": 1,
+      "address": "0x96543ef8d2c75c26387c1a319ae69c0bee6f3fe7",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x88909d489678dd17aa6d9609f89b0419bf78fd9a",
+      "symbol": "L3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37768/large/Square.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0fc2a55d5bd13033f1ee0cdd11f60f7efe66f467",
+      "symbol": "LA",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/36510.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x037a54aab062628c9bbae1fdb1583c195585fe41",
+      "symbol": "LCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1789e0043623282d5dcc7f213d703c6d8bafbb04",
+      "symbol": "LINEA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68507/large/linea-logo.jpeg?1756025484"
+    },
+    {
+      "chainId": 1,
+      "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb59490ab09a0f526cc7305822ac65f2ab12f9723",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x232ce3bd40fcd6f80f3d55a522d03f25df784ee2",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71121/large/lighter.png?1765888098"
+    },
+    {
+      "chainId": 1,
+      "address": "0x61e90a50137e1f645c9ef4a0d3a4f01477738406",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa4e8c3ec456107ea67d3075bf9e3df3a75823db0",
+      "symbol": "LOOM",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58b6a8a3302369daec383334672404ee733ab239",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd0a6053f087e87a25dc60701ba6e663b1a548e85",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/standard/LRDS_PNG.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8c1bed5b9a0928467c9b1341da1d7bd5e10b6549",
+      "symbol": "LSETH",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28848/large/LsETH-receipt-token-circle.png?1696527824"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
+      "symbol": "LSK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
+    },
+    {
+      "chainId": 1,
+      "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 1,
+      "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
+      "symbol": "MATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 1,
+      "address": "0x949d48eca67b17269629c7194f4b727d4ef9e5d6",
+      "symbol": "MC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfc98e825a2264d890f9a1e68ed50e1526abccacd",
+      "symbol": "MCO2",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522"
+    },
+    {
+      "chainId": 1,
+      "address": "0x814e0908b12a99fecf5bc101bb5d0b8b5cdf7d26",
+      "symbol": "MDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb131f4a55907b10d1f0a50d8ab8fa09ec342cd74",
+      "symbol": "MEME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32528/large/memecoin_(2).png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8e4cbbcc33db6c0a18561fde1f6ba35906d4848b",
+      "symbol": "MEZO",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39727.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+    },
+    {
+      "chainId": 1,
+      "address": "0x09a3ecafa817268f77be1283176b946c4ff2e608",
+      "symbol": "MIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xec67005c4e498ec7f55e092bd1d35cbc47c91892",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+      "symbol": "MNT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30980/large/Mantle-Logo-mark.png?1739213200"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
+      "symbol": "MOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x275f5ad03be0fa221b4c6649b8aee09a42d9412a",
+      "symbol": "MONA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721"
+    },
+    {
+      "chainId": 1,
+      "address": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
+      "symbol": "MORPHO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3073f7aaa4db83f95e9fff17424f71d4751a3073",
+      "symbol": "MOVE",
+      "decimals": 8,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/32452.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x33349b282065b0284d756f0577fb39c158f935e6",
+      "symbol": "MPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf433089366899d83a9f26a773d59ec7ecf30355e",
+      "symbol": "MTL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010"
+    },
+    {
+      "chainId": 1,
+      "address": "0x65ef703f5594d2573eb71aaf55bc0cb548492df4",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+      "symbol": "MUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+      "symbol": "MUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453"
+    },
+    {
+      "chainId": 1,
+      "address": "0xae788f80f2756a86aa2f410c651f2af83639b95b",
+      "symbol": "MV",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5ca381bbfb58f0092df149bd3d243b08b9a8386e",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9e46a38f5daabe8683e10793b06749eef7d733d1",
+      "symbol": "NCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767"
+    },
+    {
+      "chainId": 1,
+      "address": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
+      "symbol": "Neiro",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd0ec028a3d21533fdd200838f39c85b03679285d",
+      "symbol": "NEWT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66819/large/newton.jpg?1750642513"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5cf04716ba20127f1e2297addcf4b5035000c9eb",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6e6f6d696e61decd6605bd4a57836c5db6923340",
+      "symbol": "NOM",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69687/large/nomina_400x400.jpg?1759312531"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4fe83213d56308330ec302a8bd641f1d0113a4cc",
+      "symbol": "NU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+    },
+    {
+      "chainId": 1,
+      "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878"
+    },
+    {
+      "chainId": 1,
+      "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
+    },
+    {
+      "chainId": 1,
+      "address": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36465/standard/Symbol-Color.png?1711511095"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfaba6f8e4a5e8ab82f62fe7c39859fa577269be3",
+      "symbol": "ONDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/standard/ONDO.png?1696525656"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6f59e0461ae5e2799f1fb3847f05a63b16d0dbf8",
+      "symbol": "ORCA",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0258f474786ddfd37abce6df6bbb1dd5dfc4434a",
+      "symbol": "ORN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4575f41308ec1483f3d399aa9a2826d74da13deb",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc1d204d77861def49b6e769347a883b15ec397ff",
+      "symbol": "PAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
+    },
+    {
+      "chainId": 1,
+      "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+      "symbol": "PAXG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0d3cbed3f69ee050668adf3d9ea57241cba33a2b",
+      "symbol": "PDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/standard/PDA-symbol.png?1710234068"
+    },
+    {
+      "chainId": 1,
+      "address": "0x808507121b80c02388fad14726482e061b8da827",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa9e8acf069c58aec8825542845fd754e41a9489a",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30219/large/pepecoin-icon_200x200.png?1735790725"
+    },
+    {
+      "chainId": 1,
+      "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7613c48e0cd50e42dd9bf0f6c235063145f6f8dc",
+      "symbol": "PIRATE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/standard/_Pirate_Transparent_200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd8912c10681d8b21fd3742244f44658dba12264e",
+      "symbol": "PLU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c1746a800d224393fe2470c70a35717ed4ea5f1",
+      "symbol": "PLUME",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53623/large/plume-token.png?1736896935"
+    },
+    {
+      "chainId": 1,
+      "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
+      "symbol": "POL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    },
+    {
+      "chainId": 1,
+      "address": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
+    },
+    {
+      "chainId": 1,
+      "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
+      "symbol": "POLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/standard/portal.jpeg"
+    },
+    {
+      "chainId": 1,
+      "address": "0x595832f8fc6bf59c85c527fec3740a1b7a361269",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb23d80f5fefcddaa212212f028021b41ded428cf",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
+    },
+    {
+      "chainId": 1,
+      "address": "0x226bb599a12c826476e3a771454697ea52e9e220",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6bef15d938d4e72056ac92ea4bdd0d76b1c4ad29",
+      "symbol": "PROVE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67905/large/succinct-logo.png?1754228574"
+    },
+    {
+      "chainId": 1,
+      "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
+      "symbol": "PRQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfb5c6815ca3ac72ce9f5006869ae67f18bf77006",
+      "symbol": "PSTAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30a25cc9c9eade4d4d9e9349be6e68c3411367d3",
+      "symbol": "PTB",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68774/large/portal.png?1756547114"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
+      "symbol": "PUFFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50630/large/puffer.jpg?1728545297"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4123a133ae3c521fd134d7b13a2dec35b56c2463",
+      "symbol": "QRDO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735"
+    },
+    {
+      "chainId": 1,
+      "address": "0x99ea4db9ee77acd40b119bd1dc4e33e1c070b80d",
+      "symbol": "QSP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70b7f7044d2ca8e2f1e999b90ef16d7cb7a0cda1",
+      "symbol": "QUAI",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/22354.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c28aef8977c9b773996d0e8376d2ee379446f2f",
+      "symbol": "QUICK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
+    },
+    {
+      "chainId": 1,
+      "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918"
+    },
+    {
+      "chainId": 1,
+      "address": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 1,
+      "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+      "symbol": "RARE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfca59cd816ab1ead66534d82bc21e7515ce441cf",
+      "symbol": "RARI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa4eed63db85311e22df4473f87ccfc3dadcfa3e3",
+      "symbol": "RBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b",
+      "symbol": "RBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc43c6bfeda065fe2c4c11765bf838789bd0bb5de",
+      "symbol": "RED",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53640/large/RedStone_Logo_New_White.png?1740640919"
+    },
+    {
+      "chainId": 1,
+      "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
+      "symbol": "REP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x221657776846890989a759ba2973e427dff5c9bb",
+      "symbol": "REPv2",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951"
+    },
+    {
+      "chainId": 1,
+      "address": "0x557b933a7c2c45672b610f8954a3deb39a51a8ca",
+      "symbol": "REVV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
+      "symbol": "REZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37327/standard/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd291e7a03283640fdc51b121ac401383a46cc623",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+    },
+    {
+      "chainId": 1,
+      "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb5f7b021a78f470d31d762c1dda05ea549904fbd",
+      "symbol": "RLS",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70091/large/cgrLS.png?1760541265"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed",
+      "symbol": "RLUSD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39651/large/RLUSD_200x200_(1).png?1727376633"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b",
+      "symbol": "RLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
+      "symbol": "RNDR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934"
+    },
+    {
+      "chainId": 1,
+      "address": "0x32b4d049fe4c888d2b92eecaf729f44df6b1f36e",
+      "symbol": "ROBO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102172005/large/ROBO.png?1770925648"
+    },
+    {
+      "chainId": 1,
+      "address": "0xfa5047c9c78b8877af97bdcb85db743fd7313d4a",
+      "symbol": "ROOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 1,
+      "address": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 1,
+      "address": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+      "symbol": "SAFE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/standard/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+      "symbol": "SAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942"
+    },
+    {
+      "chainId": 1,
+      "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x56a3ba04e95d34268a19b2a4474dc979babdaf76",
+      "symbol": "SENT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70508/large/SENTIENT-Icon-BlushForce-L.png?1762267532"
+    },
+    {
+      "chainId": 1,
+      "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7c84e62859d0715eb77d1b1c4154ecd6abb21bec",
+      "symbol": "SHPING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
+    },
+    {
+      "chainId": 1,
+      "address": "0x868fced65edbf0056c4163515dd840e9f287a4c3",
+      "symbol": "SIGN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55303/large/sign.jpg?1745303393"
+    },
+    {
+      "chainId": 1,
+      "address": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+    },
+    {
+      "chainId": 1,
+      "address": "0x56072c95faa701256059aa122697b133aded9279",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057"
+    },
+    {
+      "chainId": 1,
+      "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
+      "symbol": "SOCKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 1,
+      "address": "0x090185f2135308bad17527004364ebcc2d37e5f6",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc20059e0317de91738d13af027dfc4a50781b066",
+      "symbol": "SPK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38637/large/Spark-Logomark-RGB.png?1744878896"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518"
+    },
+    {
+      "chainId": 1,
+      "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766",
+      "symbol": "STRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/standard/starknet.png?1696525507"
+    },
+    {
+      "chainId": 1,
+      "address": "0x006bea43baa3f7a6f765f14f10a1a1b08334ef45",
+      "symbol": "STX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
+    },
+    {
+      "chainId": 1,
+      "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
+      "symbol": "SWELL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe6bfd33f52d82ccb5b37e16d3dd81f9ffdabb195",
+      "symbol": "SXT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55424/large/sxt-token_circle.jpg?1745935919"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf293d23bf2cdc05411ca0eddd588eb1977e8dcd4",
+      "symbol": "SYLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1bab804803159ad84b8854581aa53ac72455614e",
+      "symbol": "SYND",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69122/large/synd.png?1757576144"
+    },
+    {
+      "chainId": 1,
+      "address": "0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66",
+      "symbol": "SYRUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51232/standard/IMG_7420.png?1730831572"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340"
+    },
+    {
+      "chainId": 1,
+      "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+      "symbol": "tBTC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc3d21f79c3120a4ffda7a535f8005a7c297799bf",
+      "symbol": "TERM",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38142/large/terms.png?1716630303"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaffbe9a60f1f45e057fd9b6dc70004bb0ccc8b99",
+      "symbol": "THQ",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67759/large/thq.jpg?1753757049"
+    },
+    {
+      "chainId": 1,
+      "address": "0x485d17a6f1b8780392d53d64751824253011a260",
+      "symbol": "TIME",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666"
+    },
+    {
+      "chainId": 1,
+      "address": "0x888888848b652b3e3a0f34c96e00eec0f3a23f72",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2e9d63788249371f1dfc918a52f8d799f4a38c94",
+      "symbol": "TOKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+      "symbol": "TOKEN",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2ab6bb8408ca3199b8fa6c92d5b455f820af03c4",
+      "symbol": "TONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538"
+    },
+    {
+      "chainId": 1,
+      "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367"
+    },
+    {
+      "chainId": 1,
+      "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
+    },
+    {
+      "chainId": 1,
+      "address": "0x77146784315ba81904d654466968e3a7c196d1f3",
+      "symbol": "TREE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67664/large/TREE_logo.png?1753601041"
+    },
+    {
+      "chainId": 1,
+      "address": "0x228bec415ade4b61d7caf0adf8c91eac587ba369",
+      "symbol": "TRIA",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39382.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b",
+      "symbol": "TRIBE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
+      "symbol": "TURBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 1,
+      "address": "0xd084b83c305dafd76ae3e1b4e1f1fe2ecccb3988",
+      "symbol": "TVK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619"
+    },
+    {
+      "chainId": 1,
+      "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x441761326490cacf7af299725b6292597ee822c2",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+    },
+    {
+      "chainId": 1,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70d2b7c19352bb76e4409858ff5746e500f2b67c",
+      "symbol": "UPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d",
+      "symbol": "USD1",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe343167631d89b6ffc58b88d6b7fb0228795491d",
+      "symbol": "USDG",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/standard/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc83e27f270cce0a3a3a29521173a83f402c1768b",
+      "symbol": "USDQ",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51852/large/USDQ_1000px_Color.png?1732071232"
+    },
+    {
+      "chainId": 1,
+      "address": "0x7b43e3875440b44613dc3bc08e7763e6da63c8f8",
+      "symbol": "USDR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53721/large/stablrusd-logo.png?1737126629"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 1,
+      "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc4441c2be5d8fa8126822b9929ca0b81ea0de38e",
+      "symbol": "USUAL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51091/large/USUAL.jpg?1730035787"
+    },
+    {
+      "chainId": 1,
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 1,
+      "address": "0x3c4b6e6e1ea3d4863700d7f76b36b7f3d3f13e3d",
+      "symbol": "VGX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
+    },
+    {
+      "chainId": 1,
+      "address": "0xedb171c18ce90b633db442f2a6f72874093b49ef",
+      "symbol": "WAMPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf983da3ca66964c02628189ea8ca99fa9e24f66c",
+      "symbol": "WANLOG",
+      "decimals": 12,
+      "logoURI": "https://assets.kraken.com/marketing/web/icons-uni-webp/s_anlog.webp?i=kds"
+    },
+    {
+      "chainId": 1,
+      "address": "0x925206b8a707096ed26ae47c84747fe0bb734f59",
+      "symbol": "WBT",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
+    },
+    {
+      "chainId": 1,
+      "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc221b7e65ffc80de234bbb6667abdd46593d34f0",
+      "symbol": "WCFG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462"
+    },
+    {
+      "chainId": 1,
+      "address": "0xef4461891dfb3ac8572ccf7c794664a8dd927945",
+      "symbol": "WCT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+    },
+    {
+      "chainId": 1,
+      "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6c28f8cab28121ed757edb36201511aa18cdd187",
+      "symbol": "WFB",
+      "decimals": 8,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/32941.png"
+    },
+    {
+      "chainId": 1,
+      "address": "0xda5e1988097297dcdc1f90d4dfe7909e847cbef6",
+      "symbol": "WLFI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50767/large/wlfi.png?1756438915"
+    },
+    {
+      "chainId": 1,
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 1,
+      "address": "0xcedbea37c8872c4171259cdfd5255cb8923cf8e7",
+      "symbol": "XAN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69380/large/Anoma_Logo_Roundel_RGB_Colour-01.png?1758356672"
+    },
+    {
+      "chainId": 1,
+      "address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+      "symbol": "XAUT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054"
+    },
+    {
+      "chainId": 1,
+      "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 1,
+      "address": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+    },
+    {
+      "chainId": 1,
+      "address": "0x01791f726b4103694969820be083196cc7c045ff",
+      "symbol": "YB",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54871/large/yieldbasis_400x400.png?1760514173"
+    },
+    {
+      "chainId": 1,
+      "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
+      "symbol": "YFII",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348"
+    },
+    {
+      "chainId": 1,
+      "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+      "symbol": "YGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691"
+    },
+    {
+      "chainId": 1,
+      "address": "0xa12cc123ba206d4031d1c7f6223d1c2ec249f4f3",
+      "symbol": "ZAMA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70921/large/zama.png?1764591992"
+    },
+    {
+      "chainId": 1,
+      "address": "0xf091867ec603a6628ed83d274e835539d82e9cc8",
+      "symbol": "Zeta",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/standard/Twitter_icon.png?1696525788"
+    },
+    {
+      "chainId": 1,
+      "address": "0x000006c2a22ff4a44ff1f5d0f2ed65f781f55555",
+      "symbol": "ZKC",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68462/large/boundless.png?1755826792"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe1be424f442d0687129128c6c38aace44f8c8dbc",
+      "symbol": "ZKP",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70273/large/zkpass.png?1761379373"
+    },
+    {
+      "chainId": 1,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 1,
+      "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 3,
+      "address": "0xad6d458402f60fd3bd25163575031acdce07538d",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaD6D458402F60fD3Bd25163575031ACDce07538D/logo.png"
+    },
+    {
+      "chainId": 3,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 3,
+      "address": "0xc778417e063141139fce010982780140aa0cd5ab",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+    },
+    {
+      "chainId": 4,
+      "address": "0xc7ad46e0b8a400bb3c915120d284aafba8fc4735",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735/logo.png"
+    },
+    {
+      "chainId": 4,
+      "address": "0xf9ba5210f91d0474bd1e1dcdaec4c58e359aad85",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85/logo.png"
+    },
+    {
+      "chainId": 4,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 4,
+      "address": "0xc778417e063141139fce010982780140aa0cd5ab",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+    },
+    {
+      "chainId": 5,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 5,
+      "address": "0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xad42d013ac31486b73b6b059e748172994736426",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 10,
+      "address": "0x76fb31fb4af56892a25e32cfc43de717950c9278",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 10,
+      "address": "0xff733b2a3557a7ed6697007ab5d11b79fdd1b76b",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 10,
+      "address": "0x334cc734866e97d8452ae6261d68fd9bc9bfa31e",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
+    },
+    {
+      "chainId": 10,
+      "address": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xd6909e9e702024eb93312b989ee46794c0fb1c9d",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+    },
+    {
+      "chainId": 10,
+      "address": "0x07ad578ff86b135be19a12759064b802cb88854d",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
+    },
+    {
+      "chainId": 10,
+      "address": "0x3e7ef8f50246f725885102e8238cbba33f276747",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+    },
+    {
+      "chainId": 10,
+      "address": "0xed50ace88bd42b45cb0f49be15395021e141254e",
+      "symbol": "BTRST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 10,
+      "address": "0xaddb6a0412de1ba0f936dcaeb8aaa24578dcf3b2",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9b88d293b7a791e40d36a39765ffd5a1b9b5c349",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x0994206dfe8de6ec6920ff4d779b0d950605fb53",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xec6adef5e1006bb305bb1975333e8fc4071295bf",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 10,
+      "address": "0x14778860e937f509e651192a90589de711fb88a9",
+      "symbol": "CYBER",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31274/large/token.png?1715826754"
+    },
+    {
+      "chainId": 10,
+      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x33800de7e817a70a694f31476313a7c572bba100",
+      "symbol": "DRV",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+    },
+    {
+      "chainId": 10,
+      "address": "0x65559aa14915a70190438ef90104769e5e890a00",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 10,
+      "address": "0xd8737ca46aa6285de7b8777a8e3db232911bad41",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
+    },
+    {
+      "chainId": 10,
+      "address": "0xf1a0da3367bc7aa04f8d94ba57b862ff37ced174",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
+    },
+    {
+      "chainId": 10,
+      "address": "0x2e3d870790dc77a83dd1d18184acc7439a53f475",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 10,
+      "address": "0x67ccea5bb16181e7b4109c9c2143c24a1c2205be",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 10,
+      "address": "0x1eba7a6a72c894026cd654ac5cdcf83a46445b08",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+    },
+    {
+      "chainId": 10,
+      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
+    },
+    {
+      "chainId": 10,
+      "address": "0x2ed6222cb75e353b8789bec7bb443b7ec9022021",
+      "symbol": "KRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+    },
+    {
+      "chainId": 10,
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xfdb794692724153d1488ccdbe0c56c252596735f",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
+    },
+    {
+      "chainId": 10,
+      "address": "0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xfeaa9194f9f8c1b65429e31341a103071464907e",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xc40f949f8a4e094d1b49a23ea9241d289b7b2819",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327"
+    },
+    {
+      "chainId": 10,
+      "address": "0x3390108e913824b8ead638444cc52b9abdf63798",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 10,
+      "address": "0xab7badef82e9fe11f6f33f87bc9bc2aa27f2fcb5",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x2561aa2bb1d2eb6629edd7b0938d7679b8b49f9e",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
+    },
+    {
+      "chainId": 10,
+      "address": "0x4200000000000000000000000000000000000042",
+      "symbol": "OP",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/OP/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xbc7b1ff1c6989f006a1185318ed4e7b5796e66e1",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 10,
+      "address": "0xc1c167cc44f7923cd0062c4370df962f9ddb16f5",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
+    },
+    {
+      "chainId": 10,
+      "address": "0x7fb688ccf682d58f86d7e38e03f9d22e7705448b",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 10,
+      "address": "0xb548f63d4405466b36c0c0ac3318a22fdcec711a",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+    },
+    {
+      "chainId": 10,
+      "address": "0xc81d1f0eb955b0c020e5d5b264e1ff72c14d1401",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 10,
+      "address": "0x650af3c15af43dcb218406d30784416d64cfb6b2",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "chainId": 10,
+      "address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xba1cf949c382a32a09a17b2adf3587fc7fa664f1",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 10,
+      "address": "0xef6301da234fc7b0545c6e877d3359fe0b9e50a4",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
+    },
+    {
+      "chainId": 10,
+      "address": "0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 10,
+      "address": "0x3eaeb77b03dbc0f6321ae1b72b2e9adb0f60112b",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 10,
+      "address": "0x747e42eb0591547a0ab429b3627816208c734ea7",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340"
+    },
+    {
+      "chainId": 10,
+      "address": "0xaf8ca653fa2772d58f4368b0a71980e9e3ceb888",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
+    },
+    {
+      "chainId": 10,
+      "address": "0xe7798f023fc62146e8aa1b36da45fb70855a77ea",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x6fd9d7ad17242c41f7131d257212c54a0e816691",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 10,
+      "address": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0x01bff41798a0bcf287b996046ca68b395dbc1071",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9560e827af36c94d2ac33a39bce1fe78631088db",
+      "symbol": "VELO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12538/standard/Logo_200x_200.png?1696512350"
+    },
+    {
+      "chainId": 10,
+      "address": "0x68f180fcce6836688e9084f035309e29bf0a2095",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xef4461891dfb3ac8572ccf7c794664a8dd927945",
+      "symbol": "WCT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+    },
+    {
+      "chainId": 10,
+      "address": "0x4200000000000000000000000000000000000006",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 10,
+      "address": "0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1",
+      "symbol": "WLD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31069/large/worldcoin.jpeg?1696529903"
+    },
+    {
+      "chainId": 10,
+      "address": "0x871f2f2ff935fd1ed867842ff2a7bfd051a5e527",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9db118d43069b73b8a252bf0be49d50edbd81fc8",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+    },
+    {
+      "chainId": 10,
+      "address": "0x9046d36440290ffde54fe0dd84db8b1cfee9107b",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 10,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 10,
+      "address": "0xd1917629b3e6a72e6772aab5dbe58eb7fa3c2f33",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 42,
+      "address": "0x4f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa/logo.png"
+    },
+    {
+      "chainId": 42,
+      "address": "0xaaf64bfcc32d0f15873a02163e7e500671a4ffcd",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD/logo.png"
+    },
+    {
+      "chainId": 42,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 42,
+      "address": "0xd0a1e359811322d97991e03f863a0c30c2cf029c",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xd0A1E359811322d97991E03f863a0C30C2cF029C/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 56,
+      "address": "0xfb6115445bff7b52feb98650c87f44907e58f802",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 56,
+      "address": "0xbc7d6b50616989655afd682fb42743507003056d",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1599691266"
+    },
+    {
+      "chainId": 56,
+      "address": "0x6bff4fb161347ad7de4a625ae5aa3a1ca7077819",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540"
+    },
+    {
+      "chainId": 56,
+      "address": "0x12f31b73d812c6bb0d735a218c086d44d5fe5f89",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 56,
+      "address": "0x33d08d8c7a168333a85285a68c0042b39fc3741d",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
+    },
+    {
+      "chainId": 56,
+      "address": "0x82d2f8e02afb160dd5a480a617692e62de9038c4",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    },
+    {
+      "chainId": 56,
+      "address": "0xac51066d7bec65dc4589368da368b212745d63e8",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968"
+    },
+    {
+      "chainId": 56,
+      "address": "0xa1faa113cbe53436df28ff0aee54275c13b40975",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
+    },
+    {
+      "chainId": 56,
+      "address": "0xf307910a4c7bbc79691fd374889b36d8531b08e3",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+    },
+    {
+      "chainId": 56,
+      "address": "0x6f769e65c14ebd1f68817f5f1dcdb61cfa2d6f7e",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
+    },
+    {
+      "chainId": 56,
+      "address": "0x000ae314e2a2172a039b26378814c252734f556a",
+      "symbol": "ASTER",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69040/large/_ASTER.png?1757326782"
+    },
+    {
+      "chainId": 56,
+      "address": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
+    },
+    {
+      "chainId": 56,
+      "address": "0x8b1f4432f943c465a973fedc6d7aa50fc96f1f65",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 56,
+      "address": "0x715d400f88c167884bbcc41c5fea407ed4d2f8a0",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+    },
+    {
+      "chainId": 56,
+      "address": "0x935a544bf5816e3a7c13db2efe3009ffda0acda2",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe9e7cea3dedca5984780bafc599bd69add087d56",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 56,
+      "address": "0xaec945e04baf28b135fa7c640f624f8d90f1c3a6",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+    },
+    {
+      "chainId": 56,
+      "address": "0xf9cec8d50f6c8ad3fb6dccec577e05aa32b224fe",
+      "symbol": "CHR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018"
+    },
+    {
+      "chainId": 56,
+      "address": "0x09e889bb4d5b474f561db0491c38702f367a4e4d",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+    },
+    {
+      "chainId": 56,
+      "address": "0x52ce071bd9b1c4b00a0b92d298c512478cad67e8",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0xd15cee1deafbad6c0b3fd7489677cc102b141464",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+    },
+    {
+      "chainId": 56,
+      "address": "0x8da443f84fea710266c8eb6bc34b71702d033ef2",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 56,
+      "address": "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x23ce9e926048273ef83be0a3a8ba9cb6d45cd978",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe91a8d2c584ca93c7405f15c22cdfe53c29896e3",
+      "symbol": "DEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
+    },
+    {
+      "chainId": 56,
+      "address": "0x99956d38059cf7beda96ec91aa7bb2477e0901dd",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
+    },
+    {
+      "chainId": 56,
+      "address": "0xec583f25a049cc145da9a256cdbe9b6201a705ff",
+      "symbol": "DREP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+    },
+    {
+      "chainId": 56,
+      "address": "0x961c8c0b1aad0c0b10a51fef6a867e3091bcef17",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+    },
+    {
+      "chainId": 56,
+      "address": "0x7bd6fabd64813c48545c9c0e312a0099d9be2540",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
+    },
+    {
+      "chainId": 56,
+      "address": "0x4b5c23cac08a567ecf0c1ffca8372a45a5d33743",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+    },
+    {
+      "chainId": 56,
+      "address": "0x031b41e504677879370e9dbcf937283a8691fa7f",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+    },
+    {
+      "chainId": 56,
+      "address": "0xd55c9fb62e176a8eb6968f32958fefdd0962727e",
+      "symbol": "FHE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55161/large/mind.jpg?1744276359"
+    },
+    {
+      "chainId": 56,
+      "address": "0xfb5b838b6cfeedc2873ab27866079ac55363d37e",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 56,
+      "address": "0x90c97f71e18723b0cf0dfa30ee176ab653e89f40",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 56,
+      "address": "0xad29abb318791d579433d831ed122afeaf29dcfe",
+      "symbol": "FTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe48a3d7d0bc88d552f730b62c006bc925eadb9ee",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe4cc45bb5dbda06db6183e8bf016569f40497aa5",
+      "symbol": "GAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+    },
+    {
+      "chainId": 56,
+      "address": "0x30117e4bc17d7b044194b76a38365c53b72f7d49",
+      "symbol": "GWEI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71375/large/ethgas_token_200.png?1769055039"
+    },
+    {
+      "chainId": 56,
+      "address": "0x44ec807ce2f4a6f2737a92e985f318d035883e47",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/hashflow-icon-cmc.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x5f4bde007dc06b867f86ebfe4802e34a1ffeed63",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+    },
+    {
+      "chainId": 56,
+      "address": "0xa2b726b1145a4773f68593cf171187d8ebe4d495",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+    },
+    {
+      "chainId": 56,
+      "address": "0x0231f91e02debd20345ae8ab7d71a41f8e140ce7",
+      "symbol": "JUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932"
+    },
+    {
+      "chainId": 56,
+      "address": "0x0a73d885cdd66adf69c6d64c0609e55c527db2be",
+      "symbol": "K",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67966/large/kick.jpg?1754450296"
+    },
+    {
+      "chainId": 56,
+      "address": "0x073690e6ce25be816e68f32dca3e11067c9fb5cc",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x2ed9a5c8c13b93955103b9a7c167b67ef4d568a3",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 56,
+      "address": "0xf218184af829cf2b0019f8e6f0b2423498a36983",
+      "symbol": "MATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590"
+    },
+    {
+      "chainId": 56,
+      "address": "0xcc42724c6683b7e57334c4e856f4c9965ed682bd",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 56,
+      "address": "0x949d48eca67b17269629c7194f4b727d4ef9e5d6",
+      "symbol": "MC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe552fb52a4f19e44ef5a967632dbc320b0820639",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312"
+    },
+    {
+      "chainId": 56,
+      "address": "0x8e4cbbcc33db6c0a18561fde1f6ba35906d4848b",
+      "symbol": "MEZO",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39727.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+    },
+    {
+      "chainId": 56,
+      "address": "0x5b6dcf557e2abe2323c48445e8cc948910d8c2c9",
+      "symbol": "MIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
+    },
+    {
+      "chainId": 56,
+      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+    },
+    {
+      "chainId": 56,
+      "address": "0x7977bf3e7e0c954d12cdca3e013adaf57e0b06e0",
+      "symbol": "OPN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/102171893/thumb/Opinon.jpg?1770269253"
+    },
+    {
+      "chainId": 56,
+      "address": "0x4e7f408be2d4e9d60f49a64b89bb619c84c7c6f5",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
+    },
+    {
+      "chainId": 56,
+      "address": "0x7e624fa0e1c4abfd309cc15719b7e2580887f570",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
+    },
+    {
+      "chainId": 56,
+      "address": "0xd21d29b38374528675c34936bf7d5dd693d2a577",
+      "symbol": "PRQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280"
+    },
+    {
+      "chainId": 56,
+      "address": "0x4c882ec256823ee773b25b414d36f92ef58a7c0c",
+      "symbol": "PSTAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930"
+    },
+    {
+      "chainId": 56,
+      "address": "0x833f307ac507d47309fd8cdd1f835bef8d702a93",
+      "symbol": "REVV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390"
+    },
+    {
+      "chainId": 56,
+      "address": "0x3bc5ac0dfdc871b365d159f728dd1b9a0b5481e8",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x868fced65edbf0056c4163515dd840e9f287a4c3",
+      "symbol": "SIGN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55303/large/sign.jpg?1745303393"
+    },
+    {
+      "chainId": 56,
+      "address": "0xfa54ff1a158b5189ebba6ae130ced6bbd3aea76e",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 56,
+      "address": "0xb0d502e938ed5f4df2e681fe6e419ff29631d62b",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518"
+    },
+    {
+      "chainId": 56,
+      "address": "0x51ba0b044d96c3abfca52b64d733603ccc4f0d4d",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
+    },
+    {
+      "chainId": 56,
+      "address": "0x947950bcc74888a40ffa2593c5798f11fc9124c4",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 56,
+      "address": "0xe64e30276c2f826febd3784958d6da7b55dfbad3",
+      "symbol": "SWFTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022"
+    },
+    {
+      "chainId": 56,
+      "address": "0x47bead2563dcbf3bf2c9407fea4dc236faba485a",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311"
+    },
+    {
+      "chainId": 56,
+      "address": "0xa4080f1778e69467e905b8d6f72f6e441f9e9484",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+    },
+    {
+      "chainId": 56,
+      "address": "0x3b198e26e473b8fab2085b37978e36c9de5d7f68",
+      "symbol": "TIME",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666"
+    },
+    {
+      "chainId": 56,
+      "address": "0x2222227e22102fe3322098e4cbfe18cfebd57c95",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061"
+    },
+    {
+      "chainId": 56,
+      "address": "0x728c5bac3c3e370e372fc4671f9ef6916b814d8b",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+    },
+    {
+      "chainId": 56,
+      "address": "0xbf5140a22578168fd562dccf235e5d43a02ce9b1",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 56,
+      "address": "0x0d35a2b85c5a63188d566d104bebf7c694334ee4",
+      "symbol": "UPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+    },
+    {
+      "chainId": 56,
+      "address": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+      "symbol": "USDC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x55d398326f99059ff775485246999027b3197955",
+      "symbol": "USDT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0xf486ad071f3bee968384d2e39e2d8af0fcf6fd46",
+      "symbol": "VELO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12538/large/Logo_200x_200.png?1696512350"
+    },
+    {
+      "chainId": 56,
+      "address": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
+      "symbol": "WBNB",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/smartchain/assets/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 56,
+      "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 56,
+      "address": "0x21caef8a43163eea865baee23b9c2e327696a3bf",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 56,
+      "address": "0x7324c7c0d95cebc73eea7e85cbaac0dbdf88a05b",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054"
+    },
+    {
+      "chainId": 56,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbe41cde1c5e75a7b6c2c70466629878aa9acd06e",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 130,
+      "address": "0x44d618c366d7bc85945bfc922acad5b1fef7759a",
+      "symbol": "A8",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39170/standard/A8_Token-04_200x200.png?1720798300"
+    },
+    {
+      "chainId": 130,
+      "address": "0x02a24c380da560e4032dc6671d8164cfbeeaae1e",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 130,
+      "address": "0xddce42b89215548becaa160048460747fe5675bc",
+      "symbol": "ABT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb8a8e137a2daa25ef1b3577b6598fe8be66ecf77",
+      "symbol": "ACH",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12390/thumb/ACH_%281%29.png?1599691266"
+    },
+    {
+      "chainId": 130,
+      "address": "0x34424b3352af905e41078a4029b61ede62bbb32c",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 130,
+      "address": "0x3e1c572d8b069fc2f14ac4f8bdce6e8ea299a500",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540"
+    },
+    {
+      "chainId": 130,
+      "address": "0xfd38ac2316f6d3631a86065adb3292f6f15873b5",
+      "symbol": "AERGO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
+    },
+    {
+      "chainId": 130,
+      "address": "0x54fa9210ccb765639b7fd532f25bcb1060d60f8b",
+      "symbol": "AEVO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/standard/aevo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa4eef95995f40ad0b3d63a474293fc7cc681a118",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 130,
+      "address": "0x14421614587a2a3e9c3aa3131fc396af412721cf",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5f891e74947b0fc400128e5e85333d7a6cf99b1a",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbf194c82a5bb9180f9280c1832f886a65aebdcd6",
+      "symbol": "ALCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa3e646211a456e08829c33fce21cc3dc4c15bb5c",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2a87dd1e1f849ed88c18565afda98e2eeec73780",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbb72b8031f590748d8910aad7e25f8b18860960a",
+      "symbol": "ALICE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968"
+    },
+    {
+      "chainId": 130,
+      "address": "0x44c3e7c49c4bb6f4f5ecd87e035176dfcebd78d3",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6d5de04f1a3e0e554b9a15059d03e20cb3589153",
+      "symbol": "ALT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34608/standard/Logomark_200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4d6b8ecb576df9bb4bf6e6764a469a762bbc967f",
+      "symbol": "AMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf081fc8e0878d7ebe6ec381e5d7279d6eff97622",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+    },
+    {
+      "chainId": 130,
+      "address": "0x865d184885200b8e86eb2a3da8b3b4a7d4a31308",
+      "symbol": "ANT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd1b8423fde5f37464fade603f80903cb314046cf",
+      "symbol": "APE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa63122b27308eed0c1d83dd355addaa7f678961b",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
+    },
+    {
+      "chainId": 130,
+      "address": "0xcdfce5eb357e8976a80be84e94a03ba963b9e379",
+      "symbol": "APU",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5cc70a9df8e293affb14dfca1e7f851418a4b40d",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://arbitrum.foundation/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x59f16baa7a22f49c32680661e0041a53442ef089",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/standard/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe911a809f87490406ab34fad701aabca88e30b45",
+      "symbol": "ARPA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4b355de6ea44711f0353ed89545705395a30d7fb",
+      "symbol": "ASH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1e196d83e2c562de0b1f270eb72220335ba0ada7",
+      "symbol": "ASM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7f3f14a49fe5d5009e4e0a09e76cb8468c09ae56",
+      "symbol": "AST",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbaaa314d2f5af29b00867a612f24f816d890c4b2",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa249732271cba6e06be4ac8b20f0d465fee183ab",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_(1).png?1718232706"
+    },
+    {
+      "chainId": 130,
+      "address": "0x82f90996a4f67eb388116b3c6f35b6ea91bef68e",
+      "symbol": "AUCTION",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
+    },
+    {
+      "chainId": 130,
+      "address": "0x48b8441de79cee3604b805093b41028d3c81684b",
+      "symbol": "AUDIO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727"
+    },
+    {
+      "chainId": 130,
+      "address": "0x38dbf47e2a012a4b83823f15e3f3352a00939999",
+      "symbol": "AVT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbf678793522638f7439afe3b94d2d2a3a4cbf2c9",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 130,
+      "address": "0xda63ada216d2079b54f2047b2fdc2576d188f927",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc2a564b44b441d03f09f5b6b2b358b4a17388406",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976"
+    },
+    {
+      "chainId": 130,
+      "address": "0x01625e26274ed828ac1d47694c97221b34a8addf",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa264f2b88c630f260abdcab577eab7266a8857d5",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4e373c99199773f9d92d32b8c8bc0c81508ea589",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe5ecb192f1ae5839ed49886f36dfa670f9500824",
+      "symbol": "BEAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32417/standard/chain-logo.png?1698114384"
+    },
+    {
+      "chainId": 130,
+      "address": "0x604ff88adc02325efb7f93db3e442dc81d0588e7",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+    },
+    {
+      "chainId": 130,
+      "address": "0x17f3afe72caa6b9090801b60607918b6d2fa7cdc",
+      "symbol": "BIGTIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32251/standard/-6136155493475923781_121.jpg?1696998691"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa4cb2aaf7503641b441e80fc353e6748fb523a5c",
+      "symbol": "BIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088"
+    },
+    {
+      "chainId": 130,
+      "address": "0x41f6e69166e81a9583dbc96604b01d2e9b3d706f",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 130,
+      "address": "0x942fc6b61686e06fb411cb1bcf5d16dc2b9255ea",
+      "symbol": "BLUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe7b3ca9d9db06e1867781fd1c5f02e6c8ef471ee",
+      "symbol": "BLZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf2cc2d274da528ab64da86be3f8416e5472c5a62",
+      "symbol": "BNT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbe8e46422fb7f9ca9d639b3109492d64bbb41b05",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4d5b7e9cce3ab81298da7e1f52b48c9a61df8972",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbbe97f3522101e5b6976cbf77376047097ba837f",
+      "symbol": "BONK",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/standard/bonk.jpg?1696527587"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6a4a359c7453f5892392fcb8eab7a9a100986b71",
+      "symbol": "BTRST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa4da5c92f44422dfa3e2e309b53d93bbbda9f9c6",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 130,
+      "address": "0x29129fa2e0f35594ca7b362ffa8c80f5f8e4f8e1",
+      "symbol": "C98",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb6a3e8e5715fd4c99ecedaaae121bde4ab6a1ef1",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/standard/cbbtc.webp"
+    },
+    {
+      "chainId": 130,
+      "address": "0xeb64b50fef2a363940369285f86ae9a68211db59",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6008f5bad83742fdbff5aac55e3c51b65a8a8d9c",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5ad5d6b1ae6761aab12066b51d21729248035703",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
+    },
+    {
+      "chainId": 130,
+      "address": "0xac930be88cfac775a937e9291c4234bf210a4e5b",
+      "symbol": "CHR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb0c69e24450e29afa8008962052007e08b2396b0",
+      "symbol": "CHZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd7212097f6d6b195a9bc350b8dce28a7fa41404c",
+      "symbol": "CLV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+    },
+    {
+      "chainId": 130,
+      "address": "0xdf78e4f0a8279942ca68046476919a90f2288656",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc63612b3e697aeec61c3ce9baec0f9db32f499c3",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2562dc34c21371613cef236b321ee63fcc295bec",
+      "symbol": "COVAL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc3a97c76aa194711e05ff1d181534090b26d3996",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf8e7b485ce10d3c7ac30b8444b98a0cc423dfb57",
+      "symbol": "CPOOL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6c28eeb9e018011d3841f42c5b458713621f90c1",
+      "symbol": "CQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218"
+    },
+    {
+      "chainId": 130,
+      "address": "0x73c63a80ec77bfe31eec6663828c4beaa30de818",
+      "symbol": "CRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7e7784f13029c7c4bf4746112b1a503818b0d066",
+      "symbol": "CRPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
+    },
+    {
+      "chainId": 130,
+      "address": "0xac73671a1762fe835208fb93b7ae7490d1c2ccb3",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa7073f530856cd32c2037150dd9763b9baaed2c5",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 130,
+      "address": "0x36fa435f6def83cbb7a0706d035c9ea062fcb619",
+      "symbol": "CTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe60e9b2e68297d5df6b383fee787b7fb92c2f8af",
+      "symbol": "CUBE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861"
+    },
+    {
+      "chainId": 130,
+      "address": "0x35c458ad1e3e68d2717c8349b985384be85a01ed",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1c6789f30e7e335c2eca2c75ec193adbf0087ea5",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8e29e12b46fee20e034fe1e812bc12eff14e5a09",
+      "symbol": "CXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+    },
+    {
+      "chainId": 130,
+      "address": "0x20cab320a855b39f724131c69424240519573f81",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2ef0775a19d1bc2258653fc5529f8f8490288086",
+      "symbol": "DAR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+    },
+    {
+      "chainId": 130,
+      "address": "0x91ed4bb192e3461e45575730508525083a270265",
+      "symbol": "DDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641"
+    },
+    {
+      "chainId": 130,
+      "address": "0x45a4f750d806498a4c7f7b5267815aac328e874c",
+      "symbol": "DENT",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
+    },
+    {
+      "chainId": 130,
+      "address": "0x17c38207334011a131b0acf200e35cd81723cddd",
+      "symbol": "DEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4bdc8553cf14eebcd489cd1d75b7ff463f9543c2",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0eb07ce7a28ff84df132fb5ee5f56aabc1b9e545",
+      "symbol": "DNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+    },
+    {
+      "chainId": 130,
+      "address": "0x12e96c2bfea6e835cf8dd38a5834fa61cf723736",
+      "symbol": "DOGE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5/standard/dogecoin.png?1696501409"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe274f564c37ae15fd2570d544102ed4acd2f84f1",
+      "symbol": "DPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053"
+    },
+    {
+      "chainId": 130,
+      "address": "0x56af109d597eb0a0f79ebcd0786dd88c38ea9ee7",
+      "symbol": "DREP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+    },
+    {
+      "chainId": 130,
+      "address": "0x601b11907eaa8d3785c0b10b41c3a7315faeb82c",
+      "symbol": "DYDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbdad8e37a9600f0a35976fe61608a4c89d598610",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc89ab9b82610bb9b748f6757b8f3ac59d016c47d",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 130,
+      "address": "0x24abc32215354ba3ed224bfa6312e31dd8e8c1ab",
+      "symbol": "ELA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
+    },
+    {
+      "chainId": 130,
+      "address": "0x91441fe1415b00bea8930a4354fe00c426c1de05",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9116e70d613860d349495d9ef8e2ae1ca6cbd2dd",
+      "symbol": "ENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/standard/ethena.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9a0d1b7594caaf0a9e4687cac9ff4e0b84a6d0a6",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
+    },
+    {
+      "chainId": 130,
+      "address": "0x80756faf1e7fec5678bf505670ef176ab5f0383a",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5e5903c236e6873eb8400c3d1979271fa93cdb03",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf8740269f121327d03ff77bed03a9a3258880821",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/standard/etherfi.jpeg"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6319f47719b6713b1624c1b3a8e2dbf15b5d03fe",
+      "symbol": "EUL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
+    },
+    {
+      "chainId": 130,
+      "address": "0x72f34bc403a005a9be390762eaa46ed42813b0a8",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
+    },
+    {
+      "chainId": 130,
+      "address": "0xec42461d9bbdf4efb6481099253bbb7324d7d72d",
+      "symbol": "EURQ",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51853/large/EURQ_1000px_Color.png?1732071269"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7a1ef7fd6e0d708295d8fd0c30fd437d9c36fb5f",
+      "symbol": "EURR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53720/large/stablreuro-logo.png?1737125898"
+    },
+    {
+      "chainId": 130,
+      "address": "0x472e8be16cc9823b9f6a73a34ea55c0c31ee825f",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+    },
+    {
+      "chainId": 130,
+      "address": "0x45343279defdad803d81c06fbcf87936ddd7dfe7",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+    },
+    {
+      "chainId": 130,
+      "address": "0xec9be303f204864145ccc193aeb21b5fa10764a6",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1b3ec249dc44a64bf5cb8afdd70e30c26c51fa81",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb20fd6fd28e1430f98a8c1e9a83c88e5d87d94e5",
+      "symbol": "FORT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
+    },
+    {
+      "chainId": 130,
+      "address": "0xfa004fa2ad8ef993c2b0412bab776b182220f12e",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe0bb1924c17b39b71758f49a00d7c0363b7a318e",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8c7879bf25d678d9949f305857bd4437d74132b9",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe99235a02958637a5e01575297fbba3790dc7f0e",
+      "symbol": "FTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6f32725f82bbb06ffdc04974db437fec1d7af1af",
+      "symbol": "FX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
+    },
+    {
+      "chainId": 130,
+      "address": "0x79301df2117c7f56859fd01b28bbaa61062021d6",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 130,
+      "address": "0x481cb2c560fc3351833b582b92b965626fd8803c",
+      "symbol": "G",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    },
+    {
+      "chainId": 130,
+      "address": "0x70b2b785061d4c91c76cf87692f85b5c443d8675",
+      "symbol": "GAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+    },
+    {
+      "chainId": 130,
+      "address": "0x31a71801291774d267615f74b3a44fceb560fac9",
+      "symbol": "GALA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/standard/GALA-COINGECKO.png?1696512310"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0328a0255866706547b79072dee54976b157d3d0",
+      "symbol": "GFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4ae5712a153fdfde81c305ff7f2e4e59840ad24b",
+      "symbol": "GHST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321"
+    },
+    {
+      "chainId": 130,
+      "address": "0x04b747f478ae09ac797d026c8402f409e2c9f2b9",
+      "symbol": "GLM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc4c6c3a3043ad5ece5c91290630a7735e125a938",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6e74ea6546e1f21abf581b59114f2bf5d3683f48",
+      "symbol": "GODS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbb2272ffc0ef8f439373adffd45c3591b3204d71",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 130,
+      "address": "0x592620d454a10c47274dbfe3bd922b9a8fe5cf48",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+    },
+    {
+      "chainId": 130,
+      "address": "0xeba12ec786cdc21b4bd5ba601b595b6a5c0920a9",
+      "symbol": "GUSD",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278"
+    },
+    {
+      "chainId": 130,
+      "address": "0xad173f5b5fe39dd1183a0d3c49c57629a574c36f",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
+    },
+    {
+      "chainId": 130,
+      "address": "0x656104f2028bbfd7144c8f71fa15daaa8c34a28b",
+      "symbol": "HFT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26136/large/hashflow-icon-cmc.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x99f64c3db98a4870eff637315d5c86dcb1374879",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc32c0c5a52f36d244c552e45c485cbceaf385b36",
+      "symbol": "HOPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468"
+    },
+    {
+      "chainId": 130,
+      "address": "0x15d0e0c55a3e7ee67152ad7e89acf164253ff68d",
+      "symbol": "HYPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50882/large/hyperliquid.jpg?1729431300"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4ea052bcaee7d7ef2e3d61d601e878a560eabe8e",
+      "symbol": "IDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa76195fa77304bba4cd8946198f5a90e42f3e51f",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/ILV.JPG"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc4fc8cf76883094404ddb875d2af15d1f5aa8053",
+      "symbol": "IMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa5afe7646f07d2c41aa82bb6ae09e99e121e39b7",
+      "symbol": "INDEX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9361ca28625e12c7f088523b274a25059a89f9f8",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd326acab8799fb44c3a5b7f7efbaab5f9f7b54fb",
+      "symbol": "INV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd749094bc62615f0c8645467e241b71ae2b6843f",
+      "symbol": "IOTX",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x428c2b7fa7a7821891fb529bae4d80a71d5c61a8",
+      "symbol": "JAM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8ef0686f380dd07f3e2121831839371922720708",
+      "symbol": "JASMY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
+    },
+    {
+      "chainId": 130,
+      "address": "0x781cc305fcbfe7cde376c9ef5469d5a7e5cab8b2",
+      "symbol": "JUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbe51a5e8fa434f09663e8fb4cce79d0b2381afad",
+      "symbol": "JUP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/34188/standard/jup.png?1704266489"
+    },
+    {
+      "chainId": 130,
+      "address": "0x05dbd720fc26f732c8d42ea89bd7f442ea6afe80",
+      "symbol": "KEEP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
+    },
+    {
+      "chainId": 130,
+      "address": "0x68cea24f675e4f25584607f6c9fefb353f1bbfdc",
+      "symbol": "KEY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb0e4ad2dfe3754e4a2443a7a828eda5bb7cd2284",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9c41547e404942c173e28bb2b6abe4cf5fad6a74",
+      "symbol": "KP3R",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458"
+    },
+    {
+      "chainId": 130,
+      "address": "0x14cffad448aeb0876c56b7aa28999c9a4f002943",
+      "symbol": "KRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2206cdcc9b94ff7db7a9eabec77b5ce430258681",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1201209f55634bddb67034efe4e8aa4d1b7b482c",
+      "symbol": "L3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37768/large/Square.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb34b3de63d22ffc90419c1a439de6c7d46687782",
+      "symbol": "LCX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008"
+    },
+    {
+      "chainId": 130,
+      "address": "0x68a6dbc7214a0f2b0d875963663f1613814e8829",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5a53b6d19d8edcb7923f0d840eebb3f09bbeefb7",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x68648f52b85407806bc1d349b745d13c91be0fdf",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1d1bfcfc6ae6fe045f151c7e589fb241aac89733",
+      "symbol": "LOKA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc68992e0514968bfba3dad201fef91f6009f523c",
+      "symbol": "LOOM",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x11c6b34cadc550b65a9666497d7fcb39f35b73e3",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0176b38b7767451b1b682236ece2fae853c71a60",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa2af802b95d7e20167e5aeac7fe8fdf4a8ab158a",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd7eb7348ba44c5a2f9f1d1d3534623230c7bee3f",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/standard/LRDS_PNG.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf81b7485b4cb59645f74528d702c7f8cd72577fb",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327"
+    },
+    {
+      "chainId": 130,
+      "address": "0x276361c863903751771e9daba6ddfaaf00fe358b",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc42b642f5010a2a3bd3ca2396fe6f2e21b9512c4",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb999b66186d7a48bf0eb5d22f4e7053a99ed2c97",
+      "symbol": "MATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf6ac97b05b3bc92f829c7584b25839906507176b",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 130,
+      "address": "0x460ec1c67e1614bf1feab84b98795bae2d657399",
+      "symbol": "MC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+    },
+    {
+      "chainId": 130,
+      "address": "0x68619bc0c709fb63555fe988ed14e78f7e6acc40",
+      "symbol": "MCO2",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb29fddc20d5e4bace9f54c1d9237953331bfeff4",
+      "symbol": "MDT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
+    },
+    {
+      "chainId": 130,
+      "address": "0x397e34aff8bfc8ec14aa78f378074f6d8e3e7d06",
+      "symbol": "MEME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32528/large/memecoin_(2).png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbfba2a8745e5c85544db7c8824c6962ab3a8f102",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312"
+    },
+    {
+      "chainId": 130,
+      "address": "0x397c1f55feff63c8947624b0d457a2ca3e3602ab",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5fe989eab3021d7e742099d05a7937ba4a72d717",
+      "symbol": "MIR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf7a581f6e26eea790225d76af8821ea34dc3c117",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+    },
+    {
+      "chainId": 130,
+      "address": "0x58d68e179864605fea06eaadf1185c6e78921ebd",
+      "symbol": "MOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xae6065fb0244a68036c82dec9a8de5501c7a1087",
+      "symbol": "MONA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721"
+    },
+    {
+      "chainId": 130,
+      "address": "0xaa2109f14bb155766cba9e7fa8b8d4bf0ff19949",
+      "symbol": "MOVE",
+      "decimals": 8,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/32452.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x587e0e022b074015f4e81eca489c0c41d752a219",
+      "symbol": "MPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+    },
+    {
+      "chainId": 130,
+      "address": "0x71d69d07914d087f1c3536f7a5006a256cfad9ea",
+      "symbol": "MTL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1c3a8fb65ab82d73e26b6403bf505b99d82b4701",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+    },
+    {
+      "chainId": 130,
+      "address": "0x10f109379e231d5c294ee6a5f9abb2f8b40a8dd1",
+      "symbol": "MUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe3d92fb06a4eebac5879d3c1073e0eab81d5f345",
+      "symbol": "MUSE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd6ec6a24d5365a1811b05099f8d353c0ff182974",
+      "symbol": "MV",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xcf7c45ccc1327ac1e9cb9e098898c59402727794",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336"
+    },
+    {
+      "chainId": 130,
+      "address": "0x328ed7736871f863c8216ca6cbb6f29b795032df",
+      "symbol": "NCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc1c06527e810c4a198d8c5d35e1ddbc987696276",
+      "symbol": "Neiro",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
+    },
+    {
+      "chainId": 130,
+      "address": "0x75b93ced9627cd172912304fb79cd3e7336baf62",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
+    },
+    {
+      "chainId": 130,
+      "address": "0x931e587542b8603ea3c6420dd8d3b22edbda20fc",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2aeb5256de25eced47797b82d2f5c404aacea6b9",
+      "symbol": "NU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+    },
+    {
+      "chainId": 130,
+      "address": "0x652293f4e9b0ef61c52a78d6615d9f5f3cd79208",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa60ce8f7ec6a091535b4708569b39df5ee18c880",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5949b9200df1e77878db3d061e43cf878ee37383",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf5614d20c13d5bf2f9e640f00b7b2b76959eb0e3",
+      "symbol": "OMNI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36465/standard/Symbol-Color.png?1711511095"
+    },
+    {
+      "chainId": 130,
+      "address": "0xad0bae21db0b471dffc6f8f9eeacfe9a85321557",
+      "symbol": "ONDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/standard/ONDO.png?1696525656"
+    },
+    {
+      "chainId": 130,
+      "address": "0xcf2050ebc80b74370c1c2b71bdb635d11be3e8c0",
+      "symbol": "ORCA",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x3c5319013fd75976f0f13b0bc0852537b6eaf396",
+      "symbol": "ORN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9775c2b4f245248de5596252ac69311152b98042",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x3614c8d98bf905abe075bfa289231bbc0d292327",
+      "symbol": "PAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
+    },
+    {
+      "chainId": 130,
+      "address": "0xec37cdfc9a692b3ccd5c85696d14aaa31e75d6ac",
+      "symbol": "PDA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14316/standard/PDA-symbol.png?1710234068"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd9b5da95b3d97c3e9872102fdb47d4c09074952b",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5944d2728d5fea7d1f4aa4958e3aebb3ccfec7d5",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd0f77df9a8f0e855f910361f5f59958118d064c6",
+      "symbol": "PIRATE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/standard/_Pirate_Transparent_200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5441619a9754aee0665c939743cf7611abb6f6c7",
+      "symbol": "PLU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf6a49aedbd7861ded0da2be1f21c6954e5682e95",
+      "symbol": "POL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    },
+    {
+      "chainId": 130,
+      "address": "0x82a98121eaf30b0e135b08d4208c837cdc306503",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2f5cfdc89fb96f2cf6c0fb1ca6e3501dd538d863",
+      "symbol": "POLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa2a36541c5a54bd2815985418105091b4d4782d5",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451"
+    },
+    {
+      "chainId": 130,
+      "address": "0x562e588471ca0e710b2b1217867ffb2e0f2a5642",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/standard/portal.jpeg"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf265af514762286a63d015fee382b90edffa6bff",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd17d5f0da4200bbfd3d6626ac6aea2eccbf9fee0",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc6fbf362a12804feca22000f37db5efc1f41a7c9",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc7b7dcf3c6cacaac13f92c9173f9a0060abf3def",
+      "symbol": "PRQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280"
+    },
+    {
+      "chainId": 130,
+      "address": "0x13fe2c4504f3aa18708561250e2f20e4e7d7caa2",
+      "symbol": "PSTAKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930"
+    },
+    {
+      "chainId": 130,
+      "address": "0xadf70dc4aaefbc6d1e7a6cf0b02b0f2138b560d2",
+      "symbol": "PUFFER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/50630/large/puffer.jpg?1728545297"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0d2f98904d88909072ea6e61105cbbf78e6207c5",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
+    },
+    {
+      "chainId": 130,
+      "address": "0x3a8723f2929f370c61eac583d6652e5c98c360d4",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252"
+    },
+    {
+      "chainId": 130,
+      "address": "0x006254c4664c678e64c3265da28304cc8c1068b8",
+      "symbol": "QRDO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb019a038eadcb2f96321d236f6633c8d6bb5eabb",
+      "symbol": "QSP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd815958f92e6abe63437bce166e97027f8e6cac2",
+      "symbol": "QUICK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
+    },
+    {
+      "chainId": 130,
+      "address": "0x3f9a30c86dc7f0c657ea17d52efe09eff08a1a45",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6164a78f7b2ac49cf9b76c49e5b6909e89f34a66",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe8a0078aa52ac7e93ae43818ddd64591e025bb6f",
+      "symbol": "RARE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+    },
+    {
+      "chainId": 130,
+      "address": "0x16f01392ed7fc6f3c345cf544cf1172103c8561c",
+      "symbol": "RARI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
+    },
+    {
+      "chainId": 130,
+      "address": "0x29ea5682024c8c62cd8bdf691c4f0c5d66b403e3",
+      "symbol": "RBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509"
+    },
+    {
+      "chainId": 130,
+      "address": "0x75b2dbb2a7c70073133e42f64366a986c841cd3e",
+      "symbol": "RBN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
+    },
+    {
+      "chainId": 130,
+      "address": "0x560603e0bfc941063d1375ec4e3f9fe38261617e",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x097ca3fc389697080c84148c455ca839b2816fc4",
+      "symbol": "REP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe86b1e5613a5761d005a2d00d8a1b4ad1e72a8c4",
+      "symbol": "REPv2",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9fcc3133779f2039c29908c915b6efae9d8663cd",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc14a68015fa6396ef97b57839da544910f9ca657",
+      "symbol": "REVV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2178f07c1d585c39272caf69a72bef08aad6c9ab",
+      "symbol": "REZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37327/standard/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8c9606001cf1787ceb80e03def3f9baf946cf284",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+    },
+    {
+      "chainId": 130,
+      "address": "0x538fb2719135740b8877607217dc391fb3347acb",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7ad899b7c793743fde692d982f190f443f88c889",
+      "symbol": "RLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077"
+    },
+    {
+      "chainId": 130,
+      "address": "0x965c6debfa700f53a38d42dbaed922c58d649868",
+      "symbol": "RNDR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934"
+    },
+    {
+      "chainId": 130,
+      "address": "0x682b2f07e61022a80ac2753448f7d95e9de41d99",
+      "symbol": "ROOK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506"
+    },
+    {
+      "chainId": 130,
+      "address": "0x993a565a1e6219951323ca3c34cee0a3b1889066",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 130,
+      "address": "0x47b72717e48da346c3f1ed1311c8dcde10efd888",
+      "symbol": "SAFE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27032/standard/Artboard_1_copy_8circle-1.png?1696526084"
+    },
+    {
+      "chainId": 130,
+      "address": "0x6a654a2ec95fb988ea37746dbcca10772caf25ca",
+      "symbol": "SAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7ccc67c7b232aa6417d9422e90d91ec4b32d72e5",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xaa571d01057cdf477d73433d36d86fcb5664158e",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
+    },
+    {
+      "chainId": 130,
+      "address": "0x45bda7ba10dac525a86dbeab3135701a66024f2f",
+      "symbol": "SHPING",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
+    },
+    {
+      "chainId": 130,
+      "address": "0x486bbb6f250343adb4782f50dd09766f8ad20c01",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5a6058002d0d336e5e8860652e7054a6d07074e4",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbd2dd310fecbfb1111fc3262f3a97ba696cb03b3",
+      "symbol": "SLP",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057"
+    },
+    {
+      "chainId": 130,
+      "address": "0x914f7ce2b080b2186159c2213b1e193e265abf5f",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "chainId": 130,
+      "address": "0x022d952abcc6c8271f26e59e37a65dc359e6bc88",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5e03c123d829505f4dea87cf679f77c9dc4627ab",
+      "symbol": "SOCKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4ff3e944d5cb54f6f4a1dd035782be59c3d054fe",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 130,
+      "address": "0xbde8a5331e8ac4831cf8ea9e42e229219eafab97",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54680/large/base.png?1749023388"
+    },
+    {
+      "chainId": 130,
+      "address": "0x739316c7bc4a39eb39dcfa1b181b64abc17fef7f",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
+    },
+    {
+      "chainId": 130,
+      "address": "0x51a7b9a11f10d04c16306d90dc4ec22b036dd629",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
+    },
+    {
+      "chainId": 130,
+      "address": "0x77c8a8e1dd3b5270d3ab589543e9a83319373135",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf13b5b21555092882e69b22282daf891c9951835",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x09f705405677970e509d606348d4635d2332c72e",
+      "symbol": "STRK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26433/standard/starknet.png?1696525507"
+    },
+    {
+      "chainId": 130,
+      "address": "0xef86e70e534e02aadeae95b843973d4acaccea22",
+      "symbol": "STX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc05b416738ddebd14d5a9b790a6e1ce782176525",
+      "symbol": "SUKU",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0c288302629fc22504d59ddf8fbf8aa92bd86d3d",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7251d204c2e867b31096d5c7091298239b3a6a0f",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2982be2d0c6ae4a7d5bc1c8fe7b630e3bdfb3ce5",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 130,
+      "address": "0xa8015cbc9f7c58788ba00854c330f027028a5870",
+      "symbol": "SWELL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+    },
+    {
+      "chainId": 130,
+      "address": "0x0610cdf9856b8825213672981056cd4945af1616",
+      "symbol": "SWFTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022"
+    },
+    {
+      "chainId": 130,
+      "address": "0xdca295e850666753c6332d6b0e0445b09785c2e1",
+      "symbol": "SXP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1baac1979527a38f367c6f89be081abfcffcf85e",
+      "symbol": "SYLO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756"
+    },
+    {
+      "chainId": 130,
+      "address": "0xceb1f5671c47cee096c3b40353863b6781888a48",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8f7f997ba304f426e3138999919c23f68cd6fa96",
+      "symbol": "SYRUP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/51232/standard/IMG_7420.png?1730831572"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8f43ab8648f1a3baeea3782ba5f562a148f2ad54",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340"
+    },
+    {
+      "chainId": 130,
+      "address": "0xfdca15bd55f350a36e63c47661914d80411d2c22",
+      "symbol": "TAO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg?1696527447"
+    },
+    {
+      "chainId": 130,
+      "address": "0xad497996dc33dc8e8e552824ccee199420bc7814",
+      "symbol": "tBTC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd9cbd701bbea8e9aaee7d82aa60748451eda749c",
+      "symbol": "TIME",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666"
+    },
+    {
+      "chainId": 130,
+      "address": "0xd649b9ad2104418b5b032a5899fbcd54a9a46c68",
+      "symbol": "TLM",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5ed5da180bb125f229ab7b825e34d2b936213e0b",
+      "symbol": "TOKE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614"
+    },
+    {
+      "chainId": 130,
+      "address": "0x502865ecdd2a2929aa9418297be7d3c4a7bd5ac6",
+      "symbol": "TONE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1ac70c9e29bc19640e64d938dd8d6a46dbae6f2e",
+      "symbol": "TRAC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8e902fdea73e5cf9621d2bee82cd79196d8ec63b",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
+    },
+    {
+      "chainId": 130,
+      "address": "0x437dd6360bd17fb353c67376371133cd33dacdbd",
+      "symbol": "TRIBE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954"
+    },
+    {
+      "chainId": 130,
+      "address": "0x55c65102c26b173696e935b1325e5aaef30cfe0e",
+      "symbol": "TRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941"
+    },
+    {
+      "chainId": 130,
+      "address": "0x1e4339318ece1d6d9d2fb129b31c06b9f2d202a1",
+      "symbol": "TURBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 130,
+      "address": "0x756fb781389dcaf9d3bc5468927f06a913bd9d5d",
+      "symbol": "TVK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619"
+    },
+    {
+      "chainId": 130,
+      "address": "0x478923278640a10a60951e379affb60772435f8c",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xe9225a870b54f8fba42c8188d211271f0408a30b",
+      "symbol": "UNFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+    },
+    {
+      "chainId": 130,
+      "address": "0x8f187aa05619a017077f5308904739877ce9ea21",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 130,
+      "address": "0x5eaff8fa6f3831bb86feeb701e6f98293e264d36",
+      "symbol": "UPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+    },
+    {
+      "chainId": 130,
+      "address": "0x078d782b760474a361dda0af3839290b0ef57ad6",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2a22868610610199d43fe93a16661473a9f86f1e",
+      "symbol": "USDG",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf7e6430137ef8087e0d472343f358e986de0feff",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/standard/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 130,
+      "address": "0xf37748d2cc6e6d5d05945ce130c03c147b2f3a5f",
+      "symbol": "USDQ",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51852/large/USDQ_1000px_Color.png?1732071232"
+    },
+    {
+      "chainId": 130,
+      "address": "0xac025d055a6b633992de1f796b97b97f004c06a7",
+      "symbol": "USDR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53721/large/stablrusd-logo.png?1737126629"
+    },
+    {
+      "chainId": 130,
+      "address": "0x116ee4d63847fb295dd919ae57b768ea3b2f7bb4",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 130,
+      "address": "0x588ce4f028d8e7b53b687865d6a67b3a54c75518",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x9151434b16b9763660705744891fa906f660ecc5",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 130,
+      "address": "0xc7ba59c95ba747a7c374dc7208a0513798bc5950",
+      "symbol": "USUAL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51091/large/USUAL.jpg?1730035787"
+    },
+    {
+      "chainId": 130,
+      "address": "0x286b5ecea3749c7c7047104aa3c5749901564a0b",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4afd08ac2416450d9c8b84d287dbffb68ffe537f",
+      "symbol": "VGX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb86a08ec917eef9f835ac2b26c3a506c06364a49",
+      "symbol": "WAMPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951"
+    },
+    {
+      "chainId": 130,
+      "address": "0x927b51f251480a681271180da4de28d44ec4afb8",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xae87b8eb5e313ac72b306cba7c1e3f23d72e82c4",
+      "symbol": "WCFG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462"
+    },
+    {
+      "chainId": 130,
+      "address": "0x4200000000000000000000000000000000000006",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x97fadb3d000b953360fd011e173f12cddb5d70fa",
+      "symbol": "WIF",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/33566/standard/dogwifhat.jpg?1702499428"
+    },
+    {
+      "chainId": 130,
+      "address": "0xef22b9df2ddf4246a827575c4aa46bdaefd89e62",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 130,
+      "address": "0x15261eeb999ed3c3ae3c5319e0035940dc06a12f",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054"
+    },
+    {
+      "chainId": 130,
+      "address": "0x139451953ef1865c096f89c5e522c081dc3b5f11",
+      "symbol": "XPL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/plasma/info/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x2615a94df961278dcbc41fb0a54fec5f10a693ae",
+      "symbol": "XRP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ripple/info/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0xb1a9385b500fe81b58c4d0e3aacc39d8021265c3",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 130,
+      "address": "0x43d5ea0f30bce3907aad6783e61d56592aebe4ea",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+    },
+    {
+      "chainId": 130,
+      "address": "0x52bf54eb4210f588320f3e4c151bca81f84a3201",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 130,
+      "address": "0x62ffd4229bb9a327412d1be518a1dbae6c18a07e",
+      "symbol": "YFII",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348"
+    },
+    {
+      "chainId": 130,
+      "address": "0xea20c2cf22acbbf3d8311d15bc73fd7076e36f4b",
+      "symbol": "YGG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691"
+    },
+    {
+      "chainId": 130,
+      "address": "0x83f31af747189c2fa9e5deb253200c505eff6ed2",
+      "symbol": "ZEC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/zcash/info/logo.png"
+    },
+    {
+      "chainId": 130,
+      "address": "0x757dcf360f2fe999faeebcc6e80f5eceb3cb3ca4",
+      "symbol": "Zeta",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/standard/Twitter_icon.png?1696525788"
+    },
+    {
+      "chainId": 130,
+      "address": "0x00ad3704d1e101df76f87738befe67737ed29cfb",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 130,
+      "address": "0x7e7e8e5f0edd7ca2ed3d9609cea1ff37a6e7edf5",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 137,
+      "address": "0xe0b52e49357fd4daf2c15e02058dce6bc0057db4",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 137,
+      "address": "0x0621d647cecbfb64b79e44302c1933cb4f27054d",
+      "symbol": "AMP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
+    },
+    {
+      "chainId": 137,
+      "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xa8b1e0764f85f53dfe21760e8afe5446d82606ac",
+      "symbol": "BAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
+    },
+    {
+      "chainId": 137,
+      "address": "0xc26d47d5c33ac71ac5cf9f776d63ba292a4f7842",
+      "symbol": "BNT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x8505b9d2254a7ae468c0e9dd10ccea3a837aef5c",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x172370d5cd63279efa6d502dab29171933a610af",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x66dc5a08091d1968e08c16aa5b27bac8398b02be",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
+    },
+    {
+      "chainId": 137,
+      "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xbd7a5cf51d22930b8b3df6d834f9bcef90ee7c4f",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 137,
+      "address": "0x5ffd62d3c3ee2e81c00a7b9079fb248e7df024a8",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x5fe2b58c013d7601147dcdd68c143a77499f5531",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 137,
+      "address": "0x42f37a1296b2981f7c3caced84c5096b2eb0c72c",
+      "symbol": "KEEP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
+    },
+    {
+      "chainId": 137,
+      "address": "0x324b28d6565f784d596422b0f2e5ab6e9cfa1dc7",
+      "symbol": "KNC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x66efb7cc647e0efab02eba4316a2d2941193f6b3",
+      "symbol": "LOOM",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x84e1670f61347cdaed56dcc736fb990fbb47ddc1",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
+    },
+    {
+      "chainId": 137,
+      "address": "0x0000000000000000000000000000000000001010",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 137,
+      "address": "0x6f7c932e7684666c9fd1d44527765433e01ff61d",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x0bf519071b02f22c17e7ed5f4002ee1911f46729",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x9880e3dda13c8e7d4804691a45160102d31f6060",
+      "symbol": "OXT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x19782d3dc4701ceeedcd90f0993f0a9126ed89d0",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x6563c1244820cfbd6ca8820fbdf0f2847363f733",
+      "symbol": "REPv2",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x50b728d8d964fd00c2d0aad81718b71311fef68a",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xd72357daca2cf11a5f155b9ff7880e595a3f5792",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xf81b4bec6ca8f9fe7be01ca734f55b2b6e03a7a0",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 137,
+      "address": "0xfdca15bd55f350a36e63c47661914d80411d2c22",
+      "symbol": "TAO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg?1696527447"
+    },
+    {
+      "chainId": 137,
+      "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 137,
+      "address": "0x3066818837c5e6ed6601bd5a91b0762877a6b731",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xb33eaad8d922b1083446dc23f610c2567fb5180f",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 137,
+      "address": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x8de5b80a0c1b02fe4976851d030b36122dbb8624",
+      "symbol": "VANRY",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+    },
+    {
+      "chainId": 137,
+      "address": "0xd0258a3fd00f38aa8090dfee343f10a9d4d30d3f",
+      "symbol": "VOXEL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21260/large/voxies.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 137,
+      "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+      "symbol": "WMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 137,
+      "address": "0xf1815bd50389c46847f0bda824ec8da914045d14",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 137,
+      "address": "0xdc3326e71d45186f113a2f448984ca0e8d201995",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 137,
+      "address": "0xda537104d6a5edd53c6fbba9a898708e465260b6",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 137,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 137,
+      "address": "0x5559edb74751a0ede9dea4dc23aee72cca6be3d5",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 143,
+      "address": "0xea17e5a9efebf1477db45082d67010e2245217f1",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 143,
+      "address": "0x754704bc059f8c67012fed69bc8a327a5aafb603",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 143,
+      "address": "0xe7cd86e13ac4309349f30b3435a9d337750fc82d",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 143,
+      "address": "0x0555e30da8f98308edb960aa94c0db47230d2b9c",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 143,
+      "address": "0xee8c0e9f1bffb4eb878d8f15f368a02a35481242",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 143,
+      "address": "0x01bff41798a0bcf287b996046ca68b395dbc1071",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 196,
+      "address": "0x4ae46a509f6b1d9056937ba4500cb143933d2dc8",
+      "symbol": "USDG",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png?1730484111"
+    },
+    {
+      "chainId": 196,
+      "address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 324,
+      "address": "0x5a7d6b2f92c77fad6ccabd7ee0624e64907eaf3e",
+      "symbol": "ZK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38043/large/ZKTokenBlack.png?17186145029"
+    },
+    {
+      "chainId": 480,
+      "address": "0xfdca15bd55f350a36e63c47661914d80411d2c22",
+      "symbol": "TAO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg?1696527447"
+    },
+    {
+      "chainId": 480,
+      "address": "0x79a02482a880bce3f13e09da970dc34db4cd24d1",
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35218/large/USDC_Icon.png?1707908537"
+    },
+    {
+      "chainId": 480,
+      "address": "0x03c7054bcb39f7b2e5b2c7acb37583e32d70cfa3",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
+    },
+    {
+      "chainId": 480,
+      "address": "0x4200000000000000000000000000000000000006",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 1868,
+      "address": "0xba9986d2381edf1da03b0b9c1f8b00dc4aacc369",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 1868,
+      "address": "0x3a337a6ada9d885b6ad95ec48f9b75f197b5ae35",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 1868,
+      "address": "0x4200000000000000000000000000000000000006",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 4217,
+      "address": "0x20c000000000000000000000b9537d11c60e8b50",
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000b9537d11c60e8b50.svg"
+    },
+    {
+      "chainId": 4217,
+      "address": "0x20c00000000000000000000014f22ca97301eb73",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc5fecc3a29fb57b5024eec8a2239d4621e111cbe",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x63706e401c06ac8513145b7687a14804d17f814b",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe2a8ccb00e328a0ec2204cb0c736309d7c1fa556",
+      "symbol": "ABT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3c87e7af3cdbae5bb56b4936325ea95ca3e0efd9",
+      "symbol": "ADX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/847/thumb/Ambire_AdEx_Symbol_color.png?1655432540"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
+      "symbol": "AERO",
+      "decimals": 18,
+      "logoURI": "https://basescan.org/token/images/aerodrome_32.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
+      "symbol": "AIXBT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51784/large/3.png?1731981138"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd993935e13851dd7517af10687ec7e5022127228",
+      "symbol": "APXUSD",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102172243/large/apxUSD.png?1772448502"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x449b3317a6d1efb1bc3ba0700c9eaa4ffff4ae65",
+      "symbol": "AUDD",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x696f9436b67233384889472cd7cd58a6fb5df4f1",
+      "symbol": "AVNT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68972/large/avnt-token.png?1757134448"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1b4617734c43f6159f3a70b7e06d883647512778",
+      "symbol": "AWE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/8713/large/awe-network.jpg?1747816016"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb3b32f9f8827d4634fe7d973fa1034ec9fddb3b3",
+      "symbol": "B3",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54287/large/B3.png?1739001374"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf5dbaa3dfc5e81405c7306039fb037a3dcd57ce2",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2a06a17cbc6d0032cac2c6696da90f29d39a1a29",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
+      "symbol": "BNKR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52626/large/bankr-static.png?1736405365"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1f9bd96ddb4bd07d6061f8933e9ba9ede9967550",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa7d68d155d17cb30e311367c2ef1e82ab6022b67",
+      "symbol": "BTRST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcbada732173e39521cdbe8bf59a6dc85a9fc7b8c",
+      "symbol": "cbADA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66647/large/Coinbase_Wrapped_Ada_%28cbADA%29.png?1750129533"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/standard/cbbtc.webp"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcbd06e5a2b0c65597161de254aa074e489deb510",
+      "symbol": "CBDOGE",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66268/large/Coinbase_Wrapped_Doge_%28cbDOGE%29.png?1749023465"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/cbETH/logo.svg"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcb17c9db87b595717c857a08468793f5bab6445f",
+      "symbol": "cbLTC",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66646/large/Coinbase_Wrapped_Litecoin_%28cbLTC%29.png?1750129508"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xcb585250f852c6c6bf90434ab21a00f02833a4af",
+      "symbol": "cbXRP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66267/large/Coinbase_Wrapped_XPR_%28cbXRP%29.png?1749023398"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9126236476efba9ad8ab77855c60eb5bf37586eb",
+      "symbol": "CHECK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69231/large/VgVwfk9E_400x400.png?1761800742"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0c1c1c109fe34733fca54b82d7b46b75cfb71f6e",
+      "symbol": "CHIP",
+      "decimals": 18
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
+      "symbol": "CLANKER",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51440/large/CLANKER.png?1731232869"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/COMP/logo.svg"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+      "symbol": "COOKIE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38450/large/cookie_token_logo_200x200.png?1733194528"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/DAI/logo.svg"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+      "symbol": "DEGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf4d97f2da56e8c3098f3a8d538db630a2606a024",
+      "symbol": "DIEM",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68436/large/DIEM_SeaMid_-_200px.png?1755734213"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6921b130d297cc43754afba22e5eac0fbf8db75b",
+      "symbol": "doginme",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35123/large/doginme-logo1-transparent200.png?1710856784"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb38266e0e9d9681b77aeb0a280e98131b953f865",
+      "symbol": "DOVU",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9d0e8f5b25384c7310cb8c6ae32c8fbeb645d083",
+      "symbol": "DRV",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xed6e000def95780fb89734c07ee2ce9f6dcaf110",
+      "symbol": "EDGE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55072/large/EDGE-120x120.png?1743598652"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x29cc30f9d113b356ce408667aa6433589cecbdca",
+      "symbol": "ELSA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71623/large/Red_circle_white_logo_512x512_%281%29.png?1768570174"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/standard/euro.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb33ff54b9f7242ef1593d2c9bcd8f9df46c77935",
+      "symbol": "FAI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52315/large/FAI.png?1733076295"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd08a2917653d4e460893203471f0000826fb4034",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x74f804b4140ee70830b3eef4e690325841575f89",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5ab3d4c385b400f3abb49e80de2faf6a88a7b691",
+      "symbol": "FLOCK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53178/large/FLock_Token_Logo.png?1735561398"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x61e030a56d33e8260fdd81f03b162a79fe3449cd",
+      "symbol": "FLUID",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/14688/large/Logo_1_(brighter).png?1734430693"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb008bdcf9cdff9da684a190941dc3dca8c2cdd44",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7588310a7abf34dc608ac98a1c4432f85e194df5",
+      "symbol": "FORT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x968b2323d4b005c7d39c67d31774fe83c9943a60",
+      "symbol": "FORTH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x16ee7ecac70d1028e7712751e2ee6ba808a7dd92",
+      "symbol": "FUN1",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71076/large/sport-fun-logo.png?1766298060"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4bfaa776991e85e5f8b1255461cbbd216cfc714f",
+      "symbol": "HOME",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54873/large/defi-app.png?1742235743"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4",
+      "symbol": "HYPER",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55298/large/Hyperlane.png?1745248900"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xe0cd4cacddcbf4f36e845407ce53e87717b6601d",
+      "symbol": "ICNT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55484/large/ICNT_token_%281%29_%281%29.png?1751614146"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x98d0baa52b2d063e780de12f615f963fe8537553",
+      "symbol": "KAITO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54411/large/Qm4DW488_400x400.jpg?1739552780"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd5390300c5db71f80d46f0fa9983fc72d4d1e3da",
+      "symbol": "KAT",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/38769.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9a26f5433671751c3276a065f57e5a02d2817973",
+      "symbol": "KEYCAT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36608/large/keyboard_cat.jpeg?1711965348"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc0634090f2fe6c6d75e61be2b949464abb498973",
+      "symbol": "KTA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54723/large/2025-03-05_22.53.06.jpg?1741234207"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9eadbe35f3ee3bf3e28180070c429298a1b02f93",
+      "symbol": "LMTS",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69506/large/limitless.png?1758786338"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5259384690acf240e9b0a8811bd0ffbfbddc125c",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x0d760ee479401bb4c40bdb7604b329fff411b3f2",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xb676f87a6e701f0de8de5ab91b56b66109766db1",
+      "symbol": "LRDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/34775/standard/LRDS_PNG.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac485391eb2d7d88253a7f1ef18c37f4242d1a24",
+      "symbol": "LSK",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x368181499736d0c0cc614dbb145e2ec1ac86b8c6",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x7300b37dfdfab110d83290a29dfb31b1740219fe",
+      "symbol": "MAMO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55958/large/Mamo_Circle_200x200_TransBG.png?1748974093"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x8e4cbbcc33db6c0a18561fde1f6ba35906d4848b",
+      "symbol": "MEZO",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39727.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x9cb41fd9dc6891bae8187029461bfaadf6cc0c69",
+      "symbol": "NOICE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55981/large/tCtKSYL3_400x400.jpg?1747925133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xca73ed1815e5915489570014e024b7ebe65de679",
+      "symbol": "ODOS",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52914/large/odos.jpg?1734678948"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfbc2051ae2265686a469421b2c5a2d5462fbf5eb",
+      "symbol": "OPG",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102172863/large/coingecko_logo.png?1776349115"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x30c7235866872213f68cb1f08c37cb9eccb93452",
+      "symbol": "PROMPT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55169/large/wayfinder.jpg?1744336900"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5c97d726bf5130ae15408ce32bc764e458320d2f",
+      "symbol": "QUAI",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/22354.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1aa8fd5bcce2231c6100d55bf8b377cff33acfc3",
+      "symbol": "RAVE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70544/large/coin.jpeg?1762452940"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1f16e03c1a5908818f47f6ee7bb16690b40d0671",
+      "symbol": "RECALL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69994/large/recall-logo.jpeg?1760337415"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xff8104251e7761163fac3211ef5583fb3f8583d6",
+      "symbol": "REPPO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70797/large/h-rOp1hB_400x400_%281%29.jpg?1763879875"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0",
+      "symbol": "RNBW",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69445/large/RNBW-200px.png?1770053251"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1f73eaf55d696bffa9b0ea16fa987b93b0f4d302",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfbb75a59193a3525a8825bebe7d4b56899e2f7e1",
+      "symbol": "RSC",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28146/large/RH_BOTTLE_CLEAN_Aug_2024_1.png?1732742001"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xab36452dbac151be02b16ca17d8919826072f64a",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc729777d0470f30612b1564fd96e8dd26f5814e3",
+      "symbol": "SAPIEN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68423/large/logo.png?1755710030"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd67ec255100ef200a439d09ff865fbaa2ad9c730",
+      "symbol": "SCOR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71138/large/Scor_logo.jpg?1765957578"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1c7a460413dd4e964f96d8dfc56e7223ce88cd85",
+      "symbol": "SEAM",
+      "decimals": 18,
+      "logoURI": "https://basescan.org/token/images/seamless_32.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x868fced65edbf0056c4163515dd840e9f287a4c3",
+      "symbol": "SIGN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55303/large/sign.jpg?1745303393"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x662015ec830df08c0fc45896fab726542e8ac09e",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x22e6966b799c4d5b13be962e1d117b56327fda66",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x50da645f148798f68ef2d7db7c1cb22a6819bb2c",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa69f80524381275a7ffdb3ae01c54150644c8792",
+      "symbol": "SUP",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68697/large/sup.png?1756287343"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x11dc28d01984079b7efe7763b533e6ed9e3722b9",
+      "symbol": "SYND",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69122/large/synd.png?1757576144"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfdca15bd55f350a36e63c47661914d80411d2c22",
+      "symbol": "TAO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg?1696527447"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x09be1692ca16e06f536f0038ff11d1da8524adb1",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
+      "symbol": "TOSHI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31126/large/Toshi_Logo_-_Circular.png?1721677476"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x00000000a22c618fd6b4d7e9a335c4b96b189a38",
+      "symbol": "TOWNS",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55230/large/yImUvwK__400x400.png?1744857671"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6cd905df2ed214b22e0d48ff17cd4200c1c6d8a3",
+      "symbol": "TRUST",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55976/large/intuition_trust.jpg?1747904133"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xc3de830ea07524a0761646a6a4e4be0e114a3c83",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/UNI/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x5b2193fdc451c1f847be09ca9d13a4bf60f8c86b",
+      "symbol": "UP",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70945/large/superform.png?1764747920"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
+      "symbol": "USDbC",
+      "decimals": 6,
+      "logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf",
+      "symbol": "VVV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/54023/standard/Venice_Token_(1).png?1738017546"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x489fe42c267fe0366b16b0c39e7aeef977e841ef",
+      "symbol": "WAMPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xef4461891dfb3ac8572ccf7c794664a8dd927945",
+      "symbol": "WCT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xa88594d404727625a9437c3f886c7643872296ae",
+      "symbol": "WELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26133/large/WELL.png?1696525221"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x4200000000000000000000000000000000000006",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/WETH/logo.png"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3e31966d4f81c72d2a55310a6365a56a4393e98d",
+      "symbol": "WMTX",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17333/large/Token_icon_round_1024.png?1741247846"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xd7b99ffb8b2afc6fe013a17207cbe50f223adc94",
+      "symbol": "XYO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+    },
+    {
+      "chainId": 8453,
+      "address": "0xf43eb8de897fbc7f2502483b2bef7bb9ea179229",
+      "symbol": "ZEN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/691/large/Horizen2.0-logo_icon-on-yellow_%281%29.png?1751696763"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x1111111111166b7fe7bd91427724b487980afc69",
+      "symbol": "ZORA",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54693/large/zora.jpg?1741094751"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 8453,
+      "address": "0x3bb4445d30ac020a84c1b5a8a2c6248ebc9779d0",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://ethereum-optimism.github.io/data/ZRX/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6314c31a7a1652ce482cffe247e9cb7c3f4bb9af",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xba5ddd1f9d7f570dc94a51479a000e3bce967196",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53691596d1bce8cea565b84d4915e69e03d9c99d",
+      "symbol": "ACX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x377c1fc73d4d0f5600cd943776ced07c2b9783cd",
+      "symbol": "AEVO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35893/standard/aevo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb7910e8b16e63efd51d5d1a093d56280012a3b9c",
+      "symbol": "AGLD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xec76e8fe6e2242e6c2117caa244b9e2de1569923",
+      "symbol": "AIOZ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe7dcd50836d0a28c959c72d72122fedb8e245a6c",
+      "symbol": "ALEPH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef6124368c0b56556667e0de77ea008dfc0a71d1",
+      "symbol": "ALI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc9cbf102c73fb77ec14f8b4c8bd88e050a6b2646",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bfc5d35bf0f7b9e15dc24c78b8c02dbc1e95447",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x74885b4d524d497261259b38900f54e6dbad2210",
+      "symbol": "APE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf01db12f50d0cdf5fe360ae005b9c52f92ca7811",
+      "symbol": "API3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "symbol": "ARB",
+      "decimals": 18,
+      "logoURI": "https://arbitrum.foundation/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdac5094b7d59647626444a4f905060fcda4e656e",
+      "symbol": "ARKM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30929/standard/Arkham_Logo_CG.png?1696529771"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xac9ac2c17cdfed4abc80a53c5553388575714d03",
+      "symbol": "ATA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc7def82ba77baf30bbbc9b6162dc075b49092fb4",
+      "symbol": "ATH",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_(1).png?1718232706"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe88998fb579266628af6a03e3821d5983e5d0089",
+      "symbol": "AXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfa641051ba0a0ad1b0acf549a89536a0d76472e",
+      "symbol": "BADGER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+      "symbol": "BAL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3450687ef141dcd6110b77c2dc44b008616aee75",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
+      "symbol": "BICO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x406c8db506653d882295875f633bec0beb921c2a",
+      "symbol": "BIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf7e17ba61973bcdb61f471efb989e47d13bd565d",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef171a5ba71348eff16616fd692855c2fe606eb2",
+      "symbol": "BLUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7a24159672b83ed1b89467c9d6a99556ba06d073",
+      "symbol": "BNT",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0d81e50bc677fa67341c44d7eaa9228dee64a4e1",
+      "symbol": "BOND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x31190254504622cefdfa55a7d3d272e6462629a2",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcdc343ebf71e38f003ed6c80171f5b8d7cf58860",
+      "symbol": "CAKE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/40143/large/cbbtc.webp"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1debd73e752beaf79865fd6446b0c970eae7732f",
+      "symbol": "cbETH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e51ac49bc5e2d87e0ef713e9e5ab2d71ef4f336",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a8b787f78d775aecfeea15706d4221b40f345ab",
+      "symbol": "CELR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x354a6da3fcde098f8389cad84b0182725c6c91de",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6fe14d3cc2f7bddffba5cdb3bbe7467dd81ea101",
+      "symbol": "COTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04",
+      "symbol": "COW",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x69b937db799a9becc9e8a6f0a5d36ea3657273bf",
+      "symbol": "CQT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8ea3156f834a0dfc78f1a5304fac2cda676f354c",
+      "symbol": "CRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+      "symbol": "CRV",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x319f865b287fcc10b30d8ce6144e8b6d1b476999",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x84f5c2cfba754e76dd5ae4fb369cfc920425e12b",
+      "symbol": "CTX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9dffb23cad3322440bccff7ab1c58e781ddbf144",
+      "symbol": "CVC",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaafcfd42c9954c6689ef1901e03db742520829c5",
+      "symbol": "CVX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3be7cb2e9413ef8f42b4a202a0114eb59b64e227",
+      "symbol": "DEXT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca642467c6ebe58c13cb4a7091317f34e17ac05e",
+      "symbol": "DIA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe3696a02b2c9557639e29d829e9c45efa49ad47a",
+      "symbol": "DNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4667cf53c4edf659e402b733bea42b18b68dd74c",
+      "symbol": "DPI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x77b7787a09818502305c95d68a2571f090abb135",
+      "symbol": "DRV",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x51863cb90ce5d6da9663106f292fa27c8cc90c5a",
+      "symbol": "DYDX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x606c3e5075e5555e79aa15f1e9facb776f96c248",
+      "symbol": "EIGEN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3e4cff6e50f37f731284a92d44ae943e17077fd4",
+      "symbol": "ELON",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8",
+      "symbol": "ENA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/36530/standard/ethena.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7fa9549791efc9030e1ed3f25d18014163806758",
+      "symbol": "ENJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfea31d704deb0975da8e77bf13e04239e70d7c28",
+      "symbol": "ENS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2354c8e9ea898c751f1a15addeb048714d667f96",
+      "symbol": "ERN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3b8db18e69d6686ad9371a423afe3dd1065c94f1",
+      "symbol": "ESP",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67626/large/espresso.jpg?1753324525"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x07d65c18cecba423298c0aeb5d2beded4dfd5736",
+      "symbol": "ETHFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35958/standard/etherfi.jpeg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x863708032b5c328e11abcbc0df9d79c71fc52a48",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8553d254cb6934b16f87d2e486b64bbd24c83c70",
+      "symbol": "FARM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4be87c766a7ce11d5cc864b6c3abb7457dcc4cc9",
+      "symbol": "FET",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x849b40ab2469309117ed1038c5a99894767c7282",
+      "symbol": "FIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa8c25fdc09763a176353cc6a76882e05b4905fae",
+      "symbol": "FLOKI",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x63806c056fa458c548fb416b15e358a9d685710a",
+      "symbol": "FLUX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a1429d50e0cbbc45c997af600541fe1cc3d2923",
+      "symbol": "FORT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+      "symbol": "FOX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7468a5d8e02245b00e8c0217fce021c70bc51305",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd42785d323e608b9e99fa542bd8b1000d4c2df37",
+      "symbol": "FTM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd9f9d2ee2d3efe420699079f16d9e924afffdea4",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc27e7325a6bea1fcc06de7941473f5279bfd1182",
+      "symbol": "GAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2a676eead159c4c8e8593471c6d666f02827ff8c",
+      "symbol": "GALA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12493/standard/GALA-COINGECKO.png?1696512310"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+      "symbol": "GMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1631532468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa0b862f60edef4452f25b4160f177db44deb6cf1",
+      "symbol": "GNO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9623063377ad1b27544c965ccd7342f7ea7e88c7",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f9a7db853ca816b9a138aee3380ef34c437dee0",
+      "symbol": "GTC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x589d35656641d6ab57a545f08cf473ecd9b6d5f7",
+      "symbol": "GYEN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd12eeb0142d4efe7af82e4f29e5af382615bceea",
+      "symbol": "HIGH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x177f394a3ed18faa85c1462ae626438a70294ef7",
+      "symbol": "HOPR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x68731d6f14b827bbcffbebb62b19daa18de1d79c",
+      "symbol": "IDOS",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39596.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x61ca9d186f6b9a793bc08f6c79fd35f205488673",
+      "symbol": "ILV",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14468/large/ILV.JPG"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3cfd99593a7f035f717142095a3898e3fca7783e",
+      "symbol": "IMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2a2053cb633cad465b4a8975ed3d7f09df608f80",
+      "symbol": "INJ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x25f05699548d3a0820b99f93c10c8bb573e27083",
+      "symbol": "JASMY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x010700ab046dd8e92b0e3587842080df36364ed3",
+      "symbol": "K",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/54964/standard/k200.png?1742894885"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf75ee6d319741057a82a88eeff1dbafab7307b69",
+      "symbol": "KRL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+      "symbol": "KUJI",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf03a553fbcb2f52daae15170347830e5d3d16096",
+      "symbol": "L3",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37768/large/Square.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
+      "symbol": "LDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x349fc93da004a63f3b1343361465981330a40b25",
+      "symbol": "LIT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13825/large/logo_200x200.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x289ba1701c2f088cf0faf8b3705246331cb8a839",
+      "symbol": "LPT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfb9e5d956d889d91a82737b9bfcdac1dce3e1449",
+      "symbol": "LQTY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x46d0ce7de6247b0a95f67b43b589b4041bae7fbe",
+      "symbol": "LRC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
+      "symbol": "LUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "logoURI": "https://dynamic-assets.coinbase.com/30320a63f6038b944c9c0202fcb2392e6a1bd333814f74b4674774dd87f2d06d64fdd74c2f1ab4639917c75b749c323450408bec7a2737af8ae0c17871aa90de/asset_icons/98d278cda11639ed7449a0a3086cd2c83937ce71baf4ee43bb5b777423c00a75.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x442d24578a564ef628a65e6a7e3e7be2a165e231",
+      "symbol": "MANA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x533a7b414cd1236815a5e09f1e97fc7d5c313739",
+      "symbol": "MASK",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x99f40b01ba9c469193b360f72740e416b17ac332",
+      "symbol": "MATH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x561877b6b3dd7651313794e5f2894b2f18be0766",
+      "symbol": "MATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f728f3595db17b0b359f4fc47ae80fad2e33769",
+      "symbol": "METIS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb20a02dffb172c474bc4bda3fd6f4ee70c04daf2",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2e9a6df78e42a30712c10a9dc4b1c8656f8f2879",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8f5c1a99b1df736ad685006cb6adca7b7ae4b514",
+      "symbol": "MLN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9c1a1c7ba9c2602123fd7ef3eb41a769edf6c53a",
+      "symbol": "MNT",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30980/large/Mantle-Logo-mark.png?1739213200"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x96c42662820f6ea32f0a61a06a38a72b206aabac",
+      "symbol": "MOG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe390c0b46bd723995be02640e6f1e1c802f620ac",
+      "symbol": "MORPHO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x29024832ec3babf5074d4f46102aa988097f0ca0",
+      "symbol": "MPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7b9b94aebe5e2039531af8e31045f377ecd9a39a",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5445972e76c5e4cedd12b6e2bcef69133e15992f",
+      "symbol": "MV",
+      "decimals": 18,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x91b468fe3dce581d7a6cfe34189f1314b6862ed6",
+      "symbol": "MXC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53236015a675fcb937485f1ae58040e4fb920d5b",
+      "symbol": "NCT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbe06ca305a5cb49abf6b1840da7c42690406177b",
+      "symbol": "NKN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x597701b32553b9fa473e21362d480b3a6b569711",
+      "symbol": "NMR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x933d31561e470478079feb9a6dd2691fad8234df",
+      "symbol": "OCEAN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6feb262feb0f775b5312d2e009923f7f58ae423e",
+      "symbol": "OGN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe7bef5cc7750820516162f5f5b520e9aa510a466",
+      "symbol": "OKB",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1696505053"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd962c1895c46ac0378c502c207748b7061421e8e",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa2d52a05b8bead5d824df54dd1aa63188b37a5e7",
+      "symbol": "ONDO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26580/standard/ONDO.png?1696525656"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bdcc2075d5370293e248cab0173ec3e551e6218",
+      "symbol": "ORN",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x35e6a59f786d9266c7961ea28c7b768b33959cbb",
+      "symbol": "PEPE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6d78bc9ebc2431861b2928bb2af52bdd10baddd7",
+      "symbol": "PEPECOIN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30219/large/pepecoin-icon_200x200.png?1735790725"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x753d224bcf9aafacd81558c32341416df61d3dac",
+      "symbol": "PERP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xac7ce9f2794e01c0d27b096c52f592e343d77cbf",
+      "symbol": "PIRATE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/38524/standard/_Pirate_Transparent_200x200.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x73efdc761596328461b68e5fc58c3284cb15ba13",
+      "symbol": "PLUME",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53623/large/plume-token.png?1736896935"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x044d8e7f3a17751d521efea8ccf9282268fe08cc",
+      "symbol": "POL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xeeeb5eac2db7a7fc28134aa3248580d48b016b64",
+      "symbol": "POLS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe12f29704f635f4a6e7ae154838d21f9b33809e9",
+      "symbol": "POLY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xda0a57b710768ae17941a9fa33f8b720c8bd9ddd",
+      "symbol": "POND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6380f3d0c1412a80eb00f49064da30749db991de",
+      "symbol": "PORTAL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35436/standard/portal.jpeg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4e91f2af1ee0f84b529478f19794f5afd423e4a6",
+      "symbol": "POWR",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x8d8e1b6ffc6832e8d2ef0de8a3d957cae7ac5067",
+      "symbol": "PRIME",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x631a64e240180d4b604f736cb6e19c1a7ec77254",
+      "symbol": "PRO",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82164a8b646401a8776f9dc5c8cba35dcaf60cd2",
+      "symbol": "PRQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x327006c8712fe0abdbbd55b7999db39b0967342e",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc7557c73e0eca2e1bf7348bb6874aee63c7eff85",
+      "symbol": "QNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3c45038f4807c5bb72f6bc72c2a2b9c012155e49",
+      "symbol": "RAD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaef5bbcbfa438519a5ea80b4c7181b4e78d419f2",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x25118290e6a5f4139381d072181157035864099d",
+      "symbol": "RAIN",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69134/large/Rain_logo_1_.png?1762952191"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcf78572a8fe97b2b9a4b9709f6a7d9a863c1b8e0",
+      "symbol": "RARI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2e9ae8f178d5ea81970c7799a377b3985cbc335f",
+      "symbol": "RBC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9fa891e1db0a6d1eeac4b929b5aae1011c79a204",
+      "symbol": "REN",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1cb5bbc64e148c5b889e3c667b49edf78bb92171",
+      "symbol": "REQ",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xef888bca6ab6b1d26dbec977c455388ecd794794",
+      "symbol": "RGT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe575586566b02a16338c199c23ca6d295d794e66",
+      "symbol": "RLC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc8a4eea31e9b6b61c406df013dd4fec76f21e279",
+      "symbol": "RNDR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb766039cc6db368759c1e56b79affe831d0cc507",
+      "symbol": "RPL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xca5ca9083702c56b481d1eec86f1776fdbd2e594",
+      "symbol": "RSR",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd1318eb19dbf2647743c720ed35174efd64e3dac",
+      "symbol": "SAND",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1629c4112952a7a377cb9b8d7d8c903092f34b63",
+      "symbol": "SD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5033833c9fe8b9d3e09eed2f73d2aaf7e3872fd1",
+      "symbol": "SHIB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4f9b7dedd8865871df65c5d26b1c2dd537267878",
+      "symbol": "SKL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd43f10ce4bc089782ff8635c17f015edbc16d71b",
+      "symbol": "SKY",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x707f635951193ddafbb40971a0fcaab8a6415160",
+      "symbol": "SNT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcba56cd8216fcbbf3fa6df6137f3147cbca37d60",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb2be52744a804cc732d606817c2572c5a3b264e7",
+      "symbol": "SOCKS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xb74da9fe2f96b9e0a5f4a3cf0b92dd2bec617124",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x3e6648c5a70a150a88bce65f4ad4d506fe15d2af",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x53e70cc1d527b524a1c46eaa892e4cb35d2ba901",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1337420ded5adb9980cfc35f8f2b054ea86f8ab1",
+      "symbol": "SQD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/37869/standard/New_Logo_SQD_Icon.png?1720048443"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe018c7a3d175fb0fe15d70da2c874d3ca16313ec",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xe6320ebf209971b4f4696f7f0954b8457aa2fcc2",
+      "symbol": "STORJ",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7f9cf5a2630a0d58567122217df7609c26498956",
+      "symbol": "SUPER",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa970af1a584579b618be4d69ad6f73459d112f95",
+      "symbol": "sUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd4d42f0b6def4ce0383636770ef773390d85c61a",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2c96be2612bec20fe2975c3acfcbbe61a58f2571",
+      "symbol": "SWELL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1bcfc0b4ee1471674cd6a9f6b363a034375ead84",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0945cae3ae47cb384b2d47bc448dc6a9dec21f55",
+      "symbol": "T",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7e2a1edee171c5b19e6c54d73752396c0a572594",
+      "symbol": "tBTC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x0419e8bfbbb2623728c3a6129090da4ff4e48113",
+      "symbol": "TEL",
+      "decimals": 2,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/1899/large/tel.png?1696502892"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd58d345fd9c82262e087d2d0607624b410d88242",
+      "symbol": "TRB",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbfae6fecd8124ba33cbb2180aab0fe4c03914a5a",
+      "symbol": "TRIBE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x5c816d4582c857dcadb1bb1f62ad6c9dede4576a",
+      "symbol": "TURBO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xd693ec944a85eeca4247ec1c3b130dca9b0c3b22",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7550de0a4b9fb8caba8c32e72ee356afdd217a33",
+      "symbol": "USD1",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+      "symbol": "USDC.e",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x78df3a6044ce3cb1905500345b967788b699df8f",
+      "symbol": "USDP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/6013/standard/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6491c05a82219b8d1479057361ff1654749b876b",
+      "symbol": "USDS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x7639ab8599f1b417cbe4ced492fb30162140abbb",
+      "symbol": "USUAL",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51091/large/USUAL.jpg?1730035787"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x1c8ec4de3c2bfd3050695d89853ec6d78ae650bb",
+      "symbol": "WAMPL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x4d1d7134b87490ae5eebdb22a5820d7d0e1980bf",
+      "symbol": "WLFI",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50767/large/wlfi.png?1756438915"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xcafcd85d8ca7ad1e1c6f82f651fa15e33aefd07b",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x9b86f3c7d145979ec6b2f42ed7f92d06cfc6c9d3",
+      "symbol": "XAUT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x40461291347e1ecbb09499f3371d3f17f10d7159",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x58bbc087e36db40a84b22c1b93a042294deeafed",
+      "symbol": "XCN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xa05245ade25cc1063ee50cf7c083b4524c1c4302",
+      "symbol": "XSGD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x82e3a8f066a6989666b031d916c43672085b1582",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6ddbbce7858d276678fc2b36123fd60547b88954",
+      "symbol": "Zeta",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/26718/standard/Twitter_icon.png?1696525788"
+    },
+    {
+      "chainId": 42161,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 42161,
+      "address": "0xbd591bd4ddb64b77b5f76eab8f03d02519235ae2",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0xd629eb00deced2a080b7ec630ef6ac117e614f1b",
+      "symbol": "BTC",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_WBTC.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0x471ece3750da237f93b8e339c536989b8978a438",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0x2def4285787d58a2f811af24755a8150622f4361",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 42220,
+      "address": "0xaf37e8b6c9ed7f6318979f56fc287d76c30847ff",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xd501281565bf7789224523144fe5d98e8b28f267",
+      "symbol": "1INCH",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x63a72806098bd3d9520cc43356dd78afe5d386d9",
+      "symbol": "AAVE",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xaec8318a9a59baeb39861d10ff6c7f7bf1f96c57",
+      "symbol": "agEUR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19479/standard/agEUR.png?1696518915"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x2147efff675e4a4ee1c2f918d181cdbd7a8e208f",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x20cf1b6e9d856321ed4686877cf4538f2c84b4de",
+      "symbol": "ANKR",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x44c784266cf024a60e8acf2427b9857ace194c5d",
+      "symbol": "AXL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x98443b96ea4b0858fdf3219cd13e98c7a4690588",
+      "symbol": "BAT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
+      "symbol": "BUSD",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xc3048e19e76cb9a3aa9d77d8c03c29fc906e2437",
+      "symbol": "COMP",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x6b289cceaa8639e3831095d75a3e43520fabf552",
+      "symbol": "CTSI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+      "symbol": "DAI.e",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0xd586E7F844cEa2F87f50152665BCbc2C279D8d70/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x961c8c0b1aad0c0b10a51fef6a867e3091bcef17",
+      "symbol": "DYP",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xc891eb4cbdeff6e073e859e987815ed1505c2acd",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26045/standard/euro.png?1696525125"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xc4b06f17eccb2215a5dbf042c672101fc20daf55",
+      "symbol": "FLUX",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xd24c2ad096400b6fbcd2ad8b24e7acbc21a1da64",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x214db107654ff987ad859f34125307783fc8e387",
+      "symbol": "FXS",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x62edc0692bd897d2295872a9ffcac5425011c661",
+      "symbol": "GMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1631532468"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x8a0cac13c7da965a312f08ea4229c37869e85cb9",
+      "symbol": "GRT",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x26debd39d5ed069770406fca10a0e4f8d2c743eb",
+      "symbol": "GUN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/55027/standard/gunz.jpg?1743262298"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x5947bb275c521040051d82396192181b413227a3",
+      "symbol": "LINK",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x130966628846bfd36ff31a822705796e8cb8c18d",
+      "symbol": "MIM",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x88128fd4b259552a9a1d457f435a6527aab72d42",
+      "symbol": "MKR",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",
+      "symbol": "MULTI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xfb98b335551a418cd0737375a2ea0ded62ea213b",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x97cd1cfe2ed5712660bb6c14053c0ecb031bff7d",
+      "symbol": "RAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xbec243c995409e6520d7c41e404da5deba4b209b",
+      "symbol": "SNX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xfe6b19286885a4f7f55adad09c3cd1f906d2478f",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xce1bffbd5374dac86a2893119683f4911a2f7814",
+      "symbol": "SPELL",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590",
+      "symbol": "STG",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x37b608519f91f70f2eeb0e5ed9af4061722e4f76",
+      "symbol": "SUSHI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x1f1e7c893855525b303f99bdf5c3c05be09ca251",
+      "symbol": "SYN",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xfdca15bd55f350a36e63c47661914d80411d2c22",
+      "symbol": "TAO",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg?1696527447"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x3bd2b1c7ed8d396dbb98ded3aebb41350a5b2339",
+      "symbol": "UMA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x8ebaf22b6f053dffeaf46f4dd9efa95d89ba8580",
+      "symbol": "UNI.e",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0x8eBAf22B6F053dFFeaf46f4Dd9eFA95D89ba8580/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+      "symbol": "WAVAX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x50b7545627a5162f82a992c33b87adc75187b218",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0xabc9547b534519ff73921b1fba6e672b5f58d083",
+      "symbol": "WOO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x2775d5105276781b4b85ba6ea6a6653beed1dd32",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x9eaac1b23d935365bd7b542fe22ceee2922f52dc",
+      "symbol": "YFI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+      "symbol": "ZRO",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x596fa47043f99a4e0f122243b841e55375cde0d2",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
+    },
+    {
+      "chainId": 80001,
+      "address": "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 80001,
+      "address": "0x9c3c9283d3e44854697cd22d3faa240cfb032889",
+      "symbol": "WMATIC",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    },
+    {
+      "chainId": 81457,
+      "address": "0xb1a5700fa2358173fe465e6ea4ff52e36e88e2ad",
+      "symbol": "BLAST",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/35494/standard/Blast.jpg?1719385662"
+    },
+    {
+      "chainId": 7777777,
+      "address": "0xcccccccc7021b32ebb4e8c08314bd62f7c653ec4",
+      "symbol": "USDzC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/35218/large/USDC_Icon.png?1707908537"
+    },
+    {
+      "chainId": 11155111,
+      "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      "symbol": "UNI",
+      "decimals": 18,
+      "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    },
+    {
+      "chainId": 11155111,
+      "address": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
+      "symbol": "WETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5mbk36sz7j19an8jfochhqs4of8g6bwujbecsxbsowdp",
+      "symbol": "$MICHI",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37309/large/5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp.jpeg?1713952829"
+    },
+    {
+      "chainId": 501000101,
+      "address": "j6pqq3facjqewppgppwrb4nm8ju3wlyybrrlh7femfvd",
+      "symbol": "2Z",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68339/large/Coingecko_-_PFP.png?1755694420"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5maydfq5yxtudahtfyumbuhzjgabas9tbeyeqyahds5y",
+      "symbol": "ACS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28747/large/dR4FovX4_400x400.jpg?1696527727"
+    },
+    {
+      "chainId": 501000101,
+      "address": "gjafwwjj3vntsrqvabjbvk2tyb1ytrcqxrdfdgunpump",
+      "symbol": "ACT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50984/large/ai_prophecy.jpg?1729653897"
+    },
+    {
+      "chainId": 501000101,
+      "address": "help6nuqkmyb4pywo2zys22meshxpqyzxbb8n4v98jwc",
+      "symbol": "AI16Z",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51090/large/AI16Z.jpg?1730027175"
+    },
+    {
+      "chainId": 501000101,
+      "address": "14zp2toq79xwvc7fqpm4brnp9d6mp1rffsuw3gplcrx",
+      "symbol": "AIXBT",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51784/large/3.png?1731981138"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hng5pyjmtqcmzxrv6s9zp1cdkk5bgduyfbxbvnapump",
+      "symbol": "ALCH",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52302/large/small-logo.png?1733053544"
+    },
+    {
+      "chainId": 501000101,
+      "address": "9wvorgtbj8gylorftmwxwcympogvubn6mrzhwfpcdcec",
+      "symbol": "ALI",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22062/large/ALI-v2.webp?1728501978"
+    },
+    {
+      "chainId": 501000101,
+      "address": "9mcvh6w97oewlmpxqqeohuav3u5iymyq9aezzhguyf1t",
+      "symbol": "ANON",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52961/large/AAI__ANON_SQ_Wb_250x250.png?1740500195"
+    },
+    {
+      "chainId": 501000101,
+      "address": "26s3ugb9hund1qspapy1zygcritxaoogg7o63bmn89yq",
+      "symbol": "APU",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
+    },
+    {
+      "chainId": 501000101,
+      "address": "61v8vbaqagmpgdqi4jcawo1dmbghsyhzodcpqnevpump",
+      "symbol": "ARC",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52701/large/u312bPNA_400x400.jpg?1734044765"
+    },
+    {
+      "chainId": 501000101,
+      "address": "asrrja1r4rhvk5h9qkkm1jaqqmkxvv6nh5eypprvwmxq",
+      "symbol": "ASRR",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66206/large/ASRR_LOGO200.jpg?1748670826"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dm5bxymetg3aq5pag1brg7rbyqemtnkjvpnmexfacvk7",
+      "symbol": "ATH",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706"
+    },
+    {
+      "chainId": 501000101,
+      "address": "atlasxmbpqxbuybxpsv97usa3fpqyeqzqbuhgifcusxx",
+      "symbol": "ATLAS",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17659/large/Icon_Reverse.png?1696517190"
+    },
+    {
+      "chainId": 501000101,
+      "address": "auddttiepcydtm7joumbyddm72jawxzncppztdoxqbsw",
+      "symbol": "AUDD",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
+    },
+    {
+      "chainId": 501000101,
+      "address": "9lzcmqdgtkyz9drzqnpgee3sga89up3a247ypmj2xrqm",
+      "symbol": "AUDIO",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12913/large/audio-token-asset_2x.png?1747243328"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dtr4d9ftvotx2569gal837zgrb6wnjj6tkmnx9rdk9b2",
+      "symbol": "AURA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38376/large/aura_logo_200x200-01-01.png?1751114135"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dku9kyksfbn5lbffxtnndpax35o4fv6vj9fkk7pzpump",
+      "symbol": "AVA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51935/large/7VZQ0qhB_400x400_%282%29.jpg?1732206907"
+    },
+    {
+      "chainId": 501000101,
+      "address": "epeufdghrxs9xxepval6kfgqvcon7jmawkvuhuux1tpz",
+      "symbol": "BAT",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/677/large/basic-attention-token.png?1696501867"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hgbrwfyxefvphtqkaeymcqthcrke46qq43pke8hcpump",
+      "symbol": "BERT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51480/large/photo_2025-04-22_23.04.39.png?1745405423"
+    },
+    {
+      "chainId": 501000101,
+      "address": "bioj9jtqw62mlz7ukhu69gtkhppgi1bqhccj2kmsvuj",
+      "symbol": "BIO",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53022/large/bio.jpg?1735011002"
+    },
+    {
+      "chainId": 501000101,
+      "address": "g7vqwurmkmmm2du3izpxyftht9biio4f4gzcrwfpknwg",
+      "symbol": "BIRB",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/69732/standard/birb-logo.jpg?1759413928"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ctgiazuk12kccb8sosn4nt2nztzlgtpqdwyqyr2syatc",
+      "symbol": "BITCOIN",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+    },
+    {
+      "chainId": 501000101,
+      "address": "a1t2uvibywyfyzdjyky2w6td8ritgscriudunaaqn49s",
+      "symbol": "BLESS",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69339/large/Layer_1_%284%29.png?1758523043"
+    },
+    {
+      "chainId": 501000101,
+      "address": "fqgtfugbdpfn7pz6ndprzpvldbrpgxxesi4gvu3verhy",
+      "symbol": "BMT",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52778/large/background-square.png?1734284378"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3psh1mj1f7yufad5gh6zj7epe8hhrmkmetgv5tshqa4o",
+      "symbol": "BODEN",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35872/large/boden.jpeg?1709974700"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ukhh6c7mmyiwcf1b9pnwe25tspkddt3h5pqzgz74j82",
+      "symbol": "BOME",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36071/large/bome.png?1710407255"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dezxaz8z7pnrnrjjz3wxborgixca6xjnb7yab1ppb263",
+      "symbol": "BONK",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
+    },
+    {
+      "chainId": 501000101,
+      "address": "c98a4nkjxhpvznazdhua95rptf3t4whtqubl3yobiux9",
+      "symbol": "C98",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17117/large/logo.png?1696516677"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4qqez5lwsz6huupuu8jctgxyw1myqcnbfaw1swzp89hl",
+      "symbol": "CAKE",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    },
+    {
+      "chainId": 501000101,
+      "address": "afjtnuqgmaj5jao6pwxo28r1f7xaxxtsa8q3rg3q8b4a",
+      "symbol": "CARV",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37689/large/CARV_%281%29.png?1728418485"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3jomreccsesngjepflokr2dncchjsrcdtybqet5uspse",
+      "symbol": "CAT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39765/large/Dv9GheV0_400x400.jpg?1756951559"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6dkcowjpj5mfu5gwdefdpuuebasblk3wlewhuzqpaa1e",
+      "symbol": "CHEX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/10349/large/logo-white-bg-dark.png?1733475849"
+    },
+    {
+      "chainId": 501000101,
+      "address": "df6yfrkc8kze3knkrherkzaetsxbrweniqfyjy4jpump",
+      "symbol": "CHILLGUY",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51746/large/Scherm%C2%ADafbeelding_2024-11-15_om_20.57.58.png?1731926037"
+    },
+    {
+      "chainId": 501000101,
+      "address": "gkypya7nncfbdulkncfbfp7p8564x1vzhwzyj6czpump",
+      "symbol": "CHILLHOUSE",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55535/large/1irHeiVg_400x400.jpg?1746563474"
+    },
+    {
+      "chainId": 501000101,
+      "address": "cloudkc4ane7heqcppe3yhnznrxhmimj4myauqyhfzau",
+      "symbol": "CLOUD",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38485/large/CLOUD_128x128.png?1721331750"
+    },
+    {
+      "chainId": 501000101,
+      "address": "apqlh7ovtbeejgbmxh8udnbttwr9k5jev9pnnvqv7xsa",
+      "symbol": "CORN",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54471/large/corn.jpg?1739933588"
+    },
+    {
+      "chainId": 501000101,
+      "address": "aexrlftu8chuy4ctc6odeg4dux6yr4aqeakumfnvacdg",
+      "symbol": "CPOOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dbridgjamsm95motzjs7m9lnkgerpbv9v6cur1dxnuu5",
+      "symbol": "DBR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38019/large/DBR_icon_Color.png?1724708885"
+    },
+    {
+      "chainId": 501000101,
+      "address": "a7n89lqw67hjkzjkdwza2xojuk4n5gbkhz3dfjatczpz",
+      "symbol": "DEGEN",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34515/large/android-chrome-512x512.png?1706198225"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dog1viwbb2vwdper5frj4yfg6gq6xuyfohue9txn65u",
+      "symbol": "DOG",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37352/large/DOGGOTOTHEMOON.png?1714096969"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dvjbesdca43oqcw2h3hw1ct7n3x5vrcr3qrvtuhnxvgv",
+      "symbol": "DOOD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/54399/standard/doods.png?1739506481"
+    },
+    {
+      "chainId": 501000101,
+      "address": "driftupjyltosbwon8kombeysx54afavlddwsbksjwg7",
+      "symbol": "DRIFT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37509/large/DRIFT.png?1715842607"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7zcm8wbn9ala3o47soyctu6ildj7wkgg5sv2he5cgtd5",
+      "symbol": "ELON",
+      "decimals": 4,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/14962/large/6GxcPRo3_400x400.jpg?1696514622"
+    },
+    {
+      "chainId": 501000101,
+      "address": "bqpqrrquoqxfggeaemnpmdgz6rwqcajwny3v6yp4dzwp",
+      "symbol": "ES",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54958/large/image_%2832%29.png?1742979704"
+    },
+    {
+      "chainId": 501000101,
+      "address": "28g7z3vyhdfnhrnvstf1gsskogrtcrdiguasqy2bshif",
+      "symbol": "ESX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36937/large/logo.jpeg?1712847900"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hzwqbkzw8hxmn6bf2yfznrht3c2ixxzpkcfu7ubedktr",
+      "symbol": "EURC",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/26045/large/euro.png?1696525125"
+    },
+    {
+      "chainId": 501000101,
+      "address": "9bb6nfecjbctnnlfko2fqvqbq8hhm13kcyycdqbgpump",
+      "symbol": "FARTCOIN",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50891/large/fart.jpg?1729503972"
+    },
+    {
+      "chainId": 501000101,
+      "address": "echesyfxepkdltoizsl8pbe8myagyy8zrqsacncfgnvp",
+      "symbol": "FIDA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/13395/large/bonfida.png?1696513157"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8f62nyjgo7he5uweveta2jjqf4xzf8aqxkmzxrq3mxfu",
+      "symbol": "FIGHT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/70650/standard/FIGHT_Token_Icon_200x200.png?1762972217"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6lx8bhmq4sy2otmawj7y5skd9ytvvugfmsbzt6b9w7ct",
+      "symbol": "FRAX",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/13423/large/frax.png?1745921071"
+    },
+    {
+      "chainId": 501000101,
+      "address": "a8c3xuqscfmylrte3vmtqraq8kgmasius9afnanwpump",
+      "symbol": "FWOG",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39453/large/fwog.png?1722318442"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ckaktyvz6dkpymvyq9rh3ubrnnqyzayd7if4hjtjuvks",
+      "symbol": "GARI",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22615/large/gari.png?1696521931"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4tbi66vi32s7j8x1a6ewfalhymuxu7cstcemsjqdpump",
+      "symbol": "GHIBLI",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54988/large/ghibli.png?1743059802"
+    },
+    {
+      "chainId": 501000101,
+      "address": "63lfdmnb3mq8mw9mtz2to9bea2m71kzuugq5tijxcqj9",
+      "symbol": "GIGA",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34755/large/IMG_0015.png?1705957165"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7i5kksx2weitkry7ja4zwsuxghs5ejbejy8vvxr4pfrx",
+      "symbol": "GMT",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/23597/large/token-gmt-200x200.png?1703153841"
+    },
+    {
+      "chainId": 501000101,
+      "address": "czlsujwblfssjncfkh59rufqvafwcy5tzedwjsuypump",
+      "symbol": "GOAT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50717/large/GOAT_LOGO_NEW.jpg?1731292759"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3kzae8dpyjrgz36eh81v7wpwi6dm7bdhdmb8eaus2raf",
+      "symbol": "GOMINING",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15662/large/GoMining_Logo.png?1714757256"
+    },
+    {
+      "chainId": 501000101,
+      "address": "grass7b4rdkfbcjtkgsqnxkqjwigvqyfbuscujr3xxjs",
+      "symbol": "GRASS",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/40094/large/Grass.jpg?1725697048"
+    },
+    {
+      "chainId": 501000101,
+      "address": "kenjsuylashumfhyy5o4hp2fdnqzg1asuphfh2kyvep",
+      "symbol": "GRIFFAIN",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52547/large/aAp7HijF4Uf1SkZO3FsVMyrbBc5kux_0vIlI7Amxiu7ygza2T_Swtp8bA2KoL_yU0YWw7c52LG9wflD7b5KMZ6GNJgDtgQfmMKy75SBQ5ldIHl6qffC9SNWqKyvqKQJ5sWZgJnXztPPsuJD_IVTTdPlabPlxxuNq7OAxQcjCbRxnge3tim3QyyIrc5vTOzWR93BoZVf0pd7EzwziVlhzov.jpg?1733590142"
+    },
+    {
+      "chainId": 501000101,
+      "address": "afbx8ogjgpmvfywbvouvhqsrmiw2ar1mohfahi4y2adb",
+      "symbol": "GST-SOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/21841/large/gst.png?1696521196"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3juf2rtyxp867pisb2dt8uucnildw58asjgtxkrakbbe",
+      "symbol": "GUN",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55027/large/gunz.jpg?1743262298"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hntyvp6yfm1hg25tn9wglqm12b8tqmcknkrdu1oxwux",
+      "symbol": "HNT",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/4284/large/helium_logo_use.png?1748092589"
+    },
+    {
+      "chainId": 501000101,
+      "address": "j3umbwqhsjd13sag1e1auojviwvpya5dfnyqpkux3wxj",
+      "symbol": "HOME",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54873/large/defi-app.png?1742235743"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4vmsout2bwatfweudnqm1xedrlfjgj7hswhcpz4xgbty",
+      "symbol": "HONEY",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28388/large/honey.png?1696527388"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dithyrmqisdhn5cnkmjv2cddt6svct96yrecim49pump",
+      "symbol": "HOUSE",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55056/large/house.jpg?1743469684"
+    },
+    {
+      "chainId": 501000101,
+      "address": "bzlbgtncsffoth2gydtwr7e4imwzpr5jqcuugewr646k",
+      "symbol": "IO",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37754/large/io_blackbg.png?1715446363"
+    },
+    {
+      "chainId": 501000101,
+      "address": "axriehr6xw3adzhopnvmn7gcprfcd41ddpitwmg6pump",
+      "symbol": "JAILSTOOL",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54296/large/jailstool-logo.webp?1739093360"
+    },
+    {
+      "chainId": 501000101,
+      "address": "j1toso1uck3rlmjorhttrvwy9hj7x8v9yyac6y7kgcpn",
+      "symbol": "JITOSOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28046/large/JitoSOL-200.png?1696527060"
+    },
+    {
+      "chainId": 501000101,
+      "address": "jtojtomepa8bep8auqc6ext5frijwffmwqx2v2f9mcl",
+      "symbol": "JTO",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33228/large/jto.png?1701137022"
+    },
+    {
+      "chainId": 501000101,
+      "address": "jupyiwryjfskupiha7hker8vutaefosybkedznsdvcn",
+      "symbol": "JUP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34188/large/jup.png?1704266489"
+    },
+    {
+      "chainId": 501000101,
+      "address": "erpdpymuifjukbab1dv9hnj67rm21jujmxz18jcedzbr",
+      "symbol": "K",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67966/large/kick.jpg?1754450296"
+    },
+    {
+      "chainId": 501000101,
+      "address": "kinxdecpdqehpeuqnqmugtyykqkgvfq6cevx5iahjq6",
+      "symbol": "KIN",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/959/large/image.png?1721122241"
+    },
+    {
+      "chainId": 501000101,
+      "address": "kmno3njsbxfcpjtvhzcxlw7rmtwtt4gvfe7suubo9ss",
+      "symbol": "KMNO",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35801/large/tP0Lcgwp_400x400.jpg?1709824189"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5k84vjakogpxa7ias1bngkurx7e61empwhzdqsid4bpe",
+      "symbol": "L3",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37768/large/Square.png?1722045128"
+    },
+    {
+      "chainId": 501000101,
+      "address": "layer4xpptcb3ql8s9u41eahax7mhbn8q6xmtwy2yzc",
+      "symbol": "LAYER",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53498/large/Layer_Green.png?1744950002"
+    },
+    {
+      "chainId": 501000101,
+      "address": "linkhb3afbbkb2eqqu7s7umdzcev3wcvaujhqafq23l",
+      "symbol": "LINK",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/877/large/Chainlink_Logo_500.png?1760023405"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8ki8dpuwnxu9vss3kqbarscwmcfgwkzza8pupto9zbd5",
+      "symbol": "LOCKIN",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38646/large/lockin.png?1718212159"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3sfanvyjiq5uzczvyizadzbthqqtnbr6rbgdxvmfcn5p",
+      "symbol": "LSSOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68286/large/LsSOL_Token_Image_%282%29.png?1755247937"
+    },
+    {
+      "chainId": 501000101,
+      "address": "caga7pddfxs65gznqwp42kbhkjqdceofvt7aqyo8jr8q",
+      "symbol": "MATH",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/11335/large/2020-05-19-token-200.png?1696511257"
+    },
+    {
+      "chainId": 501000101,
+      "address": "mefnbxixkebait3xn9bkm8wsjzxtvsajen4c8sam21u",
+      "symbol": "ME",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39850/large/_ME_Profile_Dark_2x.png?1734013082"
+    },
+    {
+      "chainId": 501000101,
+      "address": "fuafbo2jgks6gb4z4lfzkqszgznucisehqnnebarxm1p",
+      "symbol": "MELANIA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53775/large/melania-meme.png?1737329885"
+    },
+    {
+      "chainId": 501000101,
+      "address": "metvsvvrapdj9cflzq4tr43xk4tajqfwx76z3n6mwql",
+      "symbol": "MET",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69110/large/meteora.png?1757517561"
+    },
+    {
+      "chainId": 501000101,
+      "address": "mew1gqwj3nexg2qgeriku7fafj79phvqvrequzscpp5",
+      "symbol": "MEW",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36440/large/MEW.png?1711442286"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8nimfw4yuv3vloqttbac6rchyasmuhgvpgsypeeecrw6",
+      "symbol": "MEZO",
+      "decimals": 9,
+      "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39727.png"
+    },
+    {
+      "chainId": 501000101,
+      "address": "moonthzekktvonb7v6yvcqit56jydz1on185ba3wizl",
+      "symbol": "MF",
+      "decimals": 4,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69602/large/moonwalk.png?1759214994"
+    },
+    {
+      "chainId": 501000101,
+      "address": "m1m6sdffcs3ozzhprvewercwdzhxth4mvvujptyec3h",
+      "symbol": "MIM",
+      "decimals": 2,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54456/large/MIM_LOGO_2.png?1740171004"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8dmhzumkdssgeycyijfdhkmeuvilbn4gndh8w6qkpp7i",
+      "symbol": "MIRROR",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/68922/large/black_mirror.png?1756974711"
+    },
+    {
+      "chainId": 501000101,
+      "address": "mndefzgvmt87ueuhvvu9vctqsap5b3ftgpshuupa5ey",
+      "symbol": "MNDE",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/18867/large/c1.png?1750668234"
+    },
+    {
+      "chainId": 501000101,
+      "address": "mangoczj36ajzykwvj3vnyu4gtonjfvenjmvvwaxlac",
+      "symbol": "MNGO",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/14773/large/token-mango.png?1696514442"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ed5nyywezpppiwimp8vym7sd7td3lat3q3grtwhzpjby",
+      "symbol": "MOODENG",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50264/large/MOODENG.jpg?1726726975"
+    },
+    {
+      "chainId": 501000101,
+      "address": "metaewgxypbgwsseh8t16a39cq5vyvxzi9zxidpy18m",
+      "symbol": "MPLX",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/27344/large/mplx.png?1696526391"
+    },
+    {
+      "chainId": 501000101,
+      "address": "msolzycxhdygdzu16g5qsh3i5k3z3kzk7ytfqcjm7so",
+      "symbol": "MSOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17752/large/mSOL.png?1696517278"
+    },
+    {
+      "chainId": 501000101,
+      "address": "neontjsjsuo3rexg9o6vhumxw62f9v7zvmu8m8zut44",
+      "symbol": "NEON",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/28331/large/neon_%281%29.png?1696527338"
+    },
+    {
+      "chainId": 501000101,
+      "address": "c29ebrgyjyojpmgpnpsgy1q3mmgk4idsqnqeqqa7moon",
+      "symbol": "NOBODY",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55425/large/IMG_3623.jpeg?1745945623"
+    },
+    {
+      "chainId": 501000101,
+      "address": "nosxbvoacttydlvky6csb4ac8jcdqkkaawytx2zmoo7",
+      "symbol": "NOS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22553/large/POfb_I4u_400x400.jpg?1696521873"
+    },
+    {
+      "chainId": 501000101,
+      "address": "begy8kqkxboewrbjd1q9h2k829js4rc5deynmyxcbv5p",
+      "symbol": "NPC",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31193/large/NPC_200x200.png?1696530021"
+    },
+    {
+      "chainId": 501000101,
+      "address": "orcaektdk7lkz57vaayr9qensvepfiu6qemu1kektze",
+      "symbol": "ORCA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17547/large/Orca_Logo.png?1696517083"
+    },
+    {
+      "chainId": 501000101,
+      "address": "abt79mkrxusohuv2cvqt32ymxqhtparkfjmidqxgiq6e",
+      "symbol": "ORDER",
+      "decimals": 10,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38501/large/Orderly_Network_Coingecko_200*200.png?1717751359"
+    },
+    {
+      "chainId": 501000101,
+      "address": "z3dn17ylagmkffvogefhq9zwvcxgqgf3pqndsns2g6m",
+      "symbol": "OXY",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/13509/large/8DjBZ79V_400x400.jpg?1696513271"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2zmmhcvqexdtde6vsfs7s7d5ouodfjhe8vd1gnbouauv",
+      "symbol": "PENGU",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52622/large/PUDGY_PENGUINS_PENGU_PFP.png?1733809110"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7s9most7vv1j3jvnnw2ayocsqdbdckpyz5apqdpky9i5",
+      "symbol": "PIPE",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/69734/large/photo_2025-10-02_16-25-13.jpg?1759457063"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2qehjdldlbubgryvsxhc5d6udwaivnfzgan56p1tpump",
+      "symbol": "PNUT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51301/large/Peanut_the_Squirrel.png?1734941241"
+    },
+    {
+      "chainId": 501000101,
+      "address": "poliswxnnrwc6obu1vhiukqzfjgl4xdsu4g9qjz9qvk",
+      "symbol": "POLIS",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17789/large/POLIS.jpg?1696517312"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5z3eqyqo9hices3r84rcdmu2n7anpdmxrhdk8pswmrrc",
+      "symbol": "PONKE",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33929/large/ponke-logo.png?1747200908"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7gcihgdb8fe6knjn2mytkzzcrjqy3t9ghdc8uhymw2hr",
+      "symbol": "POPCAT",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33760/large/image.jpg?1702964227"
+    },
+    {
+      "chainId": 501000101,
+      "address": "fmqjdvt1gztvxdvygmbede4l54fftfgx9m5gmbqejgm5",
+      "symbol": "PORTAL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35436/large/portal.jpeg?1708590254"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4llbsb5rep3yetyzmxewygjcir5uxtkfurtaeuvc2ahs",
+      "symbol": "PRCL",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37078/large/ParclToken.png?1737478326"
+    },
+    {
+      "chainId": 501000101,
+      "address": "perleqkunup1dgfz8evyxhdn9d6zqqfgxaldvfs6pds",
+      "symbol": "PRL",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/102172470/standard/Symbol_-_Mango_%281%29.png?1773500485"
+    },
+    {
+      "chainId": 501000101,
+      "address": "pumpcmxqmfrsakq5r49wcjnrayyrqmxz6ae8h7h9dfn",
+      "symbol": "PUMP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/67164/large/pump.jpg?1751949376"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2oglxyunbjrcept1mev6knetald7bf6qq3cm6skasbfe",
+      "symbol": "PUPS",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37159/large/token_logo.png?1732383184"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hz1jovnivvgrgniiyveozevgz58xau3rkwx8eacqbct3",
+      "symbol": "PYTH",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31924/large/pyth.png?1701245725"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2b1kv6dkpanxd5ixfnxcpjxmkwqjjaymczfhsfu24gxo",
+      "symbol": "PYUSD",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4k3dyjzvzp8emzwuxbbcjevwskkk59s5icnly3qrkx6r",
+      "symbol": "RAY",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/13928/large/PSigc4ie_400x400.jpg?1696513668"
+    },
+    {
+      "chainId": 501000101,
+      "address": "vqoywru2pbudcvkurrh74ktqdjgvjrcdvsodbuzm5n9",
+      "symbol": "REKT",
+      "decimals": 4,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51727/large/rektcion_trans_200px.png?1731910587"
+    },
+    {
+      "chainId": 501000101,
+      "address": "rndrizkt3mk1iimdxrdwabcf7zg7ar5t4nud4ekhbof",
+      "symbol": "RENDER",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/11636/large/rndr.png?1696511529"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6ogzhhzdrqr9pgv6hz2mnze7urzbmafybbwuyp1fhitx",
+      "symbol": "RETARDIO",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35759/large/RETARDIO_LOGO.png?1728587088"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3dk98mxpz8truim7rfqnebslpa7vsoc79bgiee1m4zw5",
+      "symbol": "REZ",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/37327/large/renzo_200x200.png?1714025012"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7xkxtg2cw87d97txjsdpbd5jbkhetqa83tzrujosgasu",
+      "symbol": "SAMO",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15051/large/IXeEj5e.png?1696514710"
+    },
+    {
+      "chainId": 501000101,
+      "address": "sarosy6vscao718m4a778z4cgtvcwcgef5m9meh1lgl",
+      "symbol": "SAROS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34594/large/_SAROS_-Mark.Purple_-_Token_logo.png?1755658309"
+    },
+    {
+      "chainId": 501000101,
+      "address": "saber2glauyim4mvftnrasomsv6nvauncvmezwclpd1",
+      "symbol": "SBR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17162/large/oYs_YFz8_400x400.jpg?1696516721"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4qnvjpg8dxoyyjifs83iexe3gwnm4jk4b6mbzrar4gs9",
+      "symbol": "SD",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/20658/large/SD_Token_Logo.png?1696520060"
+    },
+    {
+      "chainId": 501000101,
+      "address": "shdwybxihqicj6yekg2gur7wqklelamk1ghzck9pl6y",
+      "symbol": "SHDW",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22271/large/Property_1_Color.png?1696521615"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5svg3t9cnqsm2kewzbrq6hasqh1ogfjqttlxyuibpump",
+      "symbol": "SIGMA",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39408/large/sigma_logo.jpg?1722053407"
+    },
+    {
+      "chainId": 501000101,
+      "address": "skrbvo6gf7gondit3bbtfurdpqlwei4j2qy2npgzhw3",
+      "symbol": "SKR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70974/large/seeker-logo.jpg?1764922774"
+    },
+    {
+      "chainId": 501000101,
+      "address": "so11111111111111111111111111111111111111112",
+      "symbol": "SOL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/21629/large/solana.jpg?1696520989"
+    },
+    {
+      "chainId": 501000101,
+      "address": "sonicxvlud67eceaezclrnmtbqzyuuynr93dbkbddes",
+      "symbol": "SONIC",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53061/large/Token.png?1735169618"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4edf52yyzl6i6gbz6fxqrlupxbtp61f1gpsfm66m4xhe",
+      "symbol": "SOON",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55124/large/red_2.PNG?1743843131"
+    },
+    {
+      "chainId": 501000101,
+      "address": "spqkecsdallln4mqcb3xh64hytmdd4fzzk9cf5liqv8",
+      "symbol": "SPICE",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54849/large/SPICE_ICON_PINK_MAIN_200px.png?1742023756"
+    },
+    {
+      "chainId": 501000101,
+      "address": "j3nkxxxzcnnimjkw9hyb2k4luxgwb6t1ftptqvsv3kfr",
+      "symbol": "SPX",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/centeredcoin_%281%29.png?1737048493"
+    },
+    {
+      "chainId": 501000101,
+      "address": "srmuapvndxxokk5gt7xd5cuugxmbcoaz2lheuaokwrt",
+      "symbol": "SRM",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/11970/large/serum-logo.png?1696511829"
+    },
+    {
+      "chainId": 501000101,
+      "address": "stepascqoeiofxxwgnh2slbdfp9d8rvkz2yp39idpyt",
+      "symbol": "STEP",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/14988/large/step.png?1696514652"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4dxuskzkzpespd2qfrba4vyk5wqfkteqia6txpkfnubm",
+      "symbol": "SUKU",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/11969/large/suku-200.png?1696511828"
+    },
+    {
+      "chainId": 501000101,
+      "address": "chvzxwrmrtesgwd3ui3uumcn8kx7vk3wad4kgeskpypj",
+      "symbol": "SUSHI",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1696512101"
+    },
+    {
+      "chainId": 501000101,
+      "address": "74sbv4zdxxtrgv1pemoecskkbkzhc2ygpnc7gyvepump",
+      "symbol": "SWARMS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52988/large/swarms.jpg?1734921510"
+    },
+    {
+      "chainId": 501000101,
+      "address": "nsg17kisapmumwjlbz4blx8bipaaxtk9tdcdy1fb9ia",
+      "symbol": "SWEAT",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/25057/large/fhD9Xs16_400x400.jpg?1696524208"
+    },
+    {
+      "chainId": 501000101,
+      "address": "4njvi3928u3figef5tf8xvjlc5gqun33oe4xtjne7xxc",
+      "symbol": "T",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22228/large/nFPNiSbL_400x400.jpg?1696521570"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6dnsn2bjsapfdffc1zp37kkene4usc1sqkzr9c9vpwcu",
+      "symbol": "TBTC",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ftuew73k6veyhfbkfpdbzfwpxgqar2hipgdbutehpump",
+      "symbol": "TITCOIN",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54773/large/titcoinicon.png?1741514331"
+    },
+    {
+      "chainId": 501000101,
+      "address": "tnsrxcuxot9xbg3de7pijytdyu7ksklqcpddxnejas6",
+      "symbol": "TNSR",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35972/large/tnsr.png?1712687367"
+    },
+    {
+      "chainId": 501000101,
+      "address": "fu1q8vjpznurmqscisjp8bakkidgslmoub8cbdf8tkqv",
+      "symbol": "TREMP",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35871/large/tremp.jpeg?1709974567"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5uuh9rtdispq6hks6bp4ndu9pnjpxrxuiw6shbtbhgh2",
+      "symbol": "TROLL",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55282/large/trolllogo.png?1745215015"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6p6xghyf7aee6tzksmfsko444wqop15icusqi2jfgipn",
+      "symbol": "TRUMP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53746/large/trump.png?1737171561"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2dyzu65qa9zdx1uee7gx71k7fiwyuk6szdrvj7auq5wm",
+      "symbol": "TURBO",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    },
+    {
+      "chainId": 501000101,
+      "address": "el5fuxj2j4ciqsmw85k5fg9dvuqjjuobhoqbi2kpump",
+      "symbol": "UFD",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/52931/large/untitled.png?1734708671"
+    },
+    {
+      "chainId": 501000101,
+      "address": "usd1ttgy1n17neehlmeloaybftrbuserhqyiqzvemub",
+      "symbol": "USD1",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
+    },
+    {
+      "chainId": 501000101,
+      "address": "epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dekqhypn7gmrj5cartqfawefqbzb33hyf6s5icwjeont",
+      "symbol": "USDE",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059"
+    },
+    {
+      "chainId": 501000101,
+      "address": "2u1tszseqz3qbwf3ungpfc8tzmk2tdiwknnrmwgwjgwh",
+      "symbol": "USDG",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png?1730484111"
+    },
+    {
+      "chainId": 501000101,
+      "address": "hvbpjaqgnpkgbaybzqbr1t7yfdvayvp2vcqqfkken4tm",
+      "symbol": "USDP",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1696506427"
+    },
+    {
+      "chainId": 501000101,
+      "address": "usdswr9apdhk5bvjkmjzff41ffux8bsxdkcr81vtwca",
+      "symbol": "USDS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    },
+    {
+      "chainId": 501000101,
+      "address": "es9vmfrzacermjfrf4h2fyd4kconky11mcce8benwnyb",
+      "symbol": "USDT",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/325/large/Tether.png?1696501661"
+    },
+    {
+      "chainId": 501000101,
+      "address": "cb9dduft3zuqxqqsfa1c5ky935tereybw9xjxxhkpump",
+      "symbol": "USDUC",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/56006/large/usduc-logo.jpg?1748000956"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dz9mq9nzkbccsugpfj3r1bs4wgqkmhbpivuniw8mbonk",
+      "symbol": "USELESS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/55684/large/coingeckoupdate.png?1755203747"
+    },
+    {
+      "chainId": 501000101,
+      "address": "vrsebfqty9qlmmo5qgiwo74avpdqqmtnxpqwowmpump",
+      "symbol": "VERSE",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66483/large/image00001.jpeg?1749502715"
+    },
+    {
+      "chainId": 501000101,
+      "address": "6ajcp7wulwmrylbnbi825wgguapswzpbehchndprpump",
+      "symbol": "VINE",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/53859/large/vine.jpg?1737613523"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3iql8bfs2ve7mww4ehaqqhasbmrncrpxizwat2zfyr9y",
+      "symbol": "VIRTUAL",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
+    },
+    {
+      "chainId": 501000101,
+      "address": "85vbfqzc9tzkfaptbwjvuw7ybzjy52a6mjtpgjstqamq",
+      "symbol": "W",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/35087/large/W_Token_%283%29.png?1758122686"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8opvqawysx1oybxutl8phaoatixd69vfyax4smpebonk",
+      "symbol": "WAR",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/71796/large/war.png?1769676733"
+    },
+    {
+      "chainId": 501000101,
+      "address": "5xzw2lktyrfvfiskj78ampackrjpcycif1whuspduvqq",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
+    },
+    {
+      "chainId": 501000101,
+      "address": "3nz9jmvbmgaqocybic2c7lqcjscmgsaz6vqqtdzcqmjh",
+      "symbol": "WBTC",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/23004/large/WBTC_wh_small.png?1696522299"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wctk5xwdn5syg56twgj32suf3w4wfq48ogezlbuytby",
+      "symbol": "WCT",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wenwenvqqnya429ubcdr81zmd69brwqaabyy6p3lcpk",
+      "symbol": "WEN",
+      "decimals": 5,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/34856/large/wen-logo-new.jpg?1741334229"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wetzjtprkdmccuxpi9pfwnowmrzkigghdb9raburz2u",
+      "symbol": "WET",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/70397/large/720oatTU_400x400.jpg?1765007223"
+    },
+    {
+      "chainId": 501000101,
+      "address": "7vfcxtuxx5wjv5jadk17duj4ksgau7utnkj4b963voxs",
+      "symbol": "WETH",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/22990/large/ETH_wh_small.png?1696522286"
+    },
+    {
+      "chainId": 501000101,
+      "address": "ekpqgsjtjmfqkz9kqansqyxrcf8fbopzlhyxdm65zcjm",
+      "symbol": "WIF",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/33566/large/dogwifhat.jpg?1702499428"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wingsaybfs4qnegcw8jpsvetqp8xhm3gkkvow54wlcd",
+      "symbol": "WINGS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/102172968/large/wingbits.jpg?1776904828"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wlfinev6ypjkczcs83fzqfpgfzywqxutrbxge7oc16g",
+      "symbol": "WLFI",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/50767/large/wlfi.png?1756438915"
+    },
+    {
+      "chainId": 501000101,
+      "address": "wmtxyykumtg3vuza5bexuhvrlpytwwaop7h2i8ypurh",
+      "symbol": "WMTX",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/17333/large/Token_icon_round_1024.png?1741247846"
+    },
+    {
+      "chainId": 501000101,
+      "address": "dz8vuterqbhr2afl5a3s1ky4dg1unjt1jufxxpay9ytx",
+      "symbol": "WOO",
+      "decimals": 9,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/12921/large/WOO_Logos_2023_Profile_Pic_WOO.png?1696512709"
+    },
+    {
+      "chainId": 501000101,
+      "address": "aymatz4tcl9swneev9kvyz45chvhdz6kugjtjpzlpu9p",
+      "symbol": "XAUt0",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 501000101,
+      "address": "8x5vqbha8d7nkd52unus5nnt3pwa8pld34ymskeso2wn",
+      "symbol": "ZEREBRO",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/51289/large/zerebro_2.png?1730588883"
+    },
+    {
+      "chainId": 501000101,
+      "address": "zeus1ar7ax8dffjf5qjwj2ftdddntromngo8yoqm3gq",
+      "symbol": "ZEUS",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/36692/large/logo-v1.png?1712427948"
+    },
+    {
+      "chainId": 501000101,
+      "address": "zexy1pqteru3n13kdyh4lwpqknkfk3gzmmymunadwpo",
+      "symbol": "ZEX",
+      "decimals": 6,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/38787/large/_ZEX-Token-200px.png?1718929220"
+    },
+    {
+      "chainId": 501000101,
+      "address": "26f12pmbk77wqv1tzle8xkknbvmfggbuypxdtmlznlzz",
+      "symbol": "ZIG",
+      "decimals": 8,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/14796/large/zig.jpg?1731990265"
+    }
+  ]
+}

--- a/src/utils/buildConfig.ts
+++ b/src/utils/buildConfig.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+import { NativeModules, Platform } from 'react-native';
+
+const nativeBuildConfig = NativeModules.BuildConfig as
+  | { INTERNET_ENABLED: boolean }
+  | undefined;
+
+// iOS has no offline flavor — internet is always available there
+export const INTERNET_ENABLED: boolean =
+  Platform.OS === 'android'
+    ? nativeBuildConfig?.INTERNET_ENABLED ?? true
+    : true;

--- a/src/utils/tokenMetadata.ts
+++ b/src/utils/tokenMetadata.ts
@@ -1,0 +1,49 @@
+import { formatUnits } from 'viem';
+
+import tokensData from '../data/tokens.json';
+
+export type TokenMetadata = {
+  symbol: string;
+  decimals: number;
+  logoURI?: string;
+};
+
+type RawToken = {
+  chainId: number;
+  address: string;
+  symbol: string;
+  decimals: number;
+  logoURI?: string;
+};
+
+const tokenMap = new Map<string, TokenMetadata>();
+
+for (const token of (tokensData as { tokens: RawToken[] }).tokens) {
+  tokenMap.set(`${token.chainId}:${token.address}`, {
+    symbol: token.symbol,
+    decimals: token.decimals,
+    logoURI: token.logoURI,
+  });
+}
+
+export function lookupToken(
+  chainId: number | undefined,
+  address: string | undefined,
+): TokenMetadata | null {
+  if (chainId == null || !address) return null;
+  return tokenMap.get(`${chainId}:${address.toLowerCase()}`) ?? null;
+}
+
+export function formatTokenAmount(
+  amount: bigint,
+  token: TokenMetadata,
+): string {
+  const raw = formatUnits(amount, token.decimals);
+  const num = parseFloat(raw);
+  if (num === 0) return `0 ${token.symbol}`;
+  const str =
+    num >= 1
+      ? num.toLocaleString('en-US', { maximumFractionDigits: 4 })
+      : num.toPrecision(4).replace(/\.?0+$/, '');
+  return `${str} ${token.symbol}`;
+}


### PR DESCRIPTION
## Summary

- Bundled ERC-20 token metadata: 1441 tokens from Uniswap default list v20.0.0, committed snapshot in `src/data/tokens.json`, regenerated via `npm run generate:tokens`
- `lookupToken(chainId, address)` + `formatTokenAmount` in `src/utils/tokenMetadata.ts` — O(1) Map lookup, no native dep
- ERC-20 review (`transfer`, `transferFrom`, `approve`) now shows symbol, formatted amount (`1000000 → 1 USDC`), token logo, and `Unlimited USDC` for max uint256
- `BuildConfig.INTERNET_ENABLED` exposed to JS via `BuildConfigModule` Android NativeModule; offline flavor returns `false`, iOS always `true`
- Token logo skipped entirely in offline flavor — no remote request attempted
- `src/utils/buildConfig.ts` wraps the NativeModule with a safe iOS fallback
