### PR TITLE
chore: restore Gradle and AsyncStorage upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Expanded Jest coverage for signing utilities and wallet workflow screens
 - Bundled ERC-20 token metadata (1441 tokens, Uniswap default list v20.0.0); ERC-20 review shows symbol, formatted amounts, and token logo (offline flavor skips logo fetch)
 
+### Changed
+
+- Revert F-Droid build server workarounds by restoring Gradle 9.3.1 and AsyncStorage 3.0.2
+
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,3 +19,11 @@ buildscript {
 }
 
 apply plugin: "com.facebook.react.rootproject"
+
+allprojects {
+    repositories {
+        maven {
+            url("$rootDir/../node_modules/@react-native-async-storage/async-storage/android/local_repo")
+        }
+    }
+}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@ngraveio/bc-ur": "^1.1.13",
         "@noble/hashes": "^2.0.1",
         "@noble/secp256k1": "^3.0.0",
-        "@react-native-async-storage/async-storage": "^1.24.0",
+        "@react-native-async-storage/async-storage": "^3.0.2",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/blur": "^4.4.1",
         "@react-native-vector-icons/material-design-icons": "^13.0.0",
@@ -3061,15 +3061,16 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
-      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.0.2.tgz",
+      "integrity": "sha512-XP0zDIl+1XoeuQ7f878qXKdl77zLwzLALPpxvNRc7ZtDh9ew36WSvOdQOhFkexMySapFAWxEbZxS8K8J2DU4eg==",
       "license": "MIT",
       "dependencies": {
-        "merge-options": "^3.0.4"
+        "idb": "8.0.3"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-clipboard/clipboard": {
@@ -8852,6 +8853,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9326,15 +9333,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -10827,18 +10825,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
-    },
-    "node_modules/merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@ngraveio/bc-ur": "^1.1.13",
     "@noble/hashes": "^2.0.1",
     "@noble/secp256k1": "^3.0.0",
-    "@react-native-async-storage/async-storage": "^1.24.0",
+    "@react-native-async-storage/async-storage": "^3.0.2",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/blur": "^4.4.1",
     "@react-native-vector-icons/material-design-icons": "^13.0.0",


### PR DESCRIPTION
## Summary

- upgrade Gradle wrapper from 8.14.2 to 9.3.1
- restore `@react-native-async-storage/async-storage` 3.0.2
- restore AsyncStorage's Android local Maven repo needed by the 3.x package
- document the reverted F-Droid build server workarounds in the changelog

Closes #119.

## Verification

- `./gradlew :app:assembleOfflineRelease`