### PR TITLE
feat: chain metadata - name and native currency from bundled Chainlist snapshot (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Expanded Jest coverage for signing utilities and wallet workflow screens
 - Bundled ERC-20 token metadata (1441 tokens, Uniswap default list v20.0.0); ERC-20 review shows symbol, formatted amounts, and token logo (offline flavor skips logo fetch)
+- Bundled chain metadata (2593 chains, chainid.network snapshot); transaction review shows chain name and native currency symbol instead of raw chain ID and hardcoded "ETH"
 
 ### Changed
 

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { RLP } from '@ethereumjs/rlp';
+
+import EthSignRequestDetail from '../src/components/EthSignRequestDetail';
+import type { EthSignRequest } from '../src/types';
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return {
+    MD3DarkTheme: { colors: {} },
+    Text,
+    Icon: () => null,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bn(n: bigint): Uint8Array {
+  if (n === 0n) return new Uint8Array(0);
+  const hex = n.toString(16);
+  return Buffer.from(hex.length % 2 === 0 ? hex : '0' + hex, 'hex');
+}
+
+function addr(hex: string): Uint8Array {
+  return Buffer.from(hex.replace('0x', ''), 'hex');
+}
+
+/** Legacy unsigned tx: RLP([nonce, gasPrice, gasLimit, to, value, data]) */
+function legacyTxHex(value: bigint = 1_000_000_000_000_000_000n): string {
+  return Buffer.from(
+    RLP.encode([
+      bn(1n),
+      bn(20_000_000_000n),
+      bn(21000n),
+      addr('0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef'),
+      bn(value),
+      new Uint8Array(0),
+    ]),
+  ).toString('hex');
+}
+
+/** EIP-1559 tx: 0x02 || RLP([chainId, nonce, maxPFG, maxFG, gasLimit, to, value, data, []]) */
+function eip1559TxHex(
+  chainId: bigint,
+  value: bigint = 50_000_000_000_000_000n,
+): string {
+  const rlp = Buffer.from(
+    RLP.encode([
+      bn(chainId),
+      bn(1n),
+      bn(1_000_000_000n),
+      bn(10_000_000_000n),
+      bn(21000n),
+      addr('0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef'),
+      bn(value),
+      new Uint8Array(0),
+      [],
+    ]),
+  );
+  return Buffer.concat([Buffer.from([0x02]), rlp]).toString('hex');
+}
+
+/** EIP-2930 tx: 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, []]) */
+function eip2930TxHex(value: bigint = 500_000_000_000_000_000n): string {
+  const rlp = Buffer.from(
+    RLP.encode([
+      bn(1n),
+      bn(2n),
+      bn(15_000_000_000n),
+      bn(30000n),
+      addr('0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef'),
+      bn(value),
+      new Uint8Array(0),
+      [],
+    ]),
+  );
+  return Buffer.concat([Buffer.from([0x01]), rlp]).toString('hex');
+}
+
+function renderDetail(request: EthSignRequest) {
+  return render(<EthSignRequestDetail request={request} />);
+}
+
+// ---------------------------------------------------------------------------
+// Chain name display
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — chain name', () => {
+  it('shows chain name for BNB Smart Chain (56)', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 56,
+    });
+    expect(screen.getByText('BNB Smart Chain Mainnet')).toBeTruthy();
+  });
+
+  it('shows chain name for Polygon (137)', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 137,
+    });
+    expect(screen.getByText('Polygon Mainnet')).toBeTruthy();
+  });
+
+  it('shows chain name for Base (8453)', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 8453,
+    });
+    expect(screen.getByText('Base')).toBeTruthy();
+  });
+
+  it('falls back to "Chain N" for unknown chain', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 0xdeadbeef,
+    });
+    expect(screen.getByText('Chain 3735928559')).toBeTruthy();
+  });
+
+  it('omits chain row when chainId is undefined', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+    });
+    expect(screen.queryByText('Chain')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native currency symbol in amount
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — native currency symbol', () => {
+  it('shows ETH symbol for Ethereum Mainnet (chainId=1)', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText(/ETH/)).toBeTruthy();
+  });
+
+  it('shows BNB symbol for BNB Smart Chain (chainId=56)', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 56,
+    });
+    // "1 BNB" is the formatted native amount; distinct from the chain name "BNB Smart Chain Mainnet"
+    expect(screen.getByText('1 BNB')).toBeTruthy();
+  });
+
+  it('shows POL symbol for Polygon Mainnet (chainId=137)', () => {
+    renderDetail({
+      signData: eip1559TxHex(137n),
+      dataType: 4,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 137,
+    });
+    expect(screen.getByText(/POL/)).toBeTruthy();
+  });
+
+  it('shows correct symbol for EIP-2930 tx on chainId=1', () => {
+    renderDetail({
+      signData: eip2930TxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText(/ETH/)).toBeTruthy();
+  });
+
+  it('defaults to ETH symbol when chainId is undefined', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+    });
+    expect(screen.getByText(/ETH/)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transaction type labels
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — transaction type labels', () => {
+  it('shows "EIP-1559 Transaction" label for dataType=4', () => {
+    renderDetail({
+      signData: eip1559TxHex(1n),
+      dataType: 4,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText('EIP-1559 Transaction')).toBeTruthy();
+  });
+
+  it('shows "EIP-2930 Transaction" label for 0x01-prefixed dataType=1', () => {
+    renderDetail({
+      signData: eip2930TxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText('EIP-2930 Transaction')).toBeTruthy();
+  });
+
+  it('shows max fee and priority fee for EIP-1559 tx', () => {
+    renderDetail({
+      signData: eip1559TxHex(1n),
+      dataType: 4,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText('Max fee')).toBeTruthy();
+    expect(screen.getByText('Priority fee')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero value + decoded ERC-20 call hides native amount row
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — amount row visibility', () => {
+  // ERC-20 transfer calldata for transfer(address, uint256)
+  const ERC20_TRANSFER =
+    'a9059cbb' +
+    '000000000000000000000000d3cda913deb6f4967b2ef3aa68f5a843da74c4ef' +
+    '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+  function erc20TxHex(): string {
+    const data = Buffer.from(ERC20_TRANSFER, 'hex');
+    return Buffer.from(
+      RLP.encode([
+        bn(1n),
+        bn(20_000_000_000n),
+        bn(60000n),
+        addr('0xdac17f958d2ee523a2206206994597c13d831ec7'),
+        bn(0n), // zero ETH value
+        data,
+      ]),
+    ).toString('hex');
+  }
+
+  it('hides native amount when value is zero and decoded ERC-20 call present', () => {
+    renderDetail({
+      signData: erc20TxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    // DecodedCallSection renders, native amount row does not
+    expect(screen.getByText('ERC-20 Transfer')).toBeTruthy();
+    // No formatted native value (e.g. "1 ETH") — zero-value native row is suppressed
+    expect(screen.queryByText(/\d.*ETH/)).toBeNull();
+  });
+
+  it('shows native amount when value is non-zero even with decoded call', () => {
+    // 0.001 ETH + ERC-20 calldata (unusual but valid)
+    const data = Buffer.from(ERC20_TRANSFER, 'hex');
+    const txHex = Buffer.from(
+      RLP.encode([
+        bn(1n),
+        bn(20_000_000_000n),
+        bn(60000n),
+        addr('0xdac17f958d2ee523a2206206994597c13d831ec7'),
+        bn(1_000_000_000_000_000n), // 0.001 ETH
+        data,
+      ]),
+    ).toString('hex');
+    renderDetail({
+      signData: txHex,
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+    expect(screen.getByText('0.001 ETH')).toBeTruthy();
+  });
+});

--- a/__tests__/chainMetadata.test.ts
+++ b/__tests__/chainMetadata.test.ts
@@ -1,0 +1,36 @@
+import {
+  getChainName,
+  getNativeCurrencySymbol,
+} from '../src/utils/chainMetadata';
+
+describe('getChainName', () => {
+  it('returns name for known chain', () => {
+    expect(getChainName(1)).toBe('Ethereum Mainnet');
+  });
+
+  it('returns name for other known chains', () => {
+    expect(getChainName(56)).toBe('BNB Smart Chain Mainnet');
+    expect(getChainName(137)).toBe('Polygon Mainnet');
+    expect(getChainName(8453)).toBe('Base');
+    expect(getChainName(42161)).toBe('Arbitrum One');
+  });
+
+  it('falls back to Chain <id> for unknown chain', () => {
+    expect(getChainName(0xdeadbeef)).toBe('Chain 3735928559');
+  });
+});
+
+describe('getNativeCurrencySymbol', () => {
+  it('returns ETH for Ethereum Mainnet', () => {
+    expect(getNativeCurrencySymbol(1)).toBe('ETH');
+  });
+
+  it('returns correct symbol for non-ETH chains', () => {
+    expect(getNativeCurrencySymbol(56)).toBe('BNB');
+    expect(getNativeCurrencySymbol(137)).toBe('POL');
+  });
+
+  it('falls back to ETH for unknown chain', () => {
+    expect(getNativeCurrencySymbol(0xdeadbeef)).toBe('ETH');
+  });
+});

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -181,6 +181,26 @@ describe('parseTx', () => {
   it('returns null for malformed hex', () => {
     expect(parseTx('zzzz', 1)).toBeNull();
   });
+
+  describe('nativeCurrencySymbol param', () => {
+    it('uses custom symbol in value for legacy tx', () => {
+      const hex = buildLegacyTxHex({ value: 1_000_000_000_000_000_000n });
+      const tx = parseTx(hex, 1, 'BNB');
+      expect(tx?.value).toBe('1 BNB');
+    });
+
+    it('uses custom symbol in value for EIP-1559 tx', () => {
+      const hex = buildEIP1559TxHex({ value: 1_000_000_000_000_000_000n });
+      const tx = parseTx(hex, 4, 'POL');
+      expect(tx?.value).toBe('1 POL');
+    });
+
+    it('uses custom symbol in value for EIP-2930 tx', () => {
+      const hex = buildEIP2930TxHex({ value: 1_000_000_000_000_000_000n });
+      const tx = parseTx(hex, 1, 'AVAX');
+      expect(tx?.value).toBe('1 AVAX');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "jest",
     "postinstall": "npx react-native-asset",
     "bump": "node scripts/bump-version.js",
-    "generate:tokens": "node scripts/generate-tokens.js"
+    "generate:tokens": "node scripts/generate-tokens.js",
+    "generate:chains": "node scripts/generate-chains.js",
+    "generate": "npm run generate:tokens && npm run generate:chains"
   },
   "dependencies": {
     "@ethereumjs/rlp": "^10.1.1",

--- a/scripts/generate-chains.js
+++ b/scripts/generate-chains.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Fetches the Chainlist chain registry from a pinned commit of the ethereum-lists/chains repo
+ * and writes a trimmed snapshot to src/data/chains.json.
+ *
+ * Source: https://chainid.network/chains.json (2593 chains as of 2026-04-29)
+ *
+ * To update: verify new source, bump PINNED_COMMIT, run this script, commit the diff.
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const URL = 'https://chainid.network/chains.json';
+const OUT = path.join(__dirname, '..', 'src', 'data', 'chains.json');
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, res => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          return get(res.headers.location).then(resolve).catch(reject);
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        }
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString()));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+async function main() {
+  console.log('Fetching Chainlist chain registry...');
+  const raw = JSON.parse(await get(URL));
+
+  const chains = raw
+    .filter(c => c.chainId !== undefined && c.name && c.nativeCurrency?.symbol)
+    .map(c => ({
+      chainId: c.chainId,
+      name: c.name,
+      shortName: c.shortName ?? null,
+      nativeCurrency: { symbol: c.nativeCurrency.symbol },
+    }))
+    .sort((a, b) => a.chainId - b.chainId);
+
+  fs.writeFileSync(OUT, JSON.stringify(chains, null, 2) + '\n');
+  console.log(`Wrote ${chains.length} chains to ${path.relative(process.cwd(), OUT)}`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -5,39 +5,21 @@ import type { EthSignRequest } from '../types';
 import theme from '../theme';
 import DecodedCallSection from './DecodedCallSection';
 import InfoRow from './InfoRow';
+import { getChainName, getNativeCurrencySymbol } from '../utils/chainMetadata';
 import { parseEip712Prehashed, parseEip712Summary } from '../utils/eip712';
 import { getTxLabel, parseTx } from '../utils/txParser';
-
-const CHAIN_NAMES: Record<number, string> = {
-  1: 'Ethereum Mainnet',
-  10: 'Optimism',
-  56: 'BNB Smart Chain',
-  100: 'Gnosis',
-  137: 'Polygon',
-  250: 'Fantom',
-  324: 'zkSync Era',
-  8453: 'Base',
-  42161: 'Arbitrum One',
-  43114: 'Avalanche C-Chain',
-  59144: 'Linea',
-  534352: 'Scroll',
-  11155111: 'Sepolia',
-  80002: 'Polygon Amoy',
-  84532: 'Base Sepolia',
-  421614: 'Arbitrum Sepolia',
-};
-
-function chainLabel(chainId: number): string {
-  return CHAIN_NAMES[chainId] ?? `Chain ${chainId}`;
-}
 
 export default function EthSignRequestDetail({
   request,
 }: {
   request: EthSignRequest;
 }) {
+  const nativeSymbol =
+    request.chainId !== undefined
+      ? getNativeCurrencySymbol(request.chainId)
+      : 'ETH';
   const typeLabel = getTxLabel(request.signData, request.dataType);
-  const tx = parseTx(request.signData, request.dataType);
+  const tx = parseTx(request.signData, request.dataType, nativeSymbol);
   const eip712 =
     request.dataType === 2 ? parseEip712Summary(request.signData) : null;
   const eip712Prehashed =
@@ -81,7 +63,7 @@ export default function EthSignRequestDetail({
 
       {request.chainId !== undefined && (
         <View style={styles.row}>
-          <InfoRow label="Chain" value={chainLabel(request.chainId)} />
+          <InfoRow label="Chain" value={getChainName(request.chainId)} />
         </View>
       )}
 

--- a/src/data/chains.json
+++ b/src/data/chains.json
@@ -1,0 +1,20746 @@
+[
+  {
+    "chainId": 1,
+    "name": "Ethereum Mainnet",
+    "shortName": "eth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2,
+    "name": "Expanse Network",
+    "shortName": "exp",
+    "nativeCurrency": {
+      "symbol": "EXP"
+    }
+  },
+  {
+    "chainId": 3,
+    "name": "Ropsten",
+    "shortName": "rop",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4,
+    "name": "Rinkeby",
+    "shortName": "rin",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5,
+    "name": "Goerli",
+    "shortName": "gor",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6,
+    "name": "Kotti Testnet",
+    "shortName": "kot",
+    "nativeCurrency": {
+      "symbol": "KOT"
+    }
+  },
+  {
+    "chainId": 7,
+    "name": "ThaiChain",
+    "shortName": "tch",
+    "nativeCurrency": {
+      "symbol": "TCH"
+    }
+  },
+  {
+    "chainId": 8,
+    "name": "Ubiq",
+    "shortName": "ubq",
+    "nativeCurrency": {
+      "symbol": "UBQ"
+    }
+  },
+  {
+    "chainId": 9,
+    "name": "Quai Network Mainnet",
+    "shortName": "quai",
+    "nativeCurrency": {
+      "symbol": "QUAI"
+    }
+  },
+  {
+    "chainId": 10,
+    "name": "OP Mainnet",
+    "shortName": "oeth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11,
+    "name": "Metadium Mainnet",
+    "shortName": "meta",
+    "nativeCurrency": {
+      "symbol": "META"
+    }
+  },
+  {
+    "chainId": 12,
+    "name": "Metadium Testnet",
+    "shortName": "kal",
+    "nativeCurrency": {
+      "symbol": "KAL"
+    }
+  },
+  {
+    "chainId": 13,
+    "name": "Diode Testnet Staging",
+    "shortName": "dstg",
+    "nativeCurrency": {
+      "symbol": "sDIODE"
+    }
+  },
+  {
+    "chainId": 14,
+    "name": "Flare Mainnet",
+    "shortName": "flr",
+    "nativeCurrency": {
+      "symbol": "FLR"
+    }
+  },
+  {
+    "chainId": 15,
+    "name": "Diode Prenet",
+    "shortName": "diode",
+    "nativeCurrency": {
+      "symbol": "DIODE"
+    }
+  },
+  {
+    "chainId": 16,
+    "name": "Songbird Testnet Coston",
+    "shortName": "cflr",
+    "nativeCurrency": {
+      "symbol": "CFLR"
+    }
+  },
+  {
+    "chainId": 17,
+    "name": "ThaiChain 2.0 ThaiFi",
+    "shortName": "tfi",
+    "nativeCurrency": {
+      "symbol": "TFI"
+    }
+  },
+  {
+    "chainId": 18,
+    "name": "ThunderCore Testnet",
+    "shortName": "TST",
+    "nativeCurrency": {
+      "symbol": "TST"
+    }
+  },
+  {
+    "chainId": 19,
+    "name": "Songbird Canary-Network",
+    "shortName": "sgb",
+    "nativeCurrency": {
+      "symbol": "SGB"
+    }
+  },
+  {
+    "chainId": 20,
+    "name": "Elastos Smart Chain",
+    "shortName": "esc",
+    "nativeCurrency": {
+      "symbol": "ELA"
+    }
+  },
+  {
+    "chainId": 21,
+    "name": "Elastos Smart Chain Testnet",
+    "shortName": "esct",
+    "nativeCurrency": {
+      "symbol": "tELA"
+    }
+  },
+  {
+    "chainId": 22,
+    "name": "ELA-DID-Sidechain Mainnet",
+    "shortName": "eladid",
+    "nativeCurrency": {
+      "symbol": "ELA"
+    }
+  },
+  {
+    "chainId": 23,
+    "name": "ELA-DID-Sidechain Testnet",
+    "shortName": "eladidt",
+    "nativeCurrency": {
+      "symbol": "tELA"
+    }
+  },
+  {
+    "chainId": 24,
+    "name": "KardiaChain Mainnet",
+    "shortName": "kardiachain",
+    "nativeCurrency": {
+      "symbol": "KAI"
+    }
+  },
+  {
+    "chainId": 25,
+    "name": "Cronos Mainnet",
+    "shortName": "cro",
+    "nativeCurrency": {
+      "symbol": "CRO"
+    }
+  },
+  {
+    "chainId": 26,
+    "name": "Genesis L1 testnet",
+    "shortName": "L1test",
+    "nativeCurrency": {
+      "symbol": "L1test"
+    }
+  },
+  {
+    "chainId": 27,
+    "name": "ShibaChain",
+    "shortName": "shib",
+    "nativeCurrency": {
+      "symbol": "SHIB"
+    }
+  },
+  {
+    "chainId": 28,
+    "name": "Boba Network Rinkeby Testnet",
+    "shortName": "BobaRinkeby",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 29,
+    "name": "Genesis L1",
+    "shortName": "L1",
+    "nativeCurrency": {
+      "symbol": "L1"
+    }
+  },
+  {
+    "chainId": 30,
+    "name": "Rootstock Mainnet",
+    "shortName": "rsk",
+    "nativeCurrency": {
+      "symbol": "RBTC"
+    }
+  },
+  {
+    "chainId": 31,
+    "name": "Rootstock Testnet",
+    "shortName": "trsk",
+    "nativeCurrency": {
+      "symbol": "tRBTC"
+    }
+  },
+  {
+    "chainId": 32,
+    "name": "GoodData Testnet",
+    "shortName": "GooDT",
+    "nativeCurrency": {
+      "symbol": "GooD"
+    }
+  },
+  {
+    "chainId": 33,
+    "name": "GoodData Mainnet",
+    "shortName": "GooD",
+    "nativeCurrency": {
+      "symbol": "GooD"
+    }
+  },
+  {
+    "chainId": 34,
+    "name": "SecureChain Mainnet",
+    "shortName": "scai",
+    "nativeCurrency": {
+      "symbol": "SCAI"
+    }
+  },
+  {
+    "chainId": 35,
+    "name": "TBWG Chain",
+    "shortName": "tbwg",
+    "nativeCurrency": {
+      "symbol": "TBG"
+    }
+  },
+  {
+    "chainId": 36,
+    "name": "Dxchain Mainnet",
+    "shortName": "dx",
+    "nativeCurrency": {
+      "symbol": "DX"
+    }
+  },
+  {
+    "chainId": 37,
+    "name": "Xpla Mainnet",
+    "shortName": "xpla",
+    "nativeCurrency": {
+      "symbol": "XPLA"
+    }
+  },
+  {
+    "chainId": 38,
+    "name": "Valorbit",
+    "shortName": "val",
+    "nativeCurrency": {
+      "symbol": "VAL"
+    }
+  },
+  {
+    "chainId": 39,
+    "name": "U2U Solaris Mainnet",
+    "shortName": "u2u",
+    "nativeCurrency": {
+      "symbol": "U2U"
+    }
+  },
+  {
+    "chainId": 40,
+    "name": "Telos EVM Mainnet",
+    "shortName": "TelosEVM",
+    "nativeCurrency": {
+      "symbol": "TLOS"
+    }
+  },
+  {
+    "chainId": 41,
+    "name": "Telos EVM Testnet",
+    "shortName": "TelosEVMTestnet",
+    "nativeCurrency": {
+      "symbol": "TLOS"
+    }
+  },
+  {
+    "chainId": 42,
+    "name": "LUKSO Mainnet",
+    "shortName": "lukso",
+    "nativeCurrency": {
+      "symbol": "LYX"
+    }
+  },
+  {
+    "chainId": 43,
+    "name": "Darwinia Pangolin Testnet",
+    "shortName": "pangolin",
+    "nativeCurrency": {
+      "symbol": "PRING"
+    }
+  },
+  {
+    "chainId": 44,
+    "name": "Crab Network",
+    "shortName": "crab",
+    "nativeCurrency": {
+      "symbol": "CRAB"
+    }
+  },
+  {
+    "chainId": 45,
+    "name": "Darwinia Pangoro Testnet",
+    "shortName": "pangoro",
+    "nativeCurrency": {
+      "symbol": "ORING"
+    }
+  },
+  {
+    "chainId": 46,
+    "name": "Darwinia Network",
+    "shortName": "darwinia",
+    "nativeCurrency": {
+      "symbol": "RING"
+    }
+  },
+  {
+    "chainId": 47,
+    "name": "Acria IntelliChain",
+    "shortName": "aic",
+    "nativeCurrency": {
+      "symbol": "ACRIA"
+    }
+  },
+  {
+    "chainId": 48,
+    "name": "Ennothem Mainnet Proterozoic",
+    "shortName": "etmp",
+    "nativeCurrency": {
+      "symbol": "ETMP"
+    }
+  },
+  {
+    "chainId": 49,
+    "name": "Ennothem Testnet Pioneer",
+    "shortName": "etmpTest",
+    "nativeCurrency": {
+      "symbol": "ETMP"
+    }
+  },
+  {
+    "chainId": 50,
+    "name": "XDC Network",
+    "shortName": "xdc",
+    "nativeCurrency": {
+      "symbol": "XDC"
+    }
+  },
+  {
+    "chainId": 51,
+    "name": "XDC Apothem Network",
+    "shortName": "txdc",
+    "nativeCurrency": {
+      "symbol": "TXDC"
+    }
+  },
+  {
+    "chainId": 52,
+    "name": "CoinEx Smart Chain Mainnet",
+    "shortName": "cet",
+    "nativeCurrency": {
+      "symbol": "cet"
+    }
+  },
+  {
+    "chainId": 53,
+    "name": "CoinEx Smart Chain Testnet",
+    "shortName": "tcet",
+    "nativeCurrency": {
+      "symbol": "cett"
+    }
+  },
+  {
+    "chainId": 54,
+    "name": "Openpiece Mainnet",
+    "shortName": "OP",
+    "nativeCurrency": {
+      "symbol": "BELLY"
+    }
+  },
+  {
+    "chainId": 55,
+    "name": "Zyx Mainnet",
+    "shortName": "ZYX",
+    "nativeCurrency": {
+      "symbol": "ZYX"
+    }
+  },
+  {
+    "chainId": 56,
+    "name": "BNB Smart Chain Mainnet",
+    "shortName": "bnb",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 57,
+    "name": "Syscoin Mainnet",
+    "shortName": "sys",
+    "nativeCurrency": {
+      "symbol": "SYS"
+    }
+  },
+  {
+    "chainId": 58,
+    "name": "Ontology Mainnet",
+    "shortName": "OntologyMainnet",
+    "nativeCurrency": {
+      "symbol": "ONG"
+    }
+  },
+  {
+    "chainId": 59,
+    "name": "EOS EVM Legacy",
+    "shortName": "eos-legacy",
+    "nativeCurrency": {
+      "symbol": "EOS"
+    }
+  },
+  {
+    "chainId": 60,
+    "name": "GoChain",
+    "shortName": "go",
+    "nativeCurrency": {
+      "symbol": "GO"
+    }
+  },
+  {
+    "chainId": 61,
+    "name": "Ethereum Classic",
+    "shortName": "etc",
+    "nativeCurrency": {
+      "symbol": "ETC"
+    }
+  },
+  {
+    "chainId": 62,
+    "name": "Morden Testnet",
+    "shortName": "tetc",
+    "nativeCurrency": {
+      "symbol": "TETC"
+    }
+  },
+  {
+    "chainId": 63,
+    "name": "Mordor Testnet",
+    "shortName": "metc",
+    "nativeCurrency": {
+      "symbol": "METC"
+    }
+  },
+  {
+    "chainId": 64,
+    "name": "Ellaism",
+    "shortName": "ellaism",
+    "nativeCurrency": {
+      "symbol": "ELLA"
+    }
+  },
+  {
+    "chainId": 65,
+    "name": "OKExChain Testnet",
+    "shortName": "tokt",
+    "nativeCurrency": {
+      "symbol": "OKT"
+    }
+  },
+  {
+    "chainId": 66,
+    "name": "OKXChain Mainnet",
+    "shortName": "okt",
+    "nativeCurrency": {
+      "symbol": "OKT"
+    }
+  },
+  {
+    "chainId": 67,
+    "name": "DBChain Testnet",
+    "shortName": "dbm",
+    "nativeCurrency": {
+      "symbol": "DBM"
+    }
+  },
+  {
+    "chainId": 68,
+    "name": "SoterOne Mainnet",
+    "shortName": "SO1",
+    "nativeCurrency": {
+      "symbol": "SOTER"
+    }
+  },
+  {
+    "chainId": 69,
+    "name": "Optimism Kovan",
+    "shortName": "okov",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 70,
+    "name": "Hoo Smart Chain",
+    "shortName": "hsc",
+    "nativeCurrency": {
+      "symbol": "HOO"
+    }
+  },
+  {
+    "chainId": 71,
+    "name": "Conflux eSpace (Testnet)",
+    "shortName": "cfxtest",
+    "nativeCurrency": {
+      "symbol": "CFX"
+    }
+  },
+  {
+    "chainId": 72,
+    "name": "DxChain Testnet",
+    "shortName": "dxc",
+    "nativeCurrency": {
+      "symbol": "DX"
+    }
+  },
+  {
+    "chainId": 73,
+    "name": "FNCY",
+    "shortName": "FNCY",
+    "nativeCurrency": {
+      "symbol": "FNCY"
+    }
+  },
+  {
+    "chainId": 74,
+    "name": "IDChain Mainnet",
+    "shortName": "idchain",
+    "nativeCurrency": {
+      "symbol": "EIDI"
+    }
+  },
+  {
+    "chainId": 75,
+    "name": "Decimal Smart Chain Mainnet",
+    "shortName": "DSC",
+    "nativeCurrency": {
+      "symbol": "DEL"
+    }
+  },
+  {
+    "chainId": 76,
+    "name": "Mix",
+    "shortName": "mix",
+    "nativeCurrency": {
+      "symbol": "MIX"
+    }
+  },
+  {
+    "chainId": 77,
+    "name": "POA Network Sokol",
+    "shortName": "spoa",
+    "nativeCurrency": {
+      "symbol": "SPOA"
+    }
+  },
+  {
+    "chainId": 78,
+    "name": "PrimusChain mainnet",
+    "shortName": "primuschain",
+    "nativeCurrency": {
+      "symbol": "PETH"
+    }
+  },
+  {
+    "chainId": 79,
+    "name": "Zenith Mainnet",
+    "shortName": "zenith",
+    "nativeCurrency": {
+      "symbol": "ZENITH"
+    }
+  },
+  {
+    "chainId": 80,
+    "name": "GeneChain",
+    "shortName": "GeneChain",
+    "nativeCurrency": {
+      "symbol": "RNA"
+    }
+  },
+  {
+    "chainId": 81,
+    "name": "Japan Open Chain Mainnet",
+    "shortName": "joc",
+    "nativeCurrency": {
+      "symbol": "JOC"
+    }
+  },
+  {
+    "chainId": 82,
+    "name": "Meter Mainnet",
+    "shortName": "Meter",
+    "nativeCurrency": {
+      "symbol": "MTR"
+    }
+  },
+  {
+    "chainId": 83,
+    "name": "Meter Testnet",
+    "shortName": "MeterTest",
+    "nativeCurrency": {
+      "symbol": "MTR"
+    }
+  },
+  {
+    "chainId": 84,
+    "name": "Linqto Devnet",
+    "shortName": "linqto-devnet",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 85,
+    "name": "GateChain Testnet",
+    "shortName": "gttest",
+    "nativeCurrency": {
+      "symbol": "GT"
+    }
+  },
+  {
+    "chainId": 86,
+    "name": "GateChain Mainnet",
+    "shortName": "gt",
+    "nativeCurrency": {
+      "symbol": "GT"
+    }
+  },
+  {
+    "chainId": 87,
+    "name": "Nova Network",
+    "shortName": "nnw",
+    "nativeCurrency": {
+      "symbol": "SNT"
+    }
+  },
+  {
+    "chainId": 88,
+    "name": "Viction",
+    "shortName": "vic",
+    "nativeCurrency": {
+      "symbol": "VIC"
+    }
+  },
+  {
+    "chainId": 89,
+    "name": "Viction Testnet",
+    "shortName": "vict",
+    "nativeCurrency": {
+      "symbol": "VIC"
+    }
+  },
+  {
+    "chainId": 90,
+    "name": "Garizon Stage0",
+    "shortName": "gar-s0",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 91,
+    "name": "Garizon Stage1",
+    "shortName": "gar-s1",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 92,
+    "name": "Garizon Stage2",
+    "shortName": "gar-s2",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 93,
+    "name": "Garizon Stage3",
+    "shortName": "gar-s3",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 94,
+    "name": "SwissDLT",
+    "shortName": "sdlt",
+    "nativeCurrency": {
+      "symbol": "BCTS"
+    }
+  },
+  {
+    "chainId": 95,
+    "name": "CamDL Mainnet",
+    "shortName": "camdl",
+    "nativeCurrency": {
+      "symbol": "CADL"
+    }
+  },
+  {
+    "chainId": 96,
+    "name": "KUB Mainnet",
+    "shortName": "kub",
+    "nativeCurrency": {
+      "symbol": "KUB"
+    }
+  },
+  {
+    "chainId": 97,
+    "name": "BNB Smart Chain Testnet",
+    "shortName": "bnbt",
+    "nativeCurrency": {
+      "symbol": "tBNB"
+    }
+  },
+  {
+    "chainId": 98,
+    "name": "Six Protocol",
+    "shortName": "six",
+    "nativeCurrency": {
+      "symbol": "SIX"
+    }
+  },
+  {
+    "chainId": 99,
+    "name": "POA Network Core",
+    "shortName": "poa",
+    "nativeCurrency": {
+      "symbol": "POA"
+    }
+  },
+  {
+    "chainId": 100,
+    "name": "Gnosis",
+    "shortName": "gno",
+    "nativeCurrency": {
+      "symbol": "XDAI"
+    }
+  },
+  {
+    "chainId": 101,
+    "name": "EtherInc",
+    "shortName": "eti",
+    "nativeCurrency": {
+      "symbol": "ETI"
+    }
+  },
+  {
+    "chainId": 102,
+    "name": "Web3Games Testnet",
+    "shortName": "tw3g",
+    "nativeCurrency": {
+      "symbol": "W3G"
+    }
+  },
+  {
+    "chainId": 103,
+    "name": "WorldLand Mainnet",
+    "shortName": "WLC",
+    "nativeCurrency": {
+      "symbol": "WLC"
+    }
+  },
+  {
+    "chainId": 104,
+    "name": "Kaiba Lightning Chain Testnet",
+    "shortName": "tklc",
+    "nativeCurrency": {
+      "symbol": "tKAIBA"
+    }
+  },
+  {
+    "chainId": 105,
+    "name": "Web3Games Devnet",
+    "shortName": "dw3g",
+    "nativeCurrency": {
+      "symbol": "W3G"
+    }
+  },
+  {
+    "chainId": 106,
+    "name": "Velas EVM Mainnet",
+    "shortName": "vlx",
+    "nativeCurrency": {
+      "symbol": "VLX"
+    }
+  },
+  {
+    "chainId": 107,
+    "name": "Nebula Testnet",
+    "shortName": "ntn",
+    "nativeCurrency": {
+      "symbol": "NBX"
+    }
+  },
+  {
+    "chainId": 108,
+    "name": "ThunderCore Mainnet",
+    "shortName": "TT",
+    "nativeCurrency": {
+      "symbol": "TT"
+    }
+  },
+  {
+    "chainId": 109,
+    "name": "Shibarium",
+    "shortName": "shibariumecosystem",
+    "nativeCurrency": {
+      "symbol": "BONE"
+    }
+  },
+  {
+    "chainId": 110,
+    "name": "Proton Testnet",
+    "shortName": "xpr",
+    "nativeCurrency": {
+      "symbol": "XPR"
+    }
+  },
+  {
+    "chainId": 111,
+    "name": "EtherLite Chain",
+    "shortName": "ETL",
+    "nativeCurrency": {
+      "symbol": "ETL"
+    }
+  },
+  {
+    "chainId": 112,
+    "name": "Coinbit Mainnet",
+    "shortName": "coinbit",
+    "nativeCurrency": {
+      "symbol": "GIDR"
+    }
+  },
+  {
+    "chainId": 113,
+    "name": "Dehvo",
+    "shortName": "deh",
+    "nativeCurrency": {
+      "symbol": "Deh"
+    }
+  },
+  {
+    "chainId": 114,
+    "name": "Flare Testnet Coston2",
+    "shortName": "c2flr",
+    "nativeCurrency": {
+      "symbol": "C2FLR"
+    }
+  },
+  {
+    "chainId": 115,
+    "name": "DeBank Testnet(Deprecated)",
+    "shortName": "debank-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 116,
+    "name": "DeBank Mainnet",
+    "shortName": "debank-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 117,
+    "name": "Uptick Mainnet",
+    "shortName": "auptick",
+    "nativeCurrency": {
+      "symbol": "UPTICK"
+    }
+  },
+  {
+    "chainId": 118,
+    "name": "Arcology Testnet",
+    "shortName": "arcology",
+    "nativeCurrency": {
+      "symbol": "Acol"
+    }
+  },
+  {
+    "chainId": 119,
+    "name": "ENULS Mainnet",
+    "shortName": "enuls",
+    "nativeCurrency": {
+      "symbol": "NULS"
+    }
+  },
+  {
+    "chainId": 120,
+    "name": "ENULS Testnet",
+    "shortName": "enulst",
+    "nativeCurrency": {
+      "symbol": "NULS"
+    }
+  },
+  {
+    "chainId": 121,
+    "name": "Realchain Mainnet",
+    "shortName": "REAL",
+    "nativeCurrency": {
+      "symbol": "REAL"
+    }
+  },
+  {
+    "chainId": 122,
+    "name": "Fuse Mainnet",
+    "shortName": "fuse",
+    "nativeCurrency": {
+      "symbol": "FUSE"
+    }
+  },
+  {
+    "chainId": 123,
+    "name": "Fuse Sparknet",
+    "shortName": "spark",
+    "nativeCurrency": {
+      "symbol": "SPARK"
+    }
+  },
+  {
+    "chainId": 124,
+    "name": "Decentralized Web Mainnet",
+    "shortName": "dwu",
+    "nativeCurrency": {
+      "symbol": "DWU"
+    }
+  },
+  {
+    "chainId": 125,
+    "name": "OYchain Testnet",
+    "shortName": "OYchainTestnet",
+    "nativeCurrency": {
+      "symbol": "OY"
+    }
+  },
+  {
+    "chainId": 126,
+    "name": "OYchain Mainnet",
+    "shortName": "OYchainMainnet",
+    "nativeCurrency": {
+      "symbol": "OY"
+    }
+  },
+  {
+    "chainId": 127,
+    "name": "Factory 127 Mainnet",
+    "shortName": "feth",
+    "nativeCurrency": {
+      "symbol": "FETH"
+    }
+  },
+  {
+    "chainId": 128,
+    "name": "Huobi ECO Chain Mainnet",
+    "shortName": "heco",
+    "nativeCurrency": {
+      "symbol": "HT"
+    }
+  },
+  {
+    "chainId": 129,
+    "name": "Innovator Chain",
+    "shortName": "Innovator",
+    "nativeCurrency": {
+      "symbol": "INOV8"
+    }
+  },
+  {
+    "chainId": 130,
+    "name": "Unichain",
+    "shortName": "unichain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 131,
+    "name": "Engram Testnet",
+    "shortName": "tgram",
+    "nativeCurrency": {
+      "symbol": "tGRAM"
+    }
+  },
+  {
+    "chainId": 132,
+    "name": "Namefi Chain Mainnet",
+    "shortName": "nfic",
+    "nativeCurrency": {
+      "symbol": "NFIC"
+    }
+  },
+  {
+    "chainId": 133,
+    "name": "HashKey Chain Testnet",
+    "shortName": "HSKT",
+    "nativeCurrency": {
+      "symbol": "HSK"
+    }
+  },
+  {
+    "chainId": 134,
+    "name": "iExec Sidechain",
+    "shortName": "rlc",
+    "nativeCurrency": {
+      "symbol": "xRLC"
+    }
+  },
+  {
+    "chainId": 135,
+    "name": "Alyx Chain Testnet",
+    "shortName": "AlyxTestnet",
+    "nativeCurrency": {
+      "symbol": "ALYX"
+    }
+  },
+  {
+    "chainId": 136,
+    "name": "Deamchain Mainnet",
+    "shortName": "deam",
+    "nativeCurrency": {
+      "symbol": "DEAM"
+    }
+  },
+  {
+    "chainId": 137,
+    "name": "Polygon Mainnet",
+    "shortName": "pol",
+    "nativeCurrency": {
+      "symbol": "POL"
+    }
+  },
+  {
+    "chainId": 138,
+    "name": "Defi Oracle Meta Mainnet",
+    "shortName": "dfio-meta-main",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 139,
+    "name": "WoopChain Mainnet",
+    "shortName": "woop",
+    "nativeCurrency": {
+      "symbol": "WOOC"
+    }
+  },
+  {
+    "chainId": 140,
+    "name": "Eteria Mainnet",
+    "shortName": "ERA",
+    "nativeCurrency": {
+      "symbol": "ERA"
+    }
+  },
+  {
+    "chainId": 141,
+    "name": "Openpiece Testnet",
+    "shortName": "OPtest",
+    "nativeCurrency": {
+      "symbol": "BELLY"
+    }
+  },
+  {
+    "chainId": 142,
+    "name": "DAX CHAIN",
+    "shortName": "dax",
+    "nativeCurrency": {
+      "symbol": "DAX"
+    }
+  },
+  {
+    "chainId": 143,
+    "name": "Monad",
+    "shortName": "mon",
+    "nativeCurrency": {
+      "symbol": "MON"
+    }
+  },
+  {
+    "chainId": 144,
+    "name": "PHI Network v2",
+    "shortName": "PHI",
+    "nativeCurrency": {
+      "symbol": "Φ"
+    }
+  },
+  {
+    "chainId": 145,
+    "name": "SoraAI Testnet",
+    "shortName": "SETH",
+    "nativeCurrency": {
+      "symbol": "SETH"
+    }
+  },
+  {
+    "chainId": 146,
+    "name": "Sonic Mainnet",
+    "shortName": "sonic",
+    "nativeCurrency": {
+      "symbol": "S"
+    }
+  },
+  {
+    "chainId": 147,
+    "name": "Flag Mainnet",
+    "shortName": "FLAG",
+    "nativeCurrency": {
+      "symbol": "FLAG"
+    }
+  },
+  {
+    "chainId": 148,
+    "name": "ShimmerEVM",
+    "shortName": "shimmerevm",
+    "nativeCurrency": {
+      "symbol": "SMR"
+    }
+  },
+  {
+    "chainId": 150,
+    "name": "Six Protocol Testnet",
+    "shortName": "sixt",
+    "nativeCurrency": {
+      "symbol": "tSIX"
+    }
+  },
+  {
+    "chainId": 151,
+    "name": "Redbelly Network Mainnet",
+    "shortName": "rbn",
+    "nativeCurrency": {
+      "symbol": "RBNT"
+    }
+  },
+  {
+    "chainId": 152,
+    "name": "Redbelly Network Devnet",
+    "shortName": "rbn-devnet",
+    "nativeCurrency": {
+      "symbol": "RBNT"
+    }
+  },
+  {
+    "chainId": 153,
+    "name": "Redbelly Network Testnet",
+    "shortName": "rbn-testnet",
+    "nativeCurrency": {
+      "symbol": "RBNT"
+    }
+  },
+  {
+    "chainId": 154,
+    "name": "Redbelly Network TGE",
+    "shortName": "rbn-tge",
+    "nativeCurrency": {
+      "symbol": "RBNT"
+    }
+  },
+  {
+    "chainId": 155,
+    "name": "Tenet Testnet",
+    "shortName": "tenet-testnet",
+    "nativeCurrency": {
+      "symbol": "TENET"
+    }
+  },
+  {
+    "chainId": 156,
+    "name": "OEBlock Testnet",
+    "shortName": "obe",
+    "nativeCurrency": {
+      "symbol": "OEB"
+    }
+  },
+  {
+    "chainId": 157,
+    "name": "Puppynet",
+    "shortName": "puppynet",
+    "nativeCurrency": {
+      "symbol": "BONE"
+    }
+  },
+  {
+    "chainId": 158,
+    "name": "Roburna Mainnet",
+    "shortName": "rba",
+    "nativeCurrency": {
+      "symbol": "RBA"
+    }
+  },
+  {
+    "chainId": 159,
+    "name": "Roburna Testnet",
+    "shortName": "rbat",
+    "nativeCurrency": {
+      "symbol": "RBAT"
+    }
+  },
+  {
+    "chainId": 160,
+    "name": "Armonia Eva Chain Mainnet",
+    "shortName": "eva",
+    "nativeCurrency": {
+      "symbol": "AMAX"
+    }
+  },
+  {
+    "chainId": 161,
+    "name": "Armonia Eva Chain Testnet",
+    "shortName": "wall-e",
+    "nativeCurrency": {
+      "symbol": "AMAX"
+    }
+  },
+  {
+    "chainId": 162,
+    "name": "Lightstreams Testnet",
+    "shortName": "tpht",
+    "nativeCurrency": {
+      "symbol": "PHT"
+    }
+  },
+  {
+    "chainId": 163,
+    "name": "Lightstreams Mainnet",
+    "shortName": "pht",
+    "nativeCurrency": {
+      "symbol": "PHT"
+    }
+  },
+  {
+    "chainId": 164,
+    "name": "Omni Omega Testnet",
+    "shortName": "omni_omega",
+    "nativeCurrency": {
+      "symbol": "OMNI"
+    }
+  },
+  {
+    "chainId": 165,
+    "name": "Omni Testnet (Deprecated)",
+    "shortName": "omni_testnet_deprecated",
+    "nativeCurrency": {
+      "symbol": "OMNI"
+    }
+  },
+  {
+    "chainId": 166,
+    "name": "Nomina",
+    "shortName": "nom",
+    "nativeCurrency": {
+      "symbol": "NOM"
+    }
+  },
+  {
+    "chainId": 167,
+    "name": "Atoshi Testnet",
+    "shortName": "atoshi",
+    "nativeCurrency": {
+      "symbol": "ATOS"
+    }
+  },
+  {
+    "chainId": 168,
+    "name": "AIOZ Network",
+    "shortName": "aioz",
+    "nativeCurrency": {
+      "symbol": "AIOZ"
+    }
+  },
+  {
+    "chainId": 169,
+    "name": "Manta Pacific Mainnet",
+    "shortName": "manta",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 170,
+    "name": "HOO Smart Chain Testnet",
+    "shortName": "hoosmartchain",
+    "nativeCurrency": {
+      "symbol": "HOO"
+    }
+  },
+  {
+    "chainId": 171,
+    "name": "CO2e Chain",
+    "shortName": "CO2e",
+    "nativeCurrency": {
+      "symbol": "CO2E"
+    }
+  },
+  {
+    "chainId": 172,
+    "name": "Latam-Blockchain Resil Testnet",
+    "shortName": "resil",
+    "nativeCurrency": {
+      "symbol": "usd"
+    }
+  },
+  {
+    "chainId": 173,
+    "name": "ENI Mainnet",
+    "shortName": "eni",
+    "nativeCurrency": {
+      "symbol": "EGAS"
+    }
+  },
+  {
+    "chainId": 174,
+    "name": "ENI Testnet",
+    "shortName": "eni-test",
+    "nativeCurrency": {
+      "symbol": "EGAS"
+    }
+  },
+  {
+    "chainId": 175,
+    "name": "OTC",
+    "shortName": "OTC",
+    "nativeCurrency": {
+      "symbol": "OTC"
+    }
+  },
+  {
+    "chainId": 176,
+    "name": "DC Mainnet",
+    "shortName": "dcchain",
+    "nativeCurrency": {
+      "symbol": "DCT"
+    }
+  },
+  {
+    "chainId": 177,
+    "name": "HashKey Chain",
+    "shortName": "hsk",
+    "nativeCurrency": {
+      "symbol": "HSK"
+    }
+  },
+  {
+    "chainId": 178,
+    "name": "Abey Testnet",
+    "shortName": "abeyt",
+    "nativeCurrency": {
+      "symbol": "tABEY"
+    }
+  },
+  {
+    "chainId": 179,
+    "name": "Abey Mainnet",
+    "shortName": "abey",
+    "nativeCurrency": {
+      "symbol": "ABEY"
+    }
+  },
+  {
+    "chainId": 180,
+    "name": "AME Chain Mainnet",
+    "shortName": "ame",
+    "nativeCurrency": {
+      "symbol": "AME"
+    }
+  },
+  {
+    "chainId": 181,
+    "name": "Waterfall Network",
+    "shortName": "water",
+    "nativeCurrency": {
+      "symbol": "WATER"
+    }
+  },
+  {
+    "chainId": 182,
+    "name": "IOST Mainnet",
+    "shortName": "iost",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 183,
+    "name": "Ethernity",
+    "shortName": "ethernity-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 184,
+    "name": "Dojima Testnet",
+    "shortName": "dojtestnet",
+    "nativeCurrency": {
+      "symbol": "DOJ"
+    }
+  },
+  {
+    "chainId": 185,
+    "name": "Mint Mainnet",
+    "shortName": "mint",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 186,
+    "name": "Seele Mainnet",
+    "shortName": "Seele",
+    "nativeCurrency": {
+      "symbol": "Seele"
+    }
+  },
+  {
+    "chainId": 187,
+    "name": "Dojima",
+    "shortName": "dojima",
+    "nativeCurrency": {
+      "symbol": "DOJ"
+    }
+  },
+  {
+    "chainId": 188,
+    "name": "BMC Mainnet",
+    "shortName": "BMC",
+    "nativeCurrency": {
+      "symbol": "BTM"
+    }
+  },
+  {
+    "chainId": 189,
+    "name": "BMC Testnet",
+    "shortName": "BMCT",
+    "nativeCurrency": {
+      "symbol": "BTM"
+    }
+  },
+  {
+    "chainId": 190,
+    "name": "CMDAO BBQ Chain",
+    "shortName": "cmdao-bbq-chain",
+    "nativeCurrency": {
+      "symbol": "CMD"
+    }
+  },
+  {
+    "chainId": 191,
+    "name": "FileFileGo",
+    "shortName": "ffg",
+    "nativeCurrency": {
+      "symbol": "FFG"
+    }
+  },
+  {
+    "chainId": 192,
+    "name": "Redmansion Chain",
+    "shortName": "rmc",
+    "nativeCurrency": {
+      "symbol": "RMC"
+    }
+  },
+  {
+    "chainId": 193,
+    "name": "Crypto Emergency",
+    "shortName": "cem",
+    "nativeCurrency": {
+      "symbol": "CEM"
+    }
+  },
+  {
+    "chainId": 194,
+    "name": "firachain",
+    "shortName": "FIR",
+    "nativeCurrency": {
+      "symbol": "FIR"
+    }
+  },
+  {
+    "chainId": 195,
+    "name": "X Layer Testnet",
+    "shortName": "tokb",
+    "nativeCurrency": {
+      "symbol": "OKB"
+    }
+  },
+  {
+    "chainId": 196,
+    "name": "X Layer Mainnet",
+    "shortName": "okb",
+    "nativeCurrency": {
+      "symbol": "OKB"
+    }
+  },
+  {
+    "chainId": 197,
+    "name": "Neutrinos TestNet",
+    "shortName": "NEUTR",
+    "nativeCurrency": {
+      "symbol": "NEUTR"
+    }
+  },
+  {
+    "chainId": 198,
+    "name": "Bitchain Mainnet",
+    "shortName": "bit",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 199,
+    "name": "BitTorrent Chain Mainnet",
+    "shortName": "BTT",
+    "nativeCurrency": {
+      "symbol": "BTT"
+    }
+  },
+  {
+    "chainId": 200,
+    "name": "Arbitrum on xDai",
+    "shortName": "aox",
+    "nativeCurrency": {
+      "symbol": "xDAI"
+    }
+  },
+  {
+    "chainId": 201,
+    "name": "MOAC testnet",
+    "shortName": "moactest",
+    "nativeCurrency": {
+      "symbol": "mc"
+    }
+  },
+  {
+    "chainId": 202,
+    "name": "Edgeless Testnet",
+    "shortName": "edgeless-testnet",
+    "nativeCurrency": {
+      "symbol": "EwEth"
+    }
+  },
+  {
+    "chainId": 203,
+    "name": "WowChain Mainnet",
+    "shortName": "wow",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 204,
+    "name": "opBNB Mainnet",
+    "shortName": "obnb",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 205,
+    "name": "EKAASH",
+    "shortName": "ekaash",
+    "nativeCurrency": {
+      "symbol": "$EKH"
+    }
+  },
+  {
+    "chainId": 206,
+    "name": "VinuChain Testnet",
+    "shortName": "VCTEST",
+    "nativeCurrency": {
+      "symbol": "VC"
+    }
+  },
+  {
+    "chainId": 207,
+    "name": "VinuChain Network",
+    "shortName": "VC",
+    "nativeCurrency": {
+      "symbol": "VC"
+    }
+  },
+  {
+    "chainId": 208,
+    "name": "Structx Mainnet",
+    "shortName": "utx",
+    "nativeCurrency": {
+      "symbol": "utx"
+    }
+  },
+  {
+    "chainId": 210,
+    "name": "Bitnet",
+    "shortName": "BTN",
+    "nativeCurrency": {
+      "symbol": "BTN"
+    }
+  },
+  {
+    "chainId": 211,
+    "name": "Freight Trust Network",
+    "shortName": "EDI",
+    "nativeCurrency": {
+      "symbol": "0xF"
+    }
+  },
+  {
+    "chainId": 212,
+    "name": "MAPO Makalu",
+    "shortName": "makalu",
+    "nativeCurrency": {
+      "symbol": "MAPO"
+    }
+  },
+  {
+    "chainId": 213,
+    "name": "B2 Hub Mainnet",
+    "shortName": "B2Hub-mainnet",
+    "nativeCurrency": {
+      "symbol": "B2"
+    }
+  },
+  {
+    "chainId": 214,
+    "name": "Shinarium Mainnet",
+    "shortName": "shinarium",
+    "nativeCurrency": {
+      "symbol": "SHI"
+    }
+  },
+  {
+    "chainId": 215,
+    "name": "IDN Mainnet",
+    "shortName": "IDN",
+    "nativeCurrency": {
+      "symbol": "IDN"
+    }
+  },
+  {
+    "chainId": 216,
+    "name": "Happychain Testnet",
+    "shortName": "happytestnet",
+    "nativeCurrency": {
+      "symbol": "HAPPY"
+    }
+  },
+  {
+    "chainId": 217,
+    "name": "SiriusNet V2",
+    "shortName": "SIN2",
+    "nativeCurrency": {
+      "symbol": "MCD"
+    }
+  },
+  {
+    "chainId": 218,
+    "name": "SoterOne Mainnet old",
+    "shortName": "SO1-old",
+    "nativeCurrency": {
+      "symbol": "SOTER"
+    }
+  },
+  {
+    "chainId": 220,
+    "name": "Scalind Testnet",
+    "shortName": "sepscal",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 221,
+    "name": "BlockEx Mainnet",
+    "shortName": "BlockEx",
+    "nativeCurrency": {
+      "symbol": "XBE"
+    }
+  },
+  {
+    "chainId": 222,
+    "name": "Permission",
+    "shortName": "ASK",
+    "nativeCurrency": {
+      "symbol": "ASK"
+    }
+  },
+  {
+    "chainId": 223,
+    "name": "B2 Mainnet",
+    "shortName": "B2-mainnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 224,
+    "name": "Viridis Testnet",
+    "shortName": "VRD-Testnet",
+    "nativeCurrency": {
+      "symbol": "VRD"
+    }
+  },
+  {
+    "chainId": 225,
+    "name": "LACHAIN Mainnet",
+    "shortName": "LA",
+    "nativeCurrency": {
+      "symbol": "LA"
+    }
+  },
+  {
+    "chainId": 226,
+    "name": "LACHAIN Testnet",
+    "shortName": "TLA",
+    "nativeCurrency": {
+      "symbol": "TLA"
+    }
+  },
+  {
+    "chainId": 227,
+    "name": "Prom",
+    "shortName": "PROM",
+    "nativeCurrency": {
+      "symbol": "PROM"
+    }
+  },
+  {
+    "chainId": 228,
+    "name": "Mind Network Mainnet",
+    "shortName": "fhe",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 230,
+    "name": "SwapDEX",
+    "shortName": "SDX",
+    "nativeCurrency": {
+      "symbol": "SDX"
+    }
+  },
+  {
+    "chainId": 232,
+    "name": "Lens",
+    "shortName": "lens",
+    "nativeCurrency": {
+      "symbol": "GHO"
+    }
+  },
+  {
+    "chainId": 233,
+    "name": "Ethernity Testnet",
+    "shortName": "ethernity-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 234,
+    "name": "ProtoJumbo Testnet",
+    "shortName": "ProtoJumbo",
+    "nativeCurrency": {
+      "symbol": "JNFTC"
+    }
+  },
+  {
+    "chainId": 236,
+    "name": "Deamchain Testnet",
+    "shortName": "deamtest",
+    "nativeCurrency": {
+      "symbol": "DEAM"
+    }
+  },
+  {
+    "chainId": 238,
+    "name": "Blast Mainnet",
+    "shortName": "blast",
+    "nativeCurrency": {
+      "symbol": "OWCT"
+    }
+  },
+  {
+    "chainId": 239,
+    "name": "TAC Mainnet",
+    "shortName": "tacchain_239-1",
+    "nativeCurrency": {
+      "symbol": "TAC"
+    }
+  },
+  {
+    "chainId": 240,
+    "name": "Cronos zkEVM Testnet",
+    "shortName": "zkTCRO",
+    "nativeCurrency": {
+      "symbol": "zkTCRO"
+    }
+  },
+  {
+    "chainId": 242,
+    "name": "Plinga Mainnet",
+    "shortName": "plgchain",
+    "nativeCurrency": {
+      "symbol": "PLINGA"
+    }
+  },
+  {
+    "chainId": 246,
+    "name": "Energy Web Chain",
+    "shortName": "ewt",
+    "nativeCurrency": {
+      "symbol": "EWT"
+    }
+  },
+  {
+    "chainId": 247,
+    "name": "ChooChain",
+    "shortName": "choo",
+    "nativeCurrency": {
+      "symbol": "CHOO"
+    }
+  },
+  {
+    "chainId": 248,
+    "name": "Oasys Mainnet",
+    "shortName": "OAS",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 250,
+    "name": "Fantom Opera",
+    "shortName": "ftm",
+    "nativeCurrency": {
+      "symbol": "FTM"
+    }
+  },
+  {
+    "chainId": 251,
+    "name": "Glide L1 Protocol XP",
+    "shortName": "glide",
+    "nativeCurrency": {
+      "symbol": "GLXP"
+    }
+  },
+  {
+    "chainId": 252,
+    "name": "Fraxtal",
+    "shortName": "frax",
+    "nativeCurrency": {
+      "symbol": "FRAX"
+    }
+  },
+  {
+    "chainId": 253,
+    "name": "Glide L2 Protocol XP",
+    "shortName": "glidexp",
+    "nativeCurrency": {
+      "symbol": "GLXP"
+    }
+  },
+  {
+    "chainId": 254,
+    "name": "Swan Chain Mainnet",
+    "shortName": "Swan",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 255,
+    "name": "Kroma",
+    "shortName": "kroma",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 256,
+    "name": "Huobi ECO Chain Testnet",
+    "shortName": "hecot",
+    "nativeCurrency": {
+      "symbol": "htt"
+    }
+  },
+  {
+    "chainId": 258,
+    "name": "Setheum",
+    "shortName": "setm",
+    "nativeCurrency": {
+      "symbol": "SETM"
+    }
+  },
+  {
+    "chainId": 259,
+    "name": "Neonlink Mainnet",
+    "shortName": "neon",
+    "nativeCurrency": {
+      "symbol": "NEON"
+    }
+  },
+  {
+    "chainId": 260,
+    "name": "Guru Network",
+    "shortName": "guru",
+    "nativeCurrency": {
+      "symbol": "GURU"
+    }
+  },
+  {
+    "chainId": 261,
+    "name": "Guru Network Testnet",
+    "shortName": "tguru",
+    "nativeCurrency": {
+      "symbol": "tGURU"
+    }
+  },
+  {
+    "chainId": 262,
+    "name": "SUR Blockchain Network",
+    "shortName": "SUR",
+    "nativeCurrency": {
+      "symbol": "SRN"
+    }
+  },
+  {
+    "chainId": 266,
+    "name": "Neura",
+    "shortName": "neura",
+    "nativeCurrency": {
+      "symbol": "ANKR"
+    }
+  },
+  {
+    "chainId": 267,
+    "name": "Neura Testnet",
+    "shortName": "tneura",
+    "nativeCurrency": {
+      "symbol": "ANKR"
+    }
+  },
+  {
+    "chainId": 268,
+    "name": "Neura Devnet",
+    "shortName": "dneura",
+    "nativeCurrency": {
+      "symbol": "ANKR"
+    }
+  },
+  {
+    "chainId": 269,
+    "name": "High Performance Blockchain",
+    "shortName": "hpb",
+    "nativeCurrency": {
+      "symbol": "HPB"
+    }
+  },
+  {
+    "chainId": 271,
+    "name": "EgonCoin Mainnet",
+    "shortName": "EGONm",
+    "nativeCurrency": {
+      "symbol": "EGON"
+    }
+  },
+  {
+    "chainId": 273,
+    "name": "XR One",
+    "shortName": "xr1",
+    "nativeCurrency": {
+      "symbol": "XR1"
+    }
+  },
+  {
+    "chainId": 274,
+    "name": "LaChain",
+    "shortName": "lachain",
+    "nativeCurrency": {
+      "symbol": "LAC"
+    }
+  },
+  {
+    "chainId": 278,
+    "name": "xFair.AI Mainnet",
+    "shortName": "fai",
+    "nativeCurrency": {
+      "symbol": "FAI"
+    }
+  },
+  {
+    "chainId": 279,
+    "name": "BPX Chain",
+    "shortName": "bpx",
+    "nativeCurrency": {
+      "symbol": "BPX"
+    }
+  },
+  {
+    "chainId": 280,
+    "name": "zkSync Era Goerli Testnet (deprecated)",
+    "shortName": "zksync-goerli",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 282,
+    "name": "Deprecated Cronos zkEVM Testnet",
+    "shortName": "deprecated-zkTCRO",
+    "nativeCurrency": {
+      "symbol": "zkTCRO"
+    }
+  },
+  {
+    "chainId": 288,
+    "name": "Boba Network",
+    "shortName": "Boba",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 291,
+    "name": "Orderly Mainnet",
+    "shortName": "orderly",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 293,
+    "name": "DaVinci",
+    "shortName": "davinci",
+    "nativeCurrency": {
+      "symbol": "DCOIN"
+    }
+  },
+  {
+    "chainId": 295,
+    "name": "Hedera Mainnet",
+    "shortName": "hedera-mainnet",
+    "nativeCurrency": {
+      "symbol": "HBAR"
+    }
+  },
+  {
+    "chainId": 296,
+    "name": "Hedera Testnet",
+    "shortName": "hedera-testnet",
+    "nativeCurrency": {
+      "symbol": "HBAR"
+    }
+  },
+  {
+    "chainId": 297,
+    "name": "Hedera Previewnet",
+    "shortName": "hedera-previewnet",
+    "nativeCurrency": {
+      "symbol": "HBAR"
+    }
+  },
+  {
+    "chainId": 298,
+    "name": "Hedera Localnet",
+    "shortName": "hedera-localnet",
+    "nativeCurrency": {
+      "symbol": "HBAR"
+    }
+  },
+  {
+    "chainId": 300,
+    "name": "zkSync Sepolia Testnet",
+    "shortName": "zksync-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 301,
+    "name": "Bobaopera",
+    "shortName": "Bobaopera",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 302,
+    "name": "ZKcandy Sepolia Testnet",
+    "shortName": "zkcandy-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 303,
+    "name": "Neurochain Testnet",
+    "shortName": "ncnt",
+    "nativeCurrency": {
+      "symbol": "tNCN"
+    }
+  },
+  {
+    "chainId": 305,
+    "name": "ZKSats Mainnet",
+    "shortName": "ZKSats-Mainnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 307,
+    "name": "Lovely Network Testnet",
+    "shortName": "LOVELY-Testnet",
+    "nativeCurrency": {
+      "symbol": "LOVELY"
+    }
+  },
+  {
+    "chainId": 308,
+    "name": "Furtheon",
+    "shortName": "furtheon",
+    "nativeCurrency": {
+      "symbol": "FTH"
+    }
+  },
+  {
+    "chainId": 309,
+    "name": "Wyzth Testnet",
+    "shortName": "wyz",
+    "nativeCurrency": {
+      "symbol": "WYZ"
+    }
+  },
+  {
+    "chainId": 311,
+    "name": "Omax Mainnet",
+    "shortName": "omax",
+    "nativeCurrency": {
+      "symbol": "OMAX"
+    }
+  },
+  {
+    "chainId": 313,
+    "name": "Neurochain Mainnet",
+    "shortName": "ncn",
+    "nativeCurrency": {
+      "symbol": "NCN"
+    }
+  },
+  {
+    "chainId": 314,
+    "name": "Filecoin - Mainnet",
+    "shortName": "filecoin",
+    "nativeCurrency": {
+      "symbol": "FIL"
+    }
+  },
+  {
+    "chainId": 315,
+    "name": "WorldEcoMoney",
+    "shortName": "wem",
+    "nativeCurrency": {
+      "symbol": "WEM"
+    }
+  },
+  {
+    "chainId": 320,
+    "name": "ZKcandy Mainnet",
+    "shortName": "zkcandy",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 321,
+    "name": "KCC Mainnet",
+    "shortName": "kcs",
+    "nativeCurrency": {
+      "symbol": "KCS"
+    }
+  },
+  {
+    "chainId": 322,
+    "name": "KCC Testnet",
+    "shortName": "kcst",
+    "nativeCurrency": {
+      "symbol": "tKCS"
+    }
+  },
+  {
+    "chainId": 323,
+    "name": "BuyCex Infinity Chain",
+    "shortName": "buycex",
+    "nativeCurrency": {
+      "symbol": "BCX"
+    }
+  },
+  {
+    "chainId": 324,
+    "name": "zkSync Mainnet",
+    "shortName": "zksync",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 325,
+    "name": "GRVT Exchange",
+    "shortName": "grvt",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 326,
+    "name": "GRVT Exchange Testnet",
+    "shortName": "grvt-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 329,
+    "name": "VirBiCoin",
+    "shortName": "virbicoin",
+    "nativeCurrency": {
+      "symbol": "VBC"
+    }
+  },
+  {
+    "chainId": 331,
+    "name": "Telos zkEVM Testnet",
+    "shortName": "telos-zkevm-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 332,
+    "name": "Omax Testnet",
+    "shortName": "omaxt",
+    "nativeCurrency": {
+      "symbol": "OMAX"
+    }
+  },
+  {
+    "chainId": 333,
+    "name": "EthStorage Mainnet",
+    "shortName": "es-m",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 335,
+    "name": "DFK Chain Test",
+    "shortName": "DFKTEST",
+    "nativeCurrency": {
+      "symbol": "JEWEL"
+    }
+  },
+  {
+    "chainId": 336,
+    "name": "Shiden",
+    "shortName": "sdn",
+    "nativeCurrency": {
+      "symbol": "SDN"
+    }
+  },
+  {
+    "chainId": 337,
+    "name": "R5 Network",
+    "shortName": "r5",
+    "nativeCurrency": {
+      "symbol": "R5"
+    }
+  },
+  {
+    "chainId": 338,
+    "name": "Cronos Testnet",
+    "shortName": "tcro",
+    "nativeCurrency": {
+      "symbol": "TCRO"
+    }
+  },
+  {
+    "chainId": 339,
+    "name": "Pencils Protocol",
+    "shortName": "dapp",
+    "nativeCurrency": {
+      "symbol": "DAPP"
+    }
+  },
+  {
+    "chainId": 345,
+    "name": "TSC Mainnet",
+    "shortName": "TSC",
+    "nativeCurrency": {
+      "symbol": "TAS"
+    }
+  },
+  {
+    "chainId": 360,
+    "name": "Shape",
+    "shortName": "shape",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 361,
+    "name": "Theta Mainnet",
+    "shortName": "theta-mainnet",
+    "nativeCurrency": {
+      "symbol": "TFUEL"
+    }
+  },
+  {
+    "chainId": 363,
+    "name": "Theta Sapphire Testnet",
+    "shortName": "theta-sapphire",
+    "nativeCurrency": {
+      "symbol": "TFUEL"
+    }
+  },
+  {
+    "chainId": 364,
+    "name": "Theta Amber Testnet",
+    "shortName": "theta-amber",
+    "nativeCurrency": {
+      "symbol": "TFUEL"
+    }
+  },
+  {
+    "chainId": 365,
+    "name": "Theta Testnet",
+    "shortName": "theta-testnet",
+    "nativeCurrency": {
+      "symbol": "TFUEL"
+    }
+  },
+  {
+    "chainId": 369,
+    "name": "PulseChain",
+    "shortName": "pls",
+    "nativeCurrency": {
+      "symbol": "PLS"
+    }
+  },
+  {
+    "chainId": 371,
+    "name": "Consta Testnet",
+    "shortName": "tCNT",
+    "nativeCurrency": {
+      "symbol": "tCNT"
+    }
+  },
+  {
+    "chainId": 373,
+    "name": "Status Network",
+    "shortName": "snt",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 374,
+    "name": "Status Network Hoodi",
+    "shortName": "snt-hoodi",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 375,
+    "name": "zkXPLA Mainnet",
+    "shortName": "zkxpla",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 380,
+    "name": "ZKAmoeba Testnet",
+    "shortName": "zkamoeba-test",
+    "nativeCurrency": {
+      "symbol": "FIL"
+    }
+  },
+  {
+    "chainId": 381,
+    "name": "ZKAmoeba Mainnet",
+    "shortName": "zkamoeba",
+    "nativeCurrency": {
+      "symbol": "FIL"
+    }
+  },
+  {
+    "chainId": 385,
+    "name": "Lisinski",
+    "shortName": "lisinski",
+    "nativeCurrency": {
+      "symbol": "LISINS"
+    }
+  },
+  {
+    "chainId": 388,
+    "name": "Cronos zkEVM Mainnet",
+    "shortName": "zkCRO",
+    "nativeCurrency": {
+      "symbol": "zkCRO"
+    }
+  },
+  {
+    "chainId": 395,
+    "name": "CamDL Testnet",
+    "shortName": "camdl-testnet",
+    "nativeCurrency": {
+      "symbol": "CADL"
+    }
+  },
+  {
+    "chainId": 397,
+    "name": "NEAR Protocol",
+    "shortName": "near",
+    "nativeCurrency": {
+      "symbol": "NEAR"
+    }
+  },
+  {
+    "chainId": 398,
+    "name": "NEAR Protocol Testnet",
+    "shortName": "near-testnet",
+    "nativeCurrency": {
+      "symbol": "NEAR"
+    }
+  },
+  {
+    "chainId": 399,
+    "name": "Nativ3 Mainnet",
+    "shortName": "N3",
+    "nativeCurrency": {
+      "symbol": "USNT"
+    }
+  },
+  {
+    "chainId": 400,
+    "name": "HyperonChain TestNet",
+    "shortName": "hpn",
+    "nativeCurrency": {
+      "symbol": "HPN"
+    }
+  },
+  {
+    "chainId": 401,
+    "name": "Ozone Chain Testnet",
+    "shortName": "ozo_tst",
+    "nativeCurrency": {
+      "symbol": "OZO"
+    }
+  },
+  {
+    "chainId": 404,
+    "name": "Syndr L3",
+    "shortName": "syndr-l3",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 411,
+    "name": "Pepe Chain Mainnet",
+    "shortName": "pepe",
+    "nativeCurrency": {
+      "symbol": "PEPE"
+    }
+  },
+  {
+    "chainId": 416,
+    "name": "SX Network Mainnet",
+    "shortName": "SX",
+    "nativeCurrency": {
+      "symbol": "SX"
+    }
+  },
+  {
+    "chainId": 418,
+    "name": "LaTestnet",
+    "shortName": "latestnet",
+    "nativeCurrency": {
+      "symbol": "TLA"
+    }
+  },
+  {
+    "chainId": 420,
+    "name": "Optimism Goerli Testnet",
+    "shortName": "ogor",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 422,
+    "name": "Viridis Mainnet",
+    "shortName": "vrd",
+    "nativeCurrency": {
+      "symbol": "VRD"
+    }
+  },
+  {
+    "chainId": 424,
+    "name": "PGN (Public Goods Network)",
+    "shortName": "PGN",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 425,
+    "name": "Stenix Mainnet",
+    "shortName": "sten",
+    "nativeCurrency": {
+      "symbol": "STEN"
+    }
+  },
+  {
+    "chainId": 426,
+    "name": "The Widows Mite",
+    "shortName": "mite",
+    "nativeCurrency": {
+      "symbol": "MITE"
+    }
+  },
+  {
+    "chainId": 427,
+    "name": "Zeeth Chain",
+    "shortName": "zeeth",
+    "nativeCurrency": {
+      "symbol": "ZTH"
+    }
+  },
+  {
+    "chainId": 428,
+    "name": "Geso Verse",
+    "shortName": "GSV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 432,
+    "name": "NutriEmp Chain",
+    "shortName": "nutriemp",
+    "nativeCurrency": {
+      "symbol": "GRAMZ"
+    }
+  },
+  {
+    "chainId": 434,
+    "name": "Boyaa Mainnet",
+    "shortName": "BYC",
+    "nativeCurrency": {
+      "symbol": "BYC"
+    }
+  },
+  {
+    "chainId": 443,
+    "name": "Ten Testnet",
+    "shortName": "ten-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 444,
+    "name": "Synapse Chain Testnet",
+    "shortName": "synapse-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 456,
+    "name": "ARZIO Chain",
+    "shortName": "arzio",
+    "nativeCurrency": {
+      "symbol": "AZO"
+    }
+  },
+  {
+    "chainId": 462,
+    "name": "Areon Network Testnet",
+    "shortName": "tarea",
+    "nativeCurrency": {
+      "symbol": "TAREA"
+    }
+  },
+  {
+    "chainId": 463,
+    "name": "Areum Network Mainnet",
+    "shortName": "area",
+    "nativeCurrency": {
+      "symbol": "AREA"
+    }
+  },
+  {
+    "chainId": 466,
+    "name": "AppChain",
+    "shortName": "appchain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 475,
+    "name": "zkXPLA Testnet",
+    "shortName": "zkxpla-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 478,
+    "name": "Form Network",
+    "shortName": "formnetwork",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 480,
+    "name": "World Chain",
+    "shortName": "wc",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 484,
+    "name": "Camp Network Mainnet",
+    "shortName": "CampMainnet",
+    "nativeCurrency": {
+      "symbol": "CAMP"
+    }
+  },
+  {
+    "chainId": 486,
+    "name": "Standard Mainnet",
+    "shortName": "stnd",
+    "nativeCurrency": {
+      "symbol": "STND"
+    }
+  },
+  {
+    "chainId": 488,
+    "name": "BlackFort Exchange Network",
+    "shortName": "BXN",
+    "nativeCurrency": {
+      "symbol": "BXN"
+    }
+  },
+  {
+    "chainId": 495,
+    "name": "Landstars",
+    "shortName": "lds",
+    "nativeCurrency": {
+      "symbol": "LDS"
+    }
+  },
+  {
+    "chainId": 499,
+    "name": "Rupaya",
+    "shortName": "rupx",
+    "nativeCurrency": {
+      "symbol": "RUPX"
+    }
+  },
+  {
+    "chainId": 500,
+    "name": "Camino C-Chain",
+    "shortName": "Camino",
+    "nativeCurrency": {
+      "symbol": "CAM"
+    }
+  },
+  {
+    "chainId": 501,
+    "name": "Columbus Test Network",
+    "shortName": "Columbus",
+    "nativeCurrency": {
+      "symbol": "CAM"
+    }
+  },
+  {
+    "chainId": 505,
+    "name": "DotOne Smart Chain",
+    "shortName": "doto",
+    "nativeCurrency": {
+      "symbol": "DOTO"
+    }
+  },
+  {
+    "chainId": 510,
+    "name": "Syndicate Mainnet",
+    "shortName": "syndicate",
+    "nativeCurrency": {
+      "symbol": "SYND"
+    }
+  },
+  {
+    "chainId": 512,
+    "name": "Double-A Chain Mainnet",
+    "shortName": "aac",
+    "nativeCurrency": {
+      "symbol": "AAC"
+    }
+  },
+  {
+    "chainId": 513,
+    "name": "Double-A Chain Testnet",
+    "shortName": "aact",
+    "nativeCurrency": {
+      "symbol": "AAC"
+    }
+  },
+  {
+    "chainId": 516,
+    "name": "Gear Zero Network Mainnet",
+    "shortName": "gz-mainnet",
+    "nativeCurrency": {
+      "symbol": "GZN"
+    }
+  },
+  {
+    "chainId": 520,
+    "name": "XT Smart Chain Mainnet",
+    "shortName": "xt",
+    "nativeCurrency": {
+      "symbol": "XT"
+    }
+  },
+  {
+    "chainId": 529,
+    "name": "Firechain Mainnet",
+    "shortName": "fire",
+    "nativeCurrency": {
+      "symbol": "FIRE"
+    }
+  },
+  {
+    "chainId": 530,
+    "name": "Pundi AIFX Omnilayer",
+    "shortName": "pundiai",
+    "nativeCurrency": {
+      "symbol": "PUNDAI"
+    }
+  },
+  {
+    "chainId": 534,
+    "name": "Candle",
+    "shortName": "CNDL",
+    "nativeCurrency": {
+      "symbol": "CNDL"
+    }
+  },
+  {
+    "chainId": 537,
+    "name": "OpTrust Mainnet",
+    "shortName": "optrust",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 542,
+    "name": "PAWCHAIN Testnet",
+    "shortName": "PAW",
+    "nativeCurrency": {
+      "symbol": "PAW"
+    }
+  },
+  {
+    "chainId": 545,
+    "name": "Flow EVM Testnet",
+    "shortName": "flow-testnet",
+    "nativeCurrency": {
+      "symbol": "FLOW"
+    }
+  },
+  {
+    "chainId": 550,
+    "name": "River",
+    "shortName": "river",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 555,
+    "name": "Vela1 Chain Mainnet",
+    "shortName": "CLASS",
+    "nativeCurrency": {
+      "symbol": "CLASS"
+    }
+  },
+  {
+    "chainId": 558,
+    "name": "Tao Network",
+    "shortName": "tao",
+    "nativeCurrency": {
+      "symbol": "TAO"
+    }
+  },
+  {
+    "chainId": 565,
+    "name": "Prometheuz Testnet",
+    "shortName": "prometheuz-testnet",
+    "nativeCurrency": {
+      "symbol": "PYRE"
+    }
+  },
+  {
+    "chainId": 567,
+    "name": "Validium Network",
+    "shortName": "validium-testnet",
+    "nativeCurrency": {
+      "symbol": "VLDM"
+    }
+  },
+  {
+    "chainId": 568,
+    "name": "Dogechain Testnet",
+    "shortName": "dct",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 570,
+    "name": "Rollux Mainnet",
+    "shortName": "sys-rollux",
+    "nativeCurrency": {
+      "symbol": "SYS"
+    }
+  },
+  {
+    "chainId": 571,
+    "name": "MetaChain Mainnet",
+    "shortName": "metatime",
+    "nativeCurrency": {
+      "symbol": "MTC"
+    }
+  },
+  {
+    "chainId": 579,
+    "name": "Filenova Mainnet",
+    "shortName": "filenova",
+    "nativeCurrency": {
+      "symbol": "FIL"
+    }
+  },
+  {
+    "chainId": 588,
+    "name": "Metis Stardust Testnet",
+    "shortName": "metis-stardust",
+    "nativeCurrency": {
+      "symbol": "METIS"
+    }
+  },
+  {
+    "chainId": 592,
+    "name": "Astar",
+    "shortName": "astr",
+    "nativeCurrency": {
+      "symbol": "ASTR"
+    }
+  },
+  {
+    "chainId": 595,
+    "name": "Acala Mandala Testnet TC9",
+    "shortName": "maca",
+    "nativeCurrency": {
+      "symbol": "mACA"
+    }
+  },
+  {
+    "chainId": 596,
+    "name": "Karura Network Testnet",
+    "shortName": "tkar",
+    "nativeCurrency": {
+      "symbol": "KAR"
+    }
+  },
+  {
+    "chainId": 597,
+    "name": "Acala Network Testnet",
+    "shortName": "taca",
+    "nativeCurrency": {
+      "symbol": "ACA"
+    }
+  },
+  {
+    "chainId": 599,
+    "name": "Metis Goerli Testnet",
+    "shortName": "metis-goerli",
+    "nativeCurrency": {
+      "symbol": "METIS"
+    }
+  },
+  {
+    "chainId": 600,
+    "name": "Meshnyan testnet",
+    "shortName": "mesh-chain-testnet",
+    "nativeCurrency": {
+      "symbol": "MESHT"
+    }
+  },
+  {
+    "chainId": 601,
+    "name": "Vine Testnet",
+    "shortName": "VINE",
+    "nativeCurrency": {
+      "symbol": "VNE"
+    }
+  },
+  {
+    "chainId": 610,
+    "name": "Darwin Devnet",
+    "shortName": "darwin-devnet",
+    "nativeCurrency": {
+      "symbol": "DNA"
+    }
+  },
+  {
+    "chainId": 612,
+    "name": "EIOB Mainnet",
+    "shortName": "eiob",
+    "nativeCurrency": {
+      "symbol": "EIOB"
+    }
+  },
+  {
+    "chainId": 614,
+    "name": "Graphlinq Blockchain Mainnet",
+    "shortName": "glq",
+    "nativeCurrency": {
+      "symbol": "GLQ"
+    }
+  },
+  {
+    "chainId": 619,
+    "name": "Skynet",
+    "shortName": "Skynet",
+    "nativeCurrency": {
+      "symbol": "sUSD"
+    }
+  },
+  {
+    "chainId": 624,
+    "name": "Binary Mainnet",
+    "shortName": "thebinaryholdings-mainnet",
+    "nativeCurrency": {
+      "symbol": "BNRY"
+    }
+  },
+  {
+    "chainId": 625,
+    "name": "Binary Sepolia",
+    "shortName": "thebinaryholdings-sepolia",
+    "nativeCurrency": {
+      "symbol": "BNRY"
+    }
+  },
+  {
+    "chainId": 626,
+    "name": "BattleChain Mainnet",
+    "shortName": "battlechain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 627,
+    "name": "BattleChain Testnet",
+    "shortName": "battlechain-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 632,
+    "name": "NFB Chain",
+    "shortName": "nfbchain",
+    "nativeCurrency": {
+      "symbol": "NFBC"
+    }
+  },
+  {
+    "chainId": 634,
+    "name": "Avocado",
+    "shortName": "avocado",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 646,
+    "name": "Flow EVM Previewnet",
+    "shortName": "flow-previewnet",
+    "nativeCurrency": {
+      "symbol": "FLOW"
+    }
+  },
+  {
+    "chainId": 647,
+    "name": "SX Network Testnet",
+    "shortName": "SX-Testnet",
+    "nativeCurrency": {
+      "symbol": "SX"
+    }
+  },
+  {
+    "chainId": 648,
+    "name": "Endurance Smart Chain Mainnet",
+    "shortName": "ace",
+    "nativeCurrency": {
+      "symbol": "ACE"
+    }
+  },
+  {
+    "chainId": 653,
+    "name": "Kalichain Testnet",
+    "shortName": "kalichain",
+    "nativeCurrency": {
+      "symbol": "KALIS"
+    }
+  },
+  {
+    "chainId": 654,
+    "name": "Kalichain",
+    "shortName": "kalichainMainnet",
+    "nativeCurrency": {
+      "symbol": "KALIS"
+    }
+  },
+  {
+    "chainId": 662,
+    "name": "AmaxSmartchain",
+    "shortName": "Amaxsmartchain",
+    "nativeCurrency": {
+      "symbol": "AMAX"
+    }
+  },
+  {
+    "chainId": 666,
+    "name": "Pixie Chain Testnet",
+    "shortName": "pixie-chain-testnet",
+    "nativeCurrency": {
+      "symbol": "PCTT"
+    }
+  },
+  {
+    "chainId": 667,
+    "name": "LAOS Arrakis",
+    "shortName": "laos",
+    "nativeCurrency": {
+      "symbol": "LAOS"
+    }
+  },
+  {
+    "chainId": 668,
+    "name": "JuncaChain",
+    "shortName": "junca",
+    "nativeCurrency": {
+      "symbol": "JGC"
+    }
+  },
+  {
+    "chainId": 669,
+    "name": "JuncaChain testnet",
+    "shortName": "juncat",
+    "nativeCurrency": {
+      "symbol": "JGCT"
+    }
+  },
+  {
+    "chainId": 678,
+    "name": "Janction",
+    "shortName": "janction",
+    "nativeCurrency": {
+      "symbol": "JCT"
+    }
+  },
+  {
+    "chainId": 679,
+    "name": "Janction Testnet",
+    "shortName": "janction_testnet",
+    "nativeCurrency": {
+      "symbol": "JCT"
+    }
+  },
+  {
+    "chainId": 680,
+    "name": "JasmyChain",
+    "shortName": "jasmychain",
+    "nativeCurrency": {
+      "symbol": "JASMY"
+    }
+  },
+  {
+    "chainId": 681,
+    "name": "JasmyChain Testnet",
+    "shortName": "jasmychain-test",
+    "nativeCurrency": {
+      "symbol": "JASMY"
+    }
+  },
+  {
+    "chainId": 686,
+    "name": "Karura Network",
+    "shortName": "kar",
+    "nativeCurrency": {
+      "symbol": "KAR"
+    }
+  },
+  {
+    "chainId": 689,
+    "name": "NERO Testnet",
+    "shortName": "NEROT",
+    "nativeCurrency": {
+      "symbol": "NERO"
+    }
+  },
+  {
+    "chainId": 690,
+    "name": "Redstone",
+    "shortName": "redstone",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 698,
+    "name": "Matchain",
+    "shortName": "Matchain",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 699,
+    "name": "Matchain Testnet",
+    "shortName": "tMatchain",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 700,
+    "name": "Star Social Testnet",
+    "shortName": "SNS",
+    "nativeCurrency": {
+      "symbol": "SNS"
+    }
+  },
+  {
+    "chainId": 701,
+    "name": "Darwinia Koi Testnet",
+    "shortName": "darwinia-koi",
+    "nativeCurrency": {
+      "symbol": "KRING"
+    }
+  },
+  {
+    "chainId": 707,
+    "name": "BlockChain Station Mainnet",
+    "shortName": "bcs",
+    "nativeCurrency": {
+      "symbol": "BCS"
+    }
+  },
+  {
+    "chainId": 708,
+    "name": "BlockChain Station Testnet",
+    "shortName": "tbcs",
+    "nativeCurrency": {
+      "symbol": "tBCS"
+    }
+  },
+  {
+    "chainId": 710,
+    "name": "Highbury",
+    "shortName": "fury",
+    "nativeCurrency": {
+      "symbol": "FURY"
+    }
+  },
+  {
+    "chainId": 711,
+    "name": "Tucana",
+    "shortName": "tuc",
+    "nativeCurrency": {
+      "symbol": "TUC"
+    }
+  },
+  {
+    "chainId": 712,
+    "name": "Birdee-2",
+    "shortName": "birdee-2",
+    "nativeCurrency": {
+      "symbol": "TUC"
+    }
+  },
+  {
+    "chainId": 713,
+    "name": "Vrcscan Mainnet",
+    "shortName": "vrc",
+    "nativeCurrency": {
+      "symbol": "VRC"
+    }
+  },
+  {
+    "chainId": 714,
+    "name": "Eden",
+    "shortName": "eden",
+    "nativeCurrency": {
+      "symbol": "TIA"
+    }
+  },
+  {
+    "chainId": 718,
+    "name": "UXLINK ONE Mainnet",
+    "shortName": "uxlink1",
+    "nativeCurrency": {
+      "symbol": "UXLINK"
+    }
+  },
+  {
+    "chainId": 719,
+    "name": "Shibarium Beta",
+    "shortName": "shibarium",
+    "nativeCurrency": {
+      "symbol": "BONE"
+    }
+  },
+  {
+    "chainId": 721,
+    "name": "Lycan Chain",
+    "shortName": "LYC",
+    "nativeCurrency": {
+      "symbol": "LYC"
+    }
+  },
+  {
+    "chainId": 723,
+    "name": "Bitasset Chain Mainnet",
+    "shortName": "bac",
+    "nativeCurrency": {
+      "symbol": "BAC"
+    }
+  },
+  {
+    "chainId": 727,
+    "name": "Blucrates",
+    "shortName": "blu",
+    "nativeCurrency": {
+      "symbol": "BLU"
+    }
+  },
+  {
+    "chainId": 730,
+    "name": "Lovely Network Mainnet",
+    "shortName": "LOVELY",
+    "nativeCurrency": {
+      "symbol": "LOVELY"
+    }
+  },
+  {
+    "chainId": 740,
+    "name": "Canto Testnet",
+    "shortName": "tcanto",
+    "nativeCurrency": {
+      "symbol": "CANTO"
+    }
+  },
+  {
+    "chainId": 741,
+    "name": "Vention Smart Chain Testnet",
+    "shortName": "vsct",
+    "nativeCurrency": {
+      "symbol": "VNT"
+    }
+  },
+  {
+    "chainId": 742,
+    "name": "Script Testnet",
+    "shortName": "SPAY",
+    "nativeCurrency": {
+      "symbol": "SPAY"
+    }
+  },
+  {
+    "chainId": 743,
+    "name": "Tranched Mainnet",
+    "shortName": "tranched-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 747,
+    "name": "Flow EVM Mainnet",
+    "shortName": "flow-mainnet",
+    "nativeCurrency": {
+      "symbol": "FLOW"
+    }
+  },
+  {
+    "chainId": 753,
+    "name": "Rivalz",
+    "shortName": "rivalz",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 766,
+    "name": "QL1",
+    "shortName": "qom",
+    "nativeCurrency": {
+      "symbol": "QOM"
+    }
+  },
+  {
+    "chainId": 776,
+    "name": "OpenChain Testnet",
+    "shortName": "opc",
+    "nativeCurrency": {
+      "symbol": "TOPC"
+    }
+  },
+  {
+    "chainId": 777,
+    "name": "cheapETH",
+    "shortName": "cth",
+    "nativeCurrency": {
+      "symbol": "cTH"
+    }
+  },
+  {
+    "chainId": 785,
+    "name": "AUTHEO Testnet",
+    "shortName": "autheo-Test-Chain",
+    "nativeCurrency": {
+      "symbol": "THEO"
+    }
+  },
+  {
+    "chainId": 786,
+    "name": "MAAL Chain",
+    "shortName": "maal",
+    "nativeCurrency": {
+      "symbol": "MAAL"
+    }
+  },
+  {
+    "chainId": 787,
+    "name": "Acala Network",
+    "shortName": "aca",
+    "nativeCurrency": {
+      "symbol": "ACA"
+    }
+  },
+  {
+    "chainId": 788,
+    "name": "Aerochain Testnet",
+    "shortName": "taero",
+    "nativeCurrency": {
+      "symbol": "TAero"
+    }
+  },
+  {
+    "chainId": 789,
+    "name": "Patex",
+    "shortName": "peth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 799,
+    "name": "Rupaya Testnet",
+    "shortName": "RupayaTestnet",
+    "nativeCurrency": {
+      "symbol": "TRUPX"
+    }
+  },
+  {
+    "chainId": 800,
+    "name": "Lucid Blockchain",
+    "shortName": "LUCID",
+    "nativeCurrency": {
+      "symbol": "LUCID"
+    }
+  },
+  {
+    "chainId": 803,
+    "name": "Haic",
+    "shortName": "haic",
+    "nativeCurrency": {
+      "symbol": "HAIC"
+    }
+  },
+  {
+    "chainId": 805,
+    "name": "Evoz Mainnet",
+    "shortName": "Evoz",
+    "nativeCurrency": {
+      "symbol": "EVOZ"
+    }
+  },
+  {
+    "chainId": 808,
+    "name": "Portal Fantasy Chain Test",
+    "shortName": "PFTEST",
+    "nativeCurrency": {
+      "symbol": "PFT"
+    }
+  },
+  {
+    "chainId": 810,
+    "name": "Haven1 Testnet",
+    "shortName": "h1",
+    "nativeCurrency": {
+      "symbol": "H1"
+    }
+  },
+  {
+    "chainId": 813,
+    "name": "Qitmeer Network Mainnet",
+    "shortName": "meer",
+    "nativeCurrency": {
+      "symbol": "MEER"
+    }
+  },
+  {
+    "chainId": 814,
+    "name": "Firechain zkEVM",
+    "shortName": "firechan-zkEVM",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 818,
+    "name": "BeOne Chain Mainnet",
+    "shortName": "BOC",
+    "nativeCurrency": {
+      "symbol": "BOC"
+    }
+  },
+  {
+    "chainId": 820,
+    "name": "Callisto Mainnet",
+    "shortName": "clo",
+    "nativeCurrency": {
+      "symbol": "CLO"
+    }
+  },
+  {
+    "chainId": 821,
+    "name": "Callisto Testnet Deprecated",
+    "shortName": "tclo",
+    "nativeCurrency": {
+      "symbol": "TCLO"
+    }
+  },
+  {
+    "chainId": 822,
+    "name": "Runic Chain Testnet",
+    "shortName": "runic-testnet",
+    "nativeCurrency": {
+      "symbol": "rBTC"
+    }
+  },
+  {
+    "chainId": 824,
+    "name": "Daily Network Mainnet",
+    "shortName": "dly",
+    "nativeCurrency": {
+      "symbol": "DLY"
+    }
+  },
+  {
+    "chainId": 825,
+    "name": "Daily Network Testnet",
+    "shortName": "tdly",
+    "nativeCurrency": {
+      "symbol": "DLY"
+    }
+  },
+  {
+    "chainId": 831,
+    "name": "CheckDot Blockchain Devnet",
+    "shortName": "cdt",
+    "nativeCurrency": {
+      "symbol": "CDT"
+    }
+  },
+  {
+    "chainId": 841,
+    "name": "Taraxa Mainnet",
+    "shortName": "tara",
+    "nativeCurrency": {
+      "symbol": "TARA"
+    }
+  },
+  {
+    "chainId": 842,
+    "name": "Taraxa Testnet",
+    "shortName": "taratest",
+    "nativeCurrency": {
+      "symbol": "TARA"
+    }
+  },
+  {
+    "chainId": 852,
+    "name": "HongKong Mainnet",
+    "shortName": "HongKong",
+    "nativeCurrency": {
+      "symbol": "HK"
+    }
+  },
+  {
+    "chainId": 859,
+    "name": "Zeeth Chain Dev",
+    "shortName": "zeethdev",
+    "nativeCurrency": {
+      "symbol": "ZTH"
+    }
+  },
+  {
+    "chainId": 861,
+    "name": "Electra Network",
+    "shortName": "elc",
+    "nativeCurrency": {
+      "symbol": "ELC"
+    }
+  },
+  {
+    "chainId": 863,
+    "name": "Radius Testnet",
+    "shortName": "radius-testnet",
+    "nativeCurrency": {
+      "symbol": "USLS"
+    }
+  },
+  {
+    "chainId": 868,
+    "name": "Fantasia Chain Mainnet",
+    "shortName": "FSCMainnet",
+    "nativeCurrency": {
+      "symbol": "FST"
+    }
+  },
+  {
+    "chainId": 869,
+    "name": "WorldMobileChain-Mainnet",
+    "shortName": "WMC",
+    "nativeCurrency": {
+      "symbol": "WMTX"
+    }
+  },
+  {
+    "chainId": 871,
+    "name": "Electra Test Network",
+    "shortName": "telc",
+    "nativeCurrency": {
+      "symbol": "TELC"
+    }
+  },
+  {
+    "chainId": 876,
+    "name": "Bandai Namco Research Verse Mainnet",
+    "shortName": "BNKEN",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 877,
+    "name": "Dexit Network",
+    "shortName": "DXT",
+    "nativeCurrency": {
+      "symbol": "DXT"
+    }
+  },
+  {
+    "chainId": 880,
+    "name": "Ambros Chain Mainnet",
+    "shortName": "ambros",
+    "nativeCurrency": {
+      "symbol": "AMBROS"
+    }
+  },
+  {
+    "chainId": 881,
+    "name": "Weber Governance Mainnet",
+    "shortName": "ptt",
+    "nativeCurrency": {
+      "symbol": "PTT"
+    }
+  },
+  {
+    "chainId": 888,
+    "name": "Wanchain",
+    "shortName": "wan",
+    "nativeCurrency": {
+      "symbol": "WAN"
+    }
+  },
+  {
+    "chainId": 890,
+    "name": "Capital Exchange",
+    "shortName": "CXM",
+    "nativeCurrency": {
+      "symbol": "CXM"
+    }
+  },
+  {
+    "chainId": 898,
+    "name": "MAXI Chain Testnet",
+    "shortName": "maxi-testnet",
+    "nativeCurrency": {
+      "symbol": "MGAS"
+    }
+  },
+  {
+    "chainId": 899,
+    "name": "MAXI Chain Mainnet",
+    "shortName": "maxi-mainnet",
+    "nativeCurrency": {
+      "symbol": "MGAS"
+    }
+  },
+  {
+    "chainId": 900,
+    "name": "Garizon Testnet Stage0",
+    "shortName": "gar-test-s0",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 901,
+    "name": "Garizon Testnet Stage1",
+    "shortName": "gar-test-s1",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 902,
+    "name": "Garizon Testnet Stage2",
+    "shortName": "gar-test-s2",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 903,
+    "name": "Garizon Testnet Stage3",
+    "shortName": "gar-test-s3",
+    "nativeCurrency": {
+      "symbol": "GAR"
+    }
+  },
+  {
+    "chainId": 904,
+    "name": "Ault Blockchain Mainnet",
+    "shortName": "ault",
+    "nativeCurrency": {
+      "symbol": "AULT"
+    }
+  },
+  {
+    "chainId": 909,
+    "name": "Portal Fantasy Chain",
+    "shortName": "PF",
+    "nativeCurrency": {
+      "symbol": "PFT"
+    }
+  },
+  {
+    "chainId": 910,
+    "name": "DecentraBone Layer1 Testnet",
+    "shortName": "DBONE",
+    "nativeCurrency": {
+      "symbol": "DBONE"
+    }
+  },
+  {
+    "chainId": 911,
+    "name": "TAPROOT Mainnet",
+    "shortName": "TAPROOT-Mainnet",
+    "nativeCurrency": {
+      "symbol": "TBTC"
+    }
+  },
+  {
+    "chainId": 917,
+    "name": "Rinia",
+    "shortName": "tfire",
+    "nativeCurrency": {
+      "symbol": "FIRE"
+    }
+  },
+  {
+    "chainId": 918,
+    "name": "SlerfChain Mainnet",
+    "shortName": "SlerfChain-Mainnet",
+    "nativeCurrency": {
+      "symbol": "WSLERF"
+    }
+  },
+  {
+    "chainId": 919,
+    "name": "Mode Testnet",
+    "shortName": "modesep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 920,
+    "name": "Fenine Testnet",
+    "shortName": "FEN",
+    "nativeCurrency": {
+      "symbol": "FEN"
+    }
+  },
+  {
+    "chainId": 927,
+    "name": "Yidark Chain Mainnet",
+    "shortName": "ydk",
+    "nativeCurrency": {
+      "symbol": "YDK"
+    }
+  },
+  {
+    "chainId": 938,
+    "name": "Haust Mainnet",
+    "shortName": "haust",
+    "nativeCurrency": {
+      "symbol": "HAUST"
+    }
+  },
+  {
+    "chainId": 940,
+    "name": "PulseChain Testnet",
+    "shortName": "tpls",
+    "nativeCurrency": {
+      "symbol": "tPLS"
+    }
+  },
+  {
+    "chainId": 941,
+    "name": "PulseChain Testnet v2b",
+    "shortName": "t2bpls",
+    "nativeCurrency": {
+      "symbol": "tPLS"
+    }
+  },
+  {
+    "chainId": 942,
+    "name": "PulseChain Testnet v3",
+    "shortName": "t3pls",
+    "nativeCurrency": {
+      "symbol": "tPLS"
+    }
+  },
+  {
+    "chainId": 943,
+    "name": "PulseChain Testnet v4",
+    "shortName": "t4pls",
+    "nativeCurrency": {
+      "symbol": "tPLS"
+    }
+  },
+  {
+    "chainId": 945,
+    "name": "Subtensor EVM Testnet",
+    "shortName": "bittensor-evm-testnet",
+    "nativeCurrency": {
+      "symbol": "TAO"
+    }
+  },
+  {
+    "chainId": 956,
+    "name": "muNode Testnet",
+    "shortName": "munode",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 957,
+    "name": "Lyra Chain",
+    "shortName": "lyra",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 963,
+    "name": "BTC20 Smart Chain",
+    "shortName": "btc20",
+    "nativeCurrency": {
+      "symbol": "BTCC"
+    }
+  },
+  {
+    "chainId": 964,
+    "name": "Subtensor EVM",
+    "shortName": "bittensor-evm-mainnet",
+    "nativeCurrency": {
+      "symbol": "TAO"
+    }
+  },
+  {
+    "chainId": 968,
+    "name": "Datagram",
+    "shortName": "dgram",
+    "nativeCurrency": {
+      "symbol": "DGRAM"
+    }
+  },
+  {
+    "chainId": 969,
+    "name": "EthXY",
+    "shortName": "sexy",
+    "nativeCurrency": {
+      "symbol": "SEXY"
+    }
+  },
+  {
+    "chainId": 970,
+    "name": "Oort Mainnet",
+    "shortName": "ccn",
+    "nativeCurrency": {
+      "symbol": "OORT"
+    }
+  },
+  {
+    "chainId": 971,
+    "name": "Oort Huygens",
+    "shortName": "Huygens",
+    "nativeCurrency": {
+      "symbol": "CCN"
+    }
+  },
+  {
+    "chainId": 972,
+    "name": "Oort Ascraeus",
+    "shortName": "Ascraeus",
+    "nativeCurrency": {
+      "symbol": "CCNA"
+    }
+  },
+  {
+    "chainId": 973,
+    "name": "Palm Smart Chain",
+    "shortName": "PalmChain",
+    "nativeCurrency": {
+      "symbol": "PALM"
+    }
+  },
+  {
+    "chainId": 977,
+    "name": "Nepal Blockchain Network",
+    "shortName": "yeti",
+    "nativeCurrency": {
+      "symbol": "YETI"
+    }
+  },
+  {
+    "chainId": 979,
+    "name": "EthXY Testnet",
+    "shortName": "sexyTestnet",
+    "nativeCurrency": {
+      "symbol": "SEXY"
+    }
+  },
+  {
+    "chainId": 980,
+    "name": "TOP Mainnet EVM",
+    "shortName": "top_evm",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 984,
+    "name": "IOPN Testnet",
+    "shortName": "iopn-Test-Chain",
+    "nativeCurrency": {
+      "symbol": "OPN"
+    }
+  },
+  {
+    "chainId": 985,
+    "name": "Memo Smart Chain Mainnet",
+    "shortName": "memochain",
+    "nativeCurrency": {
+      "symbol": "CMEMO"
+    }
+  },
+  {
+    "chainId": 986,
+    "name": "LAGOM Mainnet",
+    "shortName": "Lagom-Chain",
+    "nativeCurrency": {
+      "symbol": "LAGO"
+    }
+  },
+  {
+    "chainId": 987,
+    "name": "BinaryChain Mainnet",
+    "shortName": "binary",
+    "nativeCurrency": {
+      "symbol": "BNRY"
+    }
+  },
+  {
+    "chainId": 988,
+    "name": "Stable Mainnet",
+    "shortName": "stable",
+    "nativeCurrency": {
+      "symbol": "USDT0"
+    }
+  },
+  {
+    "chainId": 989,
+    "name": "TOP Mainnet",
+    "shortName": "top",
+    "nativeCurrency": {
+      "symbol": "TOP"
+    }
+  },
+  {
+    "chainId": 990,
+    "name": "eLiberty Mainnet",
+    "shortName": "ELm",
+    "nativeCurrency": {
+      "symbol": "$EL"
+    }
+  },
+  {
+    "chainId": 995,
+    "name": "5ireChain Mainnet",
+    "shortName": "5ire",
+    "nativeCurrency": {
+      "symbol": "5ire"
+    }
+  },
+  {
+    "chainId": 996,
+    "name": "Bifrost Polkadot Mainnet",
+    "shortName": "bnc",
+    "nativeCurrency": {
+      "symbol": "WETH"
+    }
+  },
+  {
+    "chainId": 997,
+    "name": "5ireChain Thunder Testnet",
+    "shortName": "T5ire",
+    "nativeCurrency": {
+      "symbol": "T5IRE"
+    }
+  },
+  {
+    "chainId": 998,
+    "name": "Hyperliquid EVM Testnet",
+    "shortName": "hype-evm-testnet",
+    "nativeCurrency": {
+      "symbol": "HYPE"
+    }
+  },
+  {
+    "chainId": 999,
+    "name": "Wanchain Testnet",
+    "shortName": "twan",
+    "nativeCurrency": {
+      "symbol": "WAN"
+    }
+  },
+  {
+    "chainId": 1000,
+    "name": "GTON Mainnet",
+    "shortName": "gton",
+    "nativeCurrency": {
+      "symbol": "GCD"
+    }
+  },
+  {
+    "chainId": 1001,
+    "name": "Kaia Kairos Testnet",
+    "shortName": "kaia-kairos",
+    "nativeCurrency": {
+      "symbol": "KAIA"
+    }
+  },
+  {
+    "chainId": 1003,
+    "name": "Tectum Emission Token",
+    "shortName": "tet",
+    "nativeCurrency": {
+      "symbol": "TET"
+    }
+  },
+  {
+    "chainId": 1004,
+    "name": "T-EKTA",
+    "shortName": "t-ekta",
+    "nativeCurrency": {
+      "symbol": "T-EKTA"
+    }
+  },
+  {
+    "chainId": 1005,
+    "name": "LemonChainTestnet",
+    "shortName": "tlemx",
+    "nativeCurrency": {
+      "symbol": "tLEMX"
+    }
+  },
+  {
+    "chainId": 1006,
+    "name": "LemonChain",
+    "shortName": "lemx",
+    "nativeCurrency": {
+      "symbol": "LEMX"
+    }
+  },
+  {
+    "chainId": 1007,
+    "name": "Newton Testnet",
+    "shortName": "tnew",
+    "nativeCurrency": {
+      "symbol": "NEW"
+    }
+  },
+  {
+    "chainId": 1008,
+    "name": "Eurus Mainnet",
+    "shortName": "eun",
+    "nativeCurrency": {
+      "symbol": "EUN"
+    }
+  },
+  {
+    "chainId": 1009,
+    "name": "Jumbochain Mainnet",
+    "shortName": "Jumboscan",
+    "nativeCurrency": {
+      "symbol": "JNFTC"
+    }
+  },
+  {
+    "chainId": 1010,
+    "name": "Evrice Network",
+    "shortName": "EVC",
+    "nativeCurrency": {
+      "symbol": "EVC"
+    }
+  },
+  {
+    "chainId": 1011,
+    "name": "Rebus Classic Mainnet",
+    "shortName": "rebusclassic",
+    "nativeCurrency": {
+      "symbol": "REBUS"
+    }
+  },
+  {
+    "chainId": 1012,
+    "name": "Newton",
+    "shortName": "new",
+    "nativeCurrency": {
+      "symbol": "NEW"
+    }
+  },
+  {
+    "chainId": 1022,
+    "name": "Sakura",
+    "shortName": "sku",
+    "nativeCurrency": {
+      "symbol": "SKU"
+    }
+  },
+  {
+    "chainId": 1023,
+    "name": "Clover Testnet",
+    "shortName": "tclv",
+    "nativeCurrency": {
+      "symbol": "CLV"
+    }
+  },
+  {
+    "chainId": 1024,
+    "name": "CLV Parachain",
+    "shortName": "clv",
+    "nativeCurrency": {
+      "symbol": "CLV"
+    }
+  },
+  {
+    "chainId": 1028,
+    "name": "BitTorrent Chain Testnet",
+    "shortName": "tbtt-deprecated",
+    "nativeCurrency": {
+      "symbol": "BTT"
+    }
+  },
+  {
+    "chainId": 1029,
+    "name": "BitTorrent Chain Donau",
+    "shortName": "tBTT",
+    "nativeCurrency": {
+      "symbol": "BTT"
+    }
+  },
+  {
+    "chainId": 1030,
+    "name": "Conflux eSpace",
+    "shortName": "cfx",
+    "nativeCurrency": {
+      "symbol": "CFX"
+    }
+  },
+  {
+    "chainId": 1031,
+    "name": "Proxy Network Testnet",
+    "shortName": "prx",
+    "nativeCurrency": {
+      "symbol": "PRX"
+    }
+  },
+  {
+    "chainId": 1038,
+    "name": "Bronos Testnet",
+    "shortName": "bronos-testnet",
+    "nativeCurrency": {
+      "symbol": "tBRO"
+    }
+  },
+  {
+    "chainId": 1039,
+    "name": "Bronos Mainnet",
+    "shortName": "bronos-mainnet",
+    "nativeCurrency": {
+      "symbol": "BRO"
+    }
+  },
+  {
+    "chainId": 1071,
+    "name": "OpenGPU Mainnet",
+    "shortName": "ogpu",
+    "nativeCurrency": {
+      "symbol": "OGPU"
+    }
+  },
+  {
+    "chainId": 1072,
+    "name": "ShimmerEVM Testnet Deprecated 1072",
+    "shortName": "shimmerevm-testnet-deprecated-1072",
+    "nativeCurrency": {
+      "symbol": "SMR"
+    }
+  },
+  {
+    "chainId": 1073,
+    "name": "ShimmerEVM Testnet",
+    "shortName": "shimmerevm-testnet",
+    "nativeCurrency": {
+      "symbol": "SMR"
+    }
+  },
+  {
+    "chainId": 1075,
+    "name": "IOTA EVM Testnet",
+    "shortName": "iotaevm-testnet",
+    "nativeCurrency": {
+      "symbol": "IOTA"
+    }
+  },
+  {
+    "chainId": 1079,
+    "name": "Mintara Testnet",
+    "shortName": "mintara-testnet",
+    "nativeCurrency": {
+      "symbol": "MNTR"
+    }
+  },
+  {
+    "chainId": 1080,
+    "name": "Mintara Mainnet",
+    "shortName": "mintara",
+    "nativeCurrency": {
+      "symbol": "MNTR"
+    }
+  },
+  {
+    "chainId": 1088,
+    "name": "Metis Andromeda Mainnet",
+    "shortName": "metis-andromeda",
+    "nativeCurrency": {
+      "symbol": "METIS"
+    }
+  },
+  {
+    "chainId": 1089,
+    "name": "Humans.ai Mainnet",
+    "shortName": "humans",
+    "nativeCurrency": {
+      "symbol": "HEART"
+    }
+  },
+  {
+    "chainId": 1096,
+    "name": "Xenea Ubusuna",
+    "shortName": "Xenea",
+    "nativeCurrency": {
+      "symbol": "TXENE"
+    }
+  },
+  {
+    "chainId": 1099,
+    "name": "MOAC mainnet",
+    "shortName": "moac",
+    "nativeCurrency": {
+      "symbol": "mc"
+    }
+  },
+  {
+    "chainId": 1100,
+    "name": "Dymension",
+    "shortName": "dymension",
+    "nativeCurrency": {
+      "symbol": "DYM"
+    }
+  },
+  {
+    "chainId": 1101,
+    "name": "Polygon zkEVM",
+    "shortName": "zkevm",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1107,
+    "name": "BLXq Testnet",
+    "shortName": "tblxq",
+    "nativeCurrency": {
+      "symbol": "BLXQ"
+    }
+  },
+  {
+    "chainId": 1108,
+    "name": "BLXq Mainnet",
+    "shortName": "blxq",
+    "nativeCurrency": {
+      "symbol": "BLXQ"
+    }
+  },
+  {
+    "chainId": 1111,
+    "name": "WEMIX3.0 Mainnet",
+    "shortName": "wemix",
+    "nativeCurrency": {
+      "symbol": "WEMIX"
+    }
+  },
+  {
+    "chainId": 1112,
+    "name": "WEMIX3.0 Testnet",
+    "shortName": "twemix",
+    "nativeCurrency": {
+      "symbol": "tWEMIX"
+    }
+  },
+  {
+    "chainId": 1113,
+    "name": "B2 Hub Testnet",
+    "shortName": "B2Hub-testnet",
+    "nativeCurrency": {
+      "symbol": "B2"
+    }
+  },
+  {
+    "chainId": 1114,
+    "name": "Core Blockchain Testnet2",
+    "shortName": "tcore2",
+    "nativeCurrency": {
+      "symbol": "tCORE2"
+    }
+  },
+  {
+    "chainId": 1115,
+    "name": "Core Blockchain Testnet",
+    "shortName": "tcore",
+    "nativeCurrency": {
+      "symbol": "tCORE"
+    }
+  },
+  {
+    "chainId": 1116,
+    "name": "Core Blockchain Mainnet",
+    "shortName": "core",
+    "nativeCurrency": {
+      "symbol": "CORE"
+    }
+  },
+  {
+    "chainId": 1117,
+    "name": "Dogcoin Mainnet",
+    "shortName": "DOGSm",
+    "nativeCurrency": {
+      "symbol": "DOGS"
+    }
+  },
+  {
+    "chainId": 1122,
+    "name": "LuxePorts",
+    "shortName": "lxp",
+    "nativeCurrency": {
+      "symbol": "LXP"
+    }
+  },
+  {
+    "chainId": 1123,
+    "name": "B2 Testnet",
+    "shortName": "B2-testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 1125,
+    "name": "Taker Chain Mainnet",
+    "shortName": "taker",
+    "nativeCurrency": {
+      "symbol": "TAKER"
+    }
+  },
+  {
+    "chainId": 1130,
+    "name": "DeFiChain EVM Network Mainnet",
+    "shortName": "DFI",
+    "nativeCurrency": {
+      "symbol": "DFI"
+    }
+  },
+  {
+    "chainId": 1131,
+    "name": "DeFiChain EVM Network Testnet",
+    "shortName": "DFI-T",
+    "nativeCurrency": {
+      "symbol": "DFI"
+    }
+  },
+  {
+    "chainId": 1133,
+    "name": "DeFiMetaChain Changi Testnet",
+    "shortName": "changi",
+    "nativeCurrency": {
+      "symbol": "DFI"
+    }
+  },
+  {
+    "chainId": 1134,
+    "name": "StateMesh",
+    "shortName": "mesh",
+    "nativeCurrency": {
+      "symbol": "MESH"
+    }
+  },
+  {
+    "chainId": 1135,
+    "name": "Lisk",
+    "shortName": "lisk",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1138,
+    "name": "AmStar Testnet",
+    "shortName": "ASARt",
+    "nativeCurrency": {
+      "symbol": "SINSO"
+    }
+  },
+  {
+    "chainId": 1139,
+    "name": "MathChain",
+    "shortName": "MATH",
+    "nativeCurrency": {
+      "symbol": "MATH"
+    }
+  },
+  {
+    "chainId": 1140,
+    "name": "MathChain Testnet",
+    "shortName": "tMATH",
+    "nativeCurrency": {
+      "symbol": "MATH"
+    }
+  },
+  {
+    "chainId": 1147,
+    "name": "Flag Testnet",
+    "shortName": "tFLAG",
+    "nativeCurrency": {
+      "symbol": "FLAG"
+    }
+  },
+  {
+    "chainId": 1148,
+    "name": "POC Testnet",
+    "shortName": "poc",
+    "nativeCurrency": {
+      "symbol": "POC"
+    }
+  },
+  {
+    "chainId": 1149,
+    "name": "Symplexia Smart Chain",
+    "shortName": "Plexchain",
+    "nativeCurrency": {
+      "symbol": "PLEX"
+    }
+  },
+  {
+    "chainId": 1155,
+    "name": "Intuition Mainnet",
+    "shortName": "intuition",
+    "nativeCurrency": {
+      "symbol": "TRUST"
+    }
+  },
+  {
+    "chainId": 1170,
+    "name": "Origin Testnet",
+    "shortName": "auoc",
+    "nativeCurrency": {
+      "symbol": "UOC"
+    }
+  },
+  {
+    "chainId": 1174,
+    "name": "Litheum Test Network",
+    "shortName": "lith",
+    "nativeCurrency": {
+      "symbol": "LTH"
+    }
+  },
+  {
+    "chainId": 1177,
+    "name": "Smart Host Teknoloji TESTNET",
+    "shortName": "sht",
+    "nativeCurrency": {
+      "symbol": "tSHT"
+    }
+  },
+  {
+    "chainId": 1188,
+    "name": "ClubMos Mainnet",
+    "shortName": "MOS",
+    "nativeCurrency": {
+      "symbol": "MOS"
+    }
+  },
+  {
+    "chainId": 1197,
+    "name": "Iora Chain",
+    "shortName": "iora",
+    "nativeCurrency": {
+      "symbol": "IORA"
+    }
+  },
+  {
+    "chainId": 1200,
+    "name": "Cuckoo Chain",
+    "shortName": "cai",
+    "nativeCurrency": {
+      "symbol": "CAI"
+    }
+  },
+  {
+    "chainId": 1201,
+    "name": "Evanesco Testnet",
+    "shortName": "avis",
+    "nativeCurrency": {
+      "symbol": "AVIS"
+    }
+  },
+  {
+    "chainId": 1202,
+    "name": "World Trade Technical Chain Mainnet",
+    "shortName": "wtt",
+    "nativeCurrency": {
+      "symbol": "WTT"
+    }
+  },
+  {
+    "chainId": 1209,
+    "name": "SaitaBlockChain(SBC)",
+    "shortName": "SBC",
+    "nativeCurrency": {
+      "symbol": "STC"
+    }
+  },
+  {
+    "chainId": 1210,
+    "name": "Cuckoo Sepolia",
+    "shortName": "caisepolia",
+    "nativeCurrency": {
+      "symbol": "CAI"
+    }
+  },
+  {
+    "chainId": 1212,
+    "name": "ADF Chain Testnet",
+    "shortName": "tADF",
+    "nativeCurrency": {
+      "symbol": "tADF"
+    }
+  },
+  {
+    "chainId": 1213,
+    "name": "Popcateum Mainnet",
+    "shortName": "popcat",
+    "nativeCurrency": {
+      "symbol": "POP"
+    }
+  },
+  {
+    "chainId": 1214,
+    "name": "EnterChain Mainnet",
+    "shortName": "enter",
+    "nativeCurrency": {
+      "symbol": "ENTER"
+    }
+  },
+  {
+    "chainId": 1215,
+    "name": "ADF Chain",
+    "shortName": "ADF",
+    "nativeCurrency": {
+      "symbol": "ADF"
+    }
+  },
+  {
+    "chainId": 1221,
+    "name": "Cycle Network Testnet",
+    "shortName": "Cycle",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1223,
+    "name": "Cycle Network Testnet Jellyfish",
+    "shortName": "cyclej",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1224,
+    "name": "Hybrid Testnet (Deprecated)",
+    "shortName": "hyb_deprecated",
+    "nativeCurrency": {
+      "symbol": "HYB"
+    }
+  },
+  {
+    "chainId": 1225,
+    "name": "Hybrid Testnet",
+    "shortName": "hyb",
+    "nativeCurrency": {
+      "symbol": "HYB"
+    }
+  },
+  {
+    "chainId": 1227,
+    "name": "Bitcoin Protocol Testnet",
+    "shortName": "BTCP",
+    "nativeCurrency": {
+      "symbol": "BTCP"
+    }
+  },
+  {
+    "chainId": 1228,
+    "name": "Cycle Network Testnet Cuttlefish",
+    "shortName": "cyclec",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1229,
+    "name": "Exzo Network Mainnet",
+    "shortName": "xzo",
+    "nativeCurrency": {
+      "symbol": "XZO"
+    }
+  },
+  {
+    "chainId": 1230,
+    "name": "Ultron Testnet",
+    "shortName": "UltronTestnet",
+    "nativeCurrency": {
+      "symbol": "ULX"
+    }
+  },
+  {
+    "chainId": 1231,
+    "name": "Ultron Mainnet",
+    "shortName": "UtronMainnet",
+    "nativeCurrency": {
+      "symbol": "ULX"
+    }
+  },
+  {
+    "chainId": 1234,
+    "name": "Step Network",
+    "shortName": "step",
+    "nativeCurrency": {
+      "symbol": "FITFI"
+    }
+  },
+  {
+    "chainId": 1235,
+    "name": "ITX Mainnet",
+    "shortName": "itx",
+    "nativeCurrency": {
+      "symbol": "ITX"
+    }
+  },
+  {
+    "chainId": 1243,
+    "name": "ARC Mainnet",
+    "shortName": "ARC",
+    "nativeCurrency": {
+      "symbol": "ARC"
+    }
+  },
+  {
+    "chainId": 1244,
+    "name": "ARC Testnet",
+    "shortName": "TARC",
+    "nativeCurrency": {
+      "symbol": "ARC"
+    }
+  },
+  {
+    "chainId": 1246,
+    "name": "OM Platform Mainnet",
+    "shortName": "om",
+    "nativeCurrency": {
+      "symbol": "OM"
+    }
+  },
+  {
+    "chainId": 1248,
+    "name": "Dogether Mainnet",
+    "shortName": "Dogether",
+    "nativeCurrency": {
+      "symbol": "dogeth"
+    }
+  },
+  {
+    "chainId": 1252,
+    "name": "CIC Chain Testnet",
+    "shortName": "CICT",
+    "nativeCurrency": {
+      "symbol": "CICT"
+    }
+  },
+  {
+    "chainId": 1260,
+    "name": "Metacces Testnet",
+    "shortName": "ACCESt",
+    "nativeCurrency": {
+      "symbol": "ACCES"
+    }
+  },
+  {
+    "chainId": 1270,
+    "name": "Irys Testnet V1",
+    "shortName": "irys-testnet-v1",
+    "nativeCurrency": {
+      "symbol": "IRYS"
+    }
+  },
+  {
+    "chainId": 1280,
+    "name": "HALO Mainnet",
+    "shortName": "HO",
+    "nativeCurrency": {
+      "symbol": "HO"
+    }
+  },
+  {
+    "chainId": 1284,
+    "name": "Moonbeam",
+    "shortName": "mbeam",
+    "nativeCurrency": {
+      "symbol": "GLMR"
+    }
+  },
+  {
+    "chainId": 1285,
+    "name": "Moonriver",
+    "shortName": "mriver",
+    "nativeCurrency": {
+      "symbol": "MOVR"
+    }
+  },
+  {
+    "chainId": 1286,
+    "name": "Moonrock old",
+    "shortName": "mrock-old",
+    "nativeCurrency": {
+      "symbol": "ROC"
+    }
+  },
+  {
+    "chainId": 1287,
+    "name": "Moonbase Alpha",
+    "shortName": "mbase",
+    "nativeCurrency": {
+      "symbol": "DEV"
+    }
+  },
+  {
+    "chainId": 1288,
+    "name": "Moonrock",
+    "shortName": "mrock",
+    "nativeCurrency": {
+      "symbol": "ROC"
+    }
+  },
+  {
+    "chainId": 1291,
+    "name": "Swisstronik Testnet",
+    "shortName": "swtr-testnet",
+    "nativeCurrency": {
+      "symbol": "SWTR"
+    }
+  },
+  {
+    "chainId": 1294,
+    "name": "Bobabeam",
+    "shortName": "Bobabeam",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 1297,
+    "name": "Bobabase Testnet",
+    "shortName": "Bobabase",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 1298,
+    "name": "Argochain Testnet",
+    "shortName": "tAGC",
+    "nativeCurrency": {
+      "symbol": "AGC"
+    }
+  },
+  {
+    "chainId": 1299,
+    "name": "Argochain",
+    "shortName": "AGC",
+    "nativeCurrency": {
+      "symbol": "AGC"
+    }
+  },
+  {
+    "chainId": 1300,
+    "name": "Glue Mainnet",
+    "shortName": "glue",
+    "nativeCurrency": {
+      "symbol": "GLUE"
+    }
+  },
+  {
+    "chainId": 1301,
+    "name": "Unichain Sepolia Testnet",
+    "shortName": "unichain-sep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1306,
+    "name": "STO Chain",
+    "shortName": "stoc",
+    "nativeCurrency": {
+      "symbol": "STOC"
+    }
+  },
+  {
+    "chainId": 1310,
+    "name": "COINZAX",
+    "shortName": "zax",
+    "nativeCurrency": {
+      "symbol": "ZAX"
+    }
+  },
+  {
+    "chainId": 1311,
+    "name": "Dos Fuji Subnet",
+    "shortName": "TDOS",
+    "nativeCurrency": {
+      "symbol": "DOS"
+    }
+  },
+  {
+    "chainId": 1313,
+    "name": "JaiHo Chain",
+    "shortName": "JHC",
+    "nativeCurrency": {
+      "symbol": "JaiHo"
+    }
+  },
+  {
+    "chainId": 1314,
+    "name": "Alyx Mainnet",
+    "shortName": "alyx",
+    "nativeCurrency": {
+      "symbol": "ALYX"
+    }
+  },
+  {
+    "chainId": 1315,
+    "name": "Story Aeneid Testnet",
+    "shortName": "story-aeneid",
+    "nativeCurrency": {
+      "symbol": "IP"
+    }
+  },
+  {
+    "chainId": 1319,
+    "name": "AIA Mainnet",
+    "shortName": "aia",
+    "nativeCurrency": {
+      "symbol": "AIA"
+    }
+  },
+  {
+    "chainId": 1320,
+    "name": "AIA Testnet",
+    "shortName": "aiatestnet",
+    "nativeCurrency": {
+      "symbol": "AIA"
+    }
+  },
+  {
+    "chainId": 1328,
+    "name": "Sei Testnet",
+    "shortName": "sei-testnet",
+    "nativeCurrency": {
+      "symbol": "SEI"
+    }
+  },
+  {
+    "chainId": 1329,
+    "name": "Sei Network",
+    "shortName": "sei",
+    "nativeCurrency": {
+      "symbol": "SEI"
+    }
+  },
+  {
+    "chainId": 1336,
+    "name": "Kii Testnet Oro",
+    "shortName": "kiioro",
+    "nativeCurrency": {
+      "symbol": "KII"
+    }
+  },
+  {
+    "chainId": 1337,
+    "name": "Geth Testnet",
+    "shortName": "geth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1338,
+    "name": "Elysium Testnet",
+    "shortName": "ATL",
+    "nativeCurrency": {
+      "symbol": "ELY"
+    }
+  },
+  {
+    "chainId": 1339,
+    "name": "Elysium Mainnet",
+    "shortName": "ELY",
+    "nativeCurrency": {
+      "symbol": "ELY"
+    }
+  },
+  {
+    "chainId": 1342,
+    "name": "BIE",
+    "shortName": "bie",
+    "nativeCurrency": {
+      "symbol": "BIE"
+    }
+  },
+  {
+    "chainId": 1343,
+    "name": "Blitz Subnet",
+    "shortName": "blitz",
+    "nativeCurrency": {
+      "symbol": "BGAS"
+    }
+  },
+  {
+    "chainId": 1353,
+    "name": "CIC Chain Mainnet",
+    "shortName": "CIC",
+    "nativeCurrency": {
+      "symbol": "CIC"
+    }
+  },
+  {
+    "chainId": 1369,
+    "name": "Zafirium Mainnet",
+    "shortName": "zafic",
+    "nativeCurrency": {
+      "symbol": "ZAFIC"
+    }
+  },
+  {
+    "chainId": 1370,
+    "name": "Ramestta Mainnet",
+    "shortName": "RAMA",
+    "nativeCurrency": {
+      "symbol": "RAMA"
+    }
+  },
+  {
+    "chainId": 1377,
+    "name": "Pingaksha testnet",
+    "shortName": "tRAMA",
+    "nativeCurrency": {
+      "symbol": "tRAMA"
+    }
+  },
+  {
+    "chainId": 1379,
+    "name": "Kalar Chain",
+    "shortName": "KLC",
+    "nativeCurrency": {
+      "symbol": "KLC"
+    }
+  },
+  {
+    "chainId": 1388,
+    "name": "AmStar Mainnet",
+    "shortName": "ASAR",
+    "nativeCurrency": {
+      "symbol": "SINSO"
+    }
+  },
+  {
+    "chainId": 1392,
+    "name": "Joseon Mainnet",
+    "shortName": "mun",
+    "nativeCurrency": {
+      "symbol": "JSM"
+    }
+  },
+  {
+    "chainId": 1402,
+    "name": "Polygon zkEVM Testnet old",
+    "shortName": "zkevmtest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1414,
+    "name": "Silicon zkEVM Sepolia Testnet(Deprecated)",
+    "shortName": "silicon-sepolia-testnet-deprecated",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1422,
+    "name": "Polygon zkEVM Testnet Pre Audit-Upgraded",
+    "shortName": "testnet-zkEVM-mango-pre-audit-upgraded",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1424,
+    "name": "Perennial",
+    "shortName": "perennial",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1425,
+    "name": "ONINO Mainnet",
+    "shortName": "onino",
+    "nativeCurrency": {
+      "symbol": "ONI"
+    }
+  },
+  {
+    "chainId": 1433,
+    "name": "Rikeza Network Mainnet",
+    "shortName": "RIK",
+    "nativeCurrency": {
+      "symbol": "RIK"
+    }
+  },
+  {
+    "chainId": 1439,
+    "name": "Injective Testnet",
+    "shortName": "injective-testnet",
+    "nativeCurrency": {
+      "symbol": "INJ"
+    }
+  },
+  {
+    "chainId": 1440,
+    "name": "Living Assets Mainnet",
+    "shortName": "LAS",
+    "nativeCurrency": {
+      "symbol": "LAS"
+    }
+  },
+  {
+    "chainId": 1442,
+    "name": "Polygon zkEVM Testnet",
+    "shortName": "testnet-zkEVM-mango",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1452,
+    "name": "GIL Testnet",
+    "shortName": "gil",
+    "nativeCurrency": {
+      "symbol": "GANG"
+    }
+  },
+  {
+    "chainId": 1453,
+    "name": "MetaChain Istanbul",
+    "shortName": "metatimeistanbul",
+    "nativeCurrency": {
+      "symbol": "MTC"
+    }
+  },
+  {
+    "chainId": 1455,
+    "name": "Ctex Scan Blockchain",
+    "shortName": "CTEX",
+    "nativeCurrency": {
+      "symbol": "CTEX"
+    }
+  },
+  {
+    "chainId": 1456,
+    "name": "ZKBase Mainnet",
+    "shortName": "zkbase",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1480,
+    "name": "Vana",
+    "shortName": "vana",
+    "nativeCurrency": {
+      "symbol": "VANA"
+    }
+  },
+  {
+    "chainId": 1490,
+    "name": "Vitruveo Mainnet",
+    "shortName": "vitruveo",
+    "nativeCurrency": {
+      "symbol": "VTRU"
+    }
+  },
+  {
+    "chainId": 1499,
+    "name": "iDos Games Chain Testnet",
+    "shortName": "IGC",
+    "nativeCurrency": {
+      "symbol": "IGC"
+    }
+  },
+  {
+    "chainId": 1501,
+    "name": "BEVM Canary",
+    "shortName": "chainx",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 1506,
+    "name": "Sherpax Mainnet",
+    "shortName": "Sherpax",
+    "nativeCurrency": {
+      "symbol": "KSX"
+    }
+  },
+  {
+    "chainId": 1507,
+    "name": "Sherpax Testnet",
+    "shortName": "SherpaxTestnet",
+    "nativeCurrency": {
+      "symbol": "KSX"
+    }
+  },
+  {
+    "chainId": 1513,
+    "name": "Story Testnet",
+    "shortName": "Story",
+    "nativeCurrency": {
+      "symbol": "IP"
+    }
+  },
+  {
+    "chainId": 1514,
+    "name": "Story",
+    "shortName": "sty",
+    "nativeCurrency": {
+      "symbol": "IP"
+    }
+  },
+  {
+    "chainId": 1515,
+    "name": "Beagle Messaging Chain",
+    "shortName": "beagle",
+    "nativeCurrency": {
+      "symbol": "BG"
+    }
+  },
+  {
+    "chainId": 1516,
+    "name": "Story Odyssey Testnet",
+    "shortName": "story-testnet",
+    "nativeCurrency": {
+      "symbol": "IP"
+    }
+  },
+  {
+    "chainId": 1555,
+    "name": "Datacore Smart Chain",
+    "shortName": "DSCs",
+    "nativeCurrency": {
+      "symbol": "DSC"
+    }
+  },
+  {
+    "chainId": 1559,
+    "name": "Tenet",
+    "shortName": "tenet",
+    "nativeCurrency": {
+      "symbol": "TENET"
+    }
+  },
+  {
+    "chainId": 1570,
+    "name": "StarCHAIN Testnet",
+    "shortName": "starchain-testnet",
+    "nativeCurrency": {
+      "symbol": "STARX"
+    }
+  },
+  {
+    "chainId": 1578,
+    "name": "StarCHAIN",
+    "shortName": "starchain",
+    "nativeCurrency": {
+      "symbol": "STARX"
+    }
+  },
+  {
+    "chainId": 1597,
+    "name": "Reactive Mainnet",
+    "shortName": "react",
+    "nativeCurrency": {
+      "symbol": "REACT"
+    }
+  },
+  {
+    "chainId": 1605,
+    "name": "Betherance",
+    "shortName": "Beth",
+    "nativeCurrency": {
+      "symbol": "BETH"
+    }
+  },
+  {
+    "chainId": 1612,
+    "name": "OpenLedger Mainnet",
+    "shortName": "open",
+    "nativeCurrency": {
+      "symbol": "OPEN"
+    }
+  },
+  {
+    "chainId": 1617,
+    "name": "Ethereum Inscription Mainnet",
+    "shortName": "etins",
+    "nativeCurrency": {
+      "symbol": "ETINS"
+    }
+  },
+  {
+    "chainId": 1618,
+    "name": "Catecoin Chain Mainnet",
+    "shortName": "cate",
+    "nativeCurrency": {
+      "symbol": "CATE"
+    }
+  },
+  {
+    "chainId": 1620,
+    "name": "Atheios",
+    "shortName": "ath",
+    "nativeCurrency": {
+      "symbol": "ATH"
+    }
+  },
+  {
+    "chainId": 1625,
+    "name": "Gravity Alpha Mainnet",
+    "shortName": "gravity",
+    "nativeCurrency": {
+      "symbol": "G"
+    }
+  },
+  {
+    "chainId": 1643,
+    "name": "XGR Mainnet",
+    "shortName": "xgr",
+    "nativeCurrency": {
+      "symbol": "XGR"
+    }
+  },
+  {
+    "chainId": 1648,
+    "name": "Pivotal Mainnet",
+    "shortName": "pivotal-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1650,
+    "name": "IIC Blockchain Testnet",
+    "shortName": "iic-testnet",
+    "nativeCurrency": {
+      "symbol": "SAYA"
+    }
+  },
+  {
+    "chainId": 1657,
+    "name": "Btachain",
+    "shortName": "bta",
+    "nativeCurrency": {
+      "symbol": "BTA"
+    }
+  },
+  {
+    "chainId": 1662,
+    "name": "Liquichain",
+    "shortName": "Liquichain",
+    "nativeCurrency": {
+      "symbol": "LCN"
+    }
+  },
+  {
+    "chainId": 1663,
+    "name": "Horizen Gobi Testnet",
+    "shortName": "Gobi",
+    "nativeCurrency": {
+      "symbol": "tZEN"
+    }
+  },
+  {
+    "chainId": 1686,
+    "name": "Mint Testnet",
+    "shortName": "minttest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1687,
+    "name": "Mint Sepolia Testnet",
+    "shortName": "mintsepoliatest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1688,
+    "name": "LUDAN Mainnet",
+    "shortName": "LUDAN",
+    "nativeCurrency": {
+      "symbol": "LUDAN"
+    }
+  },
+  {
+    "chainId": 1689,
+    "name": "NERO Mainnet",
+    "shortName": "NERO",
+    "nativeCurrency": {
+      "symbol": "NERO"
+    }
+  },
+  {
+    "chainId": 1701,
+    "name": "Anytype EVM Chain",
+    "shortName": "AnytypeChain",
+    "nativeCurrency": {
+      "symbol": "ANY"
+    }
+  },
+  {
+    "chainId": 1707,
+    "name": "TBSI Mainnet",
+    "shortName": "TBSI",
+    "nativeCurrency": {
+      "symbol": "JINDA"
+    }
+  },
+  {
+    "chainId": 1708,
+    "name": "TBSI Testnet",
+    "shortName": "tTBSI",
+    "nativeCurrency": {
+      "symbol": "JINDA"
+    }
+  },
+  {
+    "chainId": 1714,
+    "name": "ACiD",
+    "shortName": "acid",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1717,
+    "name": "Doric Network",
+    "shortName": "DRC",
+    "nativeCurrency": {
+      "symbol": "DRC"
+    }
+  },
+  {
+    "chainId": 1718,
+    "name": "Palette Chain Mainnet",
+    "shortName": "PCM",
+    "nativeCurrency": {
+      "symbol": "PLT"
+    }
+  },
+  {
+    "chainId": 1727,
+    "name": "Ethpar Mainnet",
+    "shortName": "ethpar",
+    "nativeCurrency": {
+      "symbol": "ETP"
+    }
+  },
+  {
+    "chainId": 1729,
+    "name": "Reya Network",
+    "shortName": "reya",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1732,
+    "name": "Fuga Mainnet",
+    "shortName": "FUGA",
+    "nativeCurrency": {
+      "symbol": "FUGA"
+    }
+  },
+  {
+    "chainId": 1733,
+    "name": "Fuga Testnet",
+    "shortName": "FUGA_T",
+    "nativeCurrency": {
+      "symbol": "FUGA"
+    }
+  },
+  {
+    "chainId": 1734,
+    "name": "Fuga Develop",
+    "shortName": "FUGA_D",
+    "nativeCurrency": {
+      "symbol": "FUGA"
+    }
+  },
+  {
+    "chainId": 1740,
+    "name": "Metal L2 Testnet",
+    "shortName": "metall2-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1750,
+    "name": "Metal L2",
+    "shortName": "metall2",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1773,
+    "name": "PartyChain",
+    "shortName": "TeaParty",
+    "nativeCurrency": {
+      "symbol": "GRAMS"
+    }
+  },
+  {
+    "chainId": 1776,
+    "name": "Injective",
+    "shortName": "injective",
+    "nativeCurrency": {
+      "symbol": "INJ"
+    }
+  },
+  {
+    "chainId": 1777,
+    "name": "Gauss Mainnet",
+    "shortName": "gauss",
+    "nativeCurrency": {
+      "symbol": "GANG"
+    }
+  },
+  {
+    "chainId": 1783,
+    "name": "KiiChain",
+    "shortName": "kiichain",
+    "nativeCurrency": {
+      "symbol": "KII"
+    }
+  },
+  {
+    "chainId": 1789,
+    "name": "ZKBase Sepolia Testnet",
+    "shortName": "zkbase-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1804,
+    "name": "Kerleano",
+    "shortName": "kerleano",
+    "nativeCurrency": {
+      "symbol": "CRC"
+    }
+  },
+  {
+    "chainId": 1807,
+    "name": "Rabbit Analog Testnet Chain",
+    "shortName": "rAna",
+    "nativeCurrency": {
+      "symbol": "rAna"
+    }
+  },
+  {
+    "chainId": 1810,
+    "name": "Ruby Chain Testnet",
+    "shortName": "ruby-testnet",
+    "nativeCurrency": {
+      "symbol": "RUBY"
+    }
+  },
+  {
+    "chainId": 1811,
+    "name": "Lif3 Chain Testnet",
+    "shortName": "lif3-testnet",
+    "nativeCurrency": {
+      "symbol": "LIF3"
+    }
+  },
+  {
+    "chainId": 1818,
+    "name": "Cube Chain Mainnet",
+    "shortName": "cube",
+    "nativeCurrency": {
+      "symbol": "CUBE"
+    }
+  },
+  {
+    "chainId": 1819,
+    "name": "Cube Chain Testnet",
+    "shortName": "cubet",
+    "nativeCurrency": {
+      "symbol": "CUBET"
+    }
+  },
+  {
+    "chainId": 1821,
+    "name": "Ruby Smart Chain MAINNET",
+    "shortName": "RUBY",
+    "nativeCurrency": {
+      "symbol": "RUBY"
+    }
+  },
+  {
+    "chainId": 1829,
+    "name": "PlayBlock",
+    "shortName": "playblock",
+    "nativeCurrency": {
+      "symbol": "PBG"
+    }
+  },
+  {
+    "chainId": 1833,
+    "name": "Verify testnet",
+    "shortName": "verify-testnet",
+    "nativeCurrency": {
+      "symbol": "MATIC"
+    }
+  },
+  {
+    "chainId": 1848,
+    "name": "Swisstronik Mainnet",
+    "shortName": "swtr",
+    "nativeCurrency": {
+      "symbol": "SWTR"
+    }
+  },
+  {
+    "chainId": 1853,
+    "name": "HighOctane Subnet",
+    "shortName": "HighOctane",
+    "nativeCurrency": {
+      "symbol": "HO"
+    }
+  },
+  {
+    "chainId": 1856,
+    "name": "Teslafunds",
+    "shortName": "tsf",
+    "nativeCurrency": {
+      "symbol": "TSF"
+    }
+  },
+  {
+    "chainId": 1868,
+    "name": "Soneium",
+    "shortName": "soneium",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1875,
+    "name": "Whitechain",
+    "shortName": "wbt",
+    "nativeCurrency": {
+      "symbol": "WBT"
+    }
+  },
+  {
+    "chainId": 1879,
+    "name": "XGR Testnet",
+    "shortName": "xgrt",
+    "nativeCurrency": {
+      "symbol": "XGR"
+    }
+  },
+  {
+    "chainId": 1881,
+    "name": "Gitshock Cartenz Testnet",
+    "shortName": "gitshockchain",
+    "nativeCurrency": {
+      "symbol": "tGTFX"
+    }
+  },
+  {
+    "chainId": 1890,
+    "name": "Lightlink Phoenix Mainnet",
+    "shortName": "lightlink_phoenix",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1891,
+    "name": "Lightlink Pegasus Testnet",
+    "shortName": "lightlink_pegasus",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1898,
+    "name": "BON Network",
+    "shortName": "boya",
+    "nativeCurrency": {
+      "symbol": "BOY"
+    }
+  },
+  {
+    "chainId": 1899,
+    "name": "ReDeFi Layer 2",
+    "shortName": "red",
+    "nativeCurrency": {
+      "symbol": "RED"
+    }
+  },
+  {
+    "chainId": 1904,
+    "name": "Sports Chain Network",
+    "shortName": "SCN",
+    "nativeCurrency": {
+      "symbol": "SCN"
+    }
+  },
+  {
+    "chainId": 1907,
+    "name": "Bitcichain Mainnet",
+    "shortName": "bitci",
+    "nativeCurrency": {
+      "symbol": "BITCI"
+    }
+  },
+  {
+    "chainId": 1908,
+    "name": "Bitcichain Testnet",
+    "shortName": "tbitci",
+    "nativeCurrency": {
+      "symbol": "TBITCI"
+    }
+  },
+  {
+    "chainId": 1909,
+    "name": "Merkle Scan",
+    "shortName": "MRK",
+    "nativeCurrency": {
+      "symbol": "MRK"
+    }
+  },
+  {
+    "chainId": 1911,
+    "name": "Scalind",
+    "shortName": "scal",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1912,
+    "name": "Ruby Smart Chain Testnet",
+    "shortName": "tRUBY",
+    "nativeCurrency": {
+      "symbol": "tRUBY"
+    }
+  },
+  {
+    "chainId": 1918,
+    "name": "UPB CRESCDI Testnet",
+    "shortName": "UPBEth",
+    "nativeCurrency": {
+      "symbol": "UPBEth"
+    }
+  },
+  {
+    "chainId": 1923,
+    "name": "Swellchain",
+    "shortName": "swellchain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1924,
+    "name": "Swellchain Testnet",
+    "shortName": "swellchain-sep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1927,
+    "name": "Arvix Testnet",
+    "shortName": "arvix",
+    "nativeCurrency": {
+      "symbol": "tARV"
+    }
+  },
+  {
+    "chainId": 1945,
+    "name": "ONUS Chain Testnet",
+    "shortName": "onus-testnet",
+    "nativeCurrency": {
+      "symbol": "ONUS"
+    }
+  },
+  {
+    "chainId": 1946,
+    "name": "Soneium Testnet Minato",
+    "shortName": "soneium-minato",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1949,
+    "name": "Bionix Testnet",
+    "shortName": "tbio",
+    "nativeCurrency": {
+      "symbol": "tBIO"
+    }
+  },
+  {
+    "chainId": 1951,
+    "name": "D-Chain Mainnet",
+    "shortName": "dchain-mainnet",
+    "nativeCurrency": {
+      "symbol": "DOINX"
+    }
+  },
+  {
+    "chainId": 1953,
+    "name": "Selendra Network Testnet",
+    "shortName": "tSEL",
+    "nativeCurrency": {
+      "symbol": "tSEL"
+    }
+  },
+  {
+    "chainId": 1954,
+    "name": "Dexilla Testnet",
+    "shortName": "Dexilla",
+    "nativeCurrency": {
+      "symbol": "DXZ"
+    }
+  },
+  {
+    "chainId": 1956,
+    "name": "AIW3 Testnet",
+    "shortName": "AIW3-Testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 1961,
+    "name": "Selendra Network Mainnet",
+    "shortName": "SEL",
+    "nativeCurrency": {
+      "symbol": "SEL"
+    }
+  },
+  {
+    "chainId": 1962,
+    "name": "T-Rex Testnet",
+    "shortName": "TREX",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1967,
+    "name": "Eleanor",
+    "shortName": "mtc",
+    "nativeCurrency": {
+      "symbol": "MTC"
+    }
+  },
+  {
+    "chainId": 1969,
+    "name": "Super Smart Chain Testnet",
+    "shortName": "tscs",
+    "nativeCurrency": {
+      "symbol": "TSCS"
+    }
+  },
+  {
+    "chainId": 1970,
+    "name": "Super Smart Chain Mainnet",
+    "shortName": "scs",
+    "nativeCurrency": {
+      "symbol": "SCS"
+    }
+  },
+  {
+    "chainId": 1971,
+    "name": "Atelier",
+    "shortName": "atlr",
+    "nativeCurrency": {
+      "symbol": "ATLR"
+    }
+  },
+  {
+    "chainId": 1972,
+    "name": "RedeCoin",
+    "shortName": "rede",
+    "nativeCurrency": {
+      "symbol": "REDEV2"
+    }
+  },
+  {
+    "chainId": 1975,
+    "name": "ONUS Chain Mainnet",
+    "shortName": "onus-mainnet",
+    "nativeCurrency": {
+      "symbol": "ONUS"
+    }
+  },
+  {
+    "chainId": 1979,
+    "name": "CratD2C Testnet",
+    "shortName": "cratd2c-testnet",
+    "nativeCurrency": {
+      "symbol": "CRAT"
+    }
+  },
+  {
+    "chainId": 1983,
+    "name": "Krown Mainnet",
+    "shortName": "krown",
+    "nativeCurrency": {
+      "symbol": "KROWN"
+    }
+  },
+  {
+    "chainId": 1984,
+    "name": "Eurus Testnet",
+    "shortName": "euntest",
+    "nativeCurrency": {
+      "symbol": "EUN"
+    }
+  },
+  {
+    "chainId": 1985,
+    "name": "SatoshIE",
+    "shortName": "satoshie",
+    "nativeCurrency": {
+      "symbol": "TUSHY"
+    }
+  },
+  {
+    "chainId": 1986,
+    "name": "SatoshIE Testnet",
+    "shortName": "satoshie_testnet",
+    "nativeCurrency": {
+      "symbol": "TUSHY"
+    }
+  },
+  {
+    "chainId": 1987,
+    "name": "EtherGem",
+    "shortName": "egem",
+    "nativeCurrency": {
+      "symbol": "EGEM"
+    }
+  },
+  {
+    "chainId": 1989,
+    "name": "Lydia Coin",
+    "shortName": "lydia",
+    "nativeCurrency": {
+      "symbol": "BSW"
+    }
+  },
+  {
+    "chainId": 1992,
+    "name": "Hubble Exchange",
+    "shortName": "hubblenet",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 1993,
+    "name": "B3 Sepolia Testnet",
+    "shortName": "b3-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1994,
+    "name": "Ekta",
+    "shortName": "ekta",
+    "nativeCurrency": {
+      "symbol": "EKTA"
+    }
+  },
+  {
+    "chainId": 1995,
+    "name": "edeXa Testnet",
+    "shortName": "edxt",
+    "nativeCurrency": {
+      "symbol": "tEDX"
+    }
+  },
+  {
+    "chainId": 1996,
+    "name": "Sanko",
+    "shortName": "Sanko",
+    "nativeCurrency": {
+      "symbol": "DMT"
+    }
+  },
+  {
+    "chainId": 1997,
+    "name": "Kyoto",
+    "shortName": "kyoto",
+    "nativeCurrency": {
+      "symbol": "KYOTO"
+    }
+  },
+  {
+    "chainId": 1998,
+    "name": "Kyoto Testnet",
+    "shortName": "kyoto-testnet",
+    "nativeCurrency": {
+      "symbol": "KYOTO"
+    }
+  },
+  {
+    "chainId": 1999,
+    "name": "STO Chain Testnet",
+    "shortName": "tstoc",
+    "nativeCurrency": {
+      "symbol": "TSTOC"
+    }
+  },
+  {
+    "chainId": 2000,
+    "name": "Dogechain Mainnet",
+    "shortName": "dc",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 2001,
+    "name": "Milkomeda C1 Mainnet",
+    "shortName": "milkAda",
+    "nativeCurrency": {
+      "symbol": "mADA"
+    }
+  },
+  {
+    "chainId": 2002,
+    "name": "Milkomeda A1 Mainnet",
+    "shortName": "milkALGO",
+    "nativeCurrency": {
+      "symbol": "mALGO"
+    }
+  },
+  {
+    "chainId": 2004,
+    "name": "MetaLink Network",
+    "shortName": "mtl",
+    "nativeCurrency": {
+      "symbol": "MTL"
+    }
+  },
+  {
+    "chainId": 2008,
+    "name": "CloudWalk Testnet",
+    "shortName": "cloudwalk_testnet",
+    "nativeCurrency": {
+      "symbol": "CWN"
+    }
+  },
+  {
+    "chainId": 2009,
+    "name": "CloudWalk Mainnet",
+    "shortName": "cloudwalk_mainnet",
+    "nativeCurrency": {
+      "symbol": "CWN"
+    }
+  },
+  {
+    "chainId": 2013,
+    "name": "Panarchy",
+    "shortName": "panarchy",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 2014,
+    "name": "NOW Chain Testnet",
+    "shortName": "tnow",
+    "nativeCurrency": {
+      "symbol": "NOW"
+    }
+  },
+  {
+    "chainId": 2016,
+    "name": "MainnetZ Mainnet",
+    "shortName": "netz",
+    "nativeCurrency": {
+      "symbol": "NetZ"
+    }
+  },
+  {
+    "chainId": 2017,
+    "name": "Adiri",
+    "shortName": "tel",
+    "nativeCurrency": {
+      "symbol": "TEL"
+    }
+  },
+  {
+    "chainId": 2018,
+    "name": "PublicMint Devnet",
+    "shortName": "pmint_dev",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 2019,
+    "name": "PublicMint Testnet",
+    "shortName": "pmint_test",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 2020,
+    "name": "Ronin Mainnet",
+    "shortName": "ron",
+    "nativeCurrency": {
+      "symbol": "RON"
+    }
+  },
+  {
+    "chainId": 2021,
+    "name": "Edgeware EdgeEVM Mainnet",
+    "shortName": "edg",
+    "nativeCurrency": {
+      "symbol": "EDG"
+    }
+  },
+  {
+    "chainId": 2022,
+    "name": "Beresheet BereEVM Testnet",
+    "shortName": "edgt",
+    "nativeCurrency": {
+      "symbol": "tEDG"
+    }
+  },
+  {
+    "chainId": 2023,
+    "name": "Taycan Testnet",
+    "shortName": "taycan-testnet",
+    "nativeCurrency": {
+      "symbol": "tSFL"
+    }
+  },
+  {
+    "chainId": 2024,
+    "name": "Swan Saturn Testnet",
+    "shortName": "saturn",
+    "nativeCurrency": {
+      "symbol": "sETH"
+    }
+  },
+  {
+    "chainId": 2025,
+    "name": "Rangers Protocol Mainnet",
+    "shortName": "rpg",
+    "nativeCurrency": {
+      "symbol": "RPG"
+    }
+  },
+  {
+    "chainId": 2026,
+    "name": "Edgeless Network",
+    "shortName": "edgeless",
+    "nativeCurrency": {
+      "symbol": "EwEth"
+    }
+  },
+  {
+    "chainId": 2028,
+    "name": "ArmaChain Testnet",
+    "shortName": "arma-testnet",
+    "nativeCurrency": {
+      "symbol": "tARMA"
+    }
+  },
+  {
+    "chainId": 2031,
+    "name": "Centrifuge",
+    "shortName": "cfg",
+    "nativeCurrency": {
+      "symbol": "CFG"
+    }
+  },
+  {
+    "chainId": 2032,
+    "name": "Catalyst",
+    "shortName": "ncfg",
+    "nativeCurrency": {
+      "symbol": "NCFG"
+    }
+  },
+  {
+    "chainId": 2035,
+    "name": "Phala Network",
+    "shortName": "phala",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2037,
+    "name": "Kiwi Subnet",
+    "shortName": "kiwi",
+    "nativeCurrency": {
+      "symbol": "SHRAP"
+    }
+  },
+  {
+    "chainId": 2038,
+    "name": "Shrapnel Testnet",
+    "shortName": "shraptest",
+    "nativeCurrency": {
+      "symbol": "SHRAPG"
+    }
+  },
+  {
+    "chainId": 2039,
+    "name": "Aleph Zero",
+    "shortName": "aleph",
+    "nativeCurrency": {
+      "symbol": "TZERO"
+    }
+  },
+  {
+    "chainId": 2040,
+    "name": "Vanar Mainnet",
+    "shortName": "Vanar",
+    "nativeCurrency": {
+      "symbol": "VANRY"
+    }
+  },
+  {
+    "chainId": 2043,
+    "name": "NeuroWeb",
+    "shortName": "NEURO",
+    "nativeCurrency": {
+      "symbol": "NEURO"
+    }
+  },
+  {
+    "chainId": 2044,
+    "name": "Shrapnel Subnet",
+    "shortName": "Shrapnel",
+    "nativeCurrency": {
+      "symbol": "SHRAPG"
+    }
+  },
+  {
+    "chainId": 2045,
+    "name": "AIW3 Mainnet",
+    "shortName": "AIW3",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2047,
+    "name": "Stratos Testnet",
+    "shortName": "stos-testnet",
+    "nativeCurrency": {
+      "symbol": "STOS"
+    }
+  },
+  {
+    "chainId": 2048,
+    "name": "Stratos",
+    "shortName": "stos-mainnet",
+    "nativeCurrency": {
+      "symbol": "STOS"
+    }
+  },
+  {
+    "chainId": 2049,
+    "name": "Movo Smart Chain Mainnet",
+    "shortName": "movo",
+    "nativeCurrency": {
+      "symbol": "MOVO"
+    }
+  },
+  {
+    "chainId": 2064,
+    "name": "MFX Network",
+    "shortName": "mfx",
+    "nativeCurrency": {
+      "symbol": "MFX"
+    }
+  },
+  {
+    "chainId": 2071,
+    "name": "Metacces Mainnet",
+    "shortName": "ACCES",
+    "nativeCurrency": {
+      "symbol": "ACCES"
+    }
+  },
+  {
+    "chainId": 2077,
+    "name": "Quokkacoin Mainnet",
+    "shortName": "QKA",
+    "nativeCurrency": {
+      "symbol": "QKA"
+    }
+  },
+  {
+    "chainId": 2088,
+    "name": "Altair",
+    "shortName": "air",
+    "nativeCurrency": {
+      "symbol": "AIR"
+    }
+  },
+  {
+    "chainId": 2089,
+    "name": "Algol",
+    "shortName": "algl",
+    "nativeCurrency": {
+      "symbol": "ALGL"
+    }
+  },
+  {
+    "chainId": 2100,
+    "name": "Ecoball Mainnet",
+    "shortName": "eco",
+    "nativeCurrency": {
+      "symbol": "ECO"
+    }
+  },
+  {
+    "chainId": 2101,
+    "name": "Ecoball Testnet Espuma",
+    "shortName": "esp",
+    "nativeCurrency": {
+      "symbol": "ECO"
+    }
+  },
+  {
+    "chainId": 2109,
+    "name": "Exosama Network",
+    "shortName": "exn",
+    "nativeCurrency": {
+      "symbol": "SAMA"
+    }
+  },
+  {
+    "chainId": 2110,
+    "name": "Parallax",
+    "shortName": "parallax",
+    "nativeCurrency": {
+      "symbol": "LAX"
+    }
+  },
+  {
+    "chainId": 2112,
+    "name": "UCHAIN Mainnet",
+    "shortName": "uchain",
+    "nativeCurrency": {
+      "symbol": "UCASH"
+    }
+  },
+  {
+    "chainId": 2121,
+    "name": "Catena Mainnet",
+    "shortName": "cmcx",
+    "nativeCurrency": {
+      "symbol": "CMCX"
+    }
+  },
+  {
+    "chainId": 2122,
+    "name": "Metaplayerone Mainnet",
+    "shortName": "Metad",
+    "nativeCurrency": {
+      "symbol": "METAD"
+    }
+  },
+  {
+    "chainId": 2124,
+    "name": "Metaplayerone Dubai Testnet",
+    "shortName": "MEU",
+    "nativeCurrency": {
+      "symbol": "MEU"
+    }
+  },
+  {
+    "chainId": 2129,
+    "name": "Memento Testnet",
+    "shortName": "memento-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2136,
+    "name": "BigShortBets Testnet",
+    "shortName": "bigsb_testnet",
+    "nativeCurrency": {
+      "symbol": "Dolarz"
+    }
+  },
+  {
+    "chainId": 2137,
+    "name": "BigShortBets",
+    "shortName": "bigsb",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 2138,
+    "name": "Defi Oracle Meta Testnet",
+    "shortName": "dfio-meta-test",
+    "nativeCurrency": {
+      "symbol": "tETH"
+    }
+  },
+  {
+    "chainId": 2140,
+    "name": "Oneness Network",
+    "shortName": "oneness",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2141,
+    "name": "Oneness TestNet",
+    "shortName": "oneness-testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2151,
+    "name": "BOSagora Mainnet",
+    "shortName": "boa",
+    "nativeCurrency": {
+      "symbol": "BOA"
+    }
+  },
+  {
+    "chainId": 2152,
+    "name": "Findora Mainnet",
+    "shortName": "fra",
+    "nativeCurrency": {
+      "symbol": "FRA"
+    }
+  },
+  {
+    "chainId": 2153,
+    "name": "Findora Testnet",
+    "shortName": "findora-testnet",
+    "nativeCurrency": {
+      "symbol": "FRA"
+    }
+  },
+  {
+    "chainId": 2154,
+    "name": "Findora Forge",
+    "shortName": "findora-forge",
+    "nativeCurrency": {
+      "symbol": "FRA"
+    }
+  },
+  {
+    "chainId": 2162,
+    "name": "Animechain Testnet",
+    "shortName": "animechaint",
+    "nativeCurrency": {
+      "symbol": "COIN"
+    }
+  },
+  {
+    "chainId": 2187,
+    "name": "Game7",
+    "shortName": "g7",
+    "nativeCurrency": {
+      "symbol": "G7"
+    }
+  },
+  {
+    "chainId": 2192,
+    "name": "SnaxChain",
+    "shortName": "snax",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2199,
+    "name": "Moonsama Network",
+    "shortName": "msn",
+    "nativeCurrency": {
+      "symbol": "SAMA"
+    }
+  },
+  {
+    "chainId": 2201,
+    "name": "Stable Testnet",
+    "shortName": "stable-testnet",
+    "nativeCurrency": {
+      "symbol": "USDT0"
+    }
+  },
+  {
+    "chainId": 2202,
+    "name": "Antofy Mainnet",
+    "shortName": "ABNm",
+    "nativeCurrency": {
+      "symbol": "ABN"
+    }
+  },
+  {
+    "chainId": 2203,
+    "name": "Bitcoin EVM",
+    "shortName": "BTC",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2213,
+    "name": "Evanesco Mainnet",
+    "shortName": "evanesco",
+    "nativeCurrency": {
+      "symbol": "EVA"
+    }
+  },
+  {
+    "chainId": 2221,
+    "name": "Kava Testnet",
+    "shortName": "tkava",
+    "nativeCurrency": {
+      "symbol": "TKAVA"
+    }
+  },
+  {
+    "chainId": 2222,
+    "name": "Kava",
+    "shortName": "kava",
+    "nativeCurrency": {
+      "symbol": "KAVA"
+    }
+  },
+  {
+    "chainId": 2223,
+    "name": "VChain Mainnet",
+    "shortName": "VChain",
+    "nativeCurrency": {
+      "symbol": "VNDT"
+    }
+  },
+  {
+    "chainId": 2241,
+    "name": "Krest Network",
+    "shortName": "KRST",
+    "nativeCurrency": {
+      "symbol": "KRST"
+    }
+  },
+  {
+    "chainId": 2300,
+    "name": "BOMB Chain",
+    "shortName": "bomb",
+    "nativeCurrency": {
+      "symbol": "BOMB"
+    }
+  },
+  {
+    "chainId": 2306,
+    "name": "Ebro Network",
+    "shortName": "ebro",
+    "nativeCurrency": {
+      "symbol": "ebro"
+    }
+  },
+  {
+    "chainId": 2309,
+    "name": "Arevia",
+    "shortName": "arevia",
+    "nativeCurrency": {
+      "symbol": "ARÉV"
+    }
+  },
+  {
+    "chainId": 2310,
+    "name": "CratD2C",
+    "shortName": "cratd2c",
+    "nativeCurrency": {
+      "symbol": "CRAT"
+    }
+  },
+  {
+    "chainId": 2311,
+    "name": "Chronicle Vesuvius - Lit Protocol Testnet",
+    "shortName": "lpv",
+    "nativeCurrency": {
+      "symbol": "tstLPX"
+    }
+  },
+  {
+    "chainId": 2323,
+    "name": "SOMA Network Testnet",
+    "shortName": "sma",
+    "nativeCurrency": {
+      "symbol": "tSMA"
+    }
+  },
+  {
+    "chainId": 2330,
+    "name": "Altcoinchain",
+    "shortName": "alt",
+    "nativeCurrency": {
+      "symbol": "ALT"
+    }
+  },
+  {
+    "chainId": 2331,
+    "name": "RSS3 VSL Sepolia Testnet",
+    "shortName": "rss3-testnet",
+    "nativeCurrency": {
+      "symbol": "RSS3"
+    }
+  },
+  {
+    "chainId": 2332,
+    "name": "SOMA Network Mainnet",
+    "shortName": "smam",
+    "nativeCurrency": {
+      "symbol": "SMA"
+    }
+  },
+  {
+    "chainId": 2340,
+    "name": "Atleta Olympia",
+    "shortName": "olym",
+    "nativeCurrency": {
+      "symbol": "ATLA"
+    }
+  },
+  {
+    "chainId": 2342,
+    "name": "Omnia Chain",
+    "shortName": "omnia",
+    "nativeCurrency": {
+      "symbol": "OMNIA"
+    }
+  },
+  {
+    "chainId": 2345,
+    "name": "GOAT Network",
+    "shortName": "goat",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2355,
+    "name": "Silicon zkEVM",
+    "shortName": "silicon-zk",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2357,
+    "name": "(deprecated) Kroma Sepolia",
+    "shortName": "deprecated-kroma-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2358,
+    "name": "Kroma Sepolia",
+    "shortName": "kroma-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2366,
+    "name": "KiteAI",
+    "shortName": "KiteAI",
+    "nativeCurrency": {
+      "symbol": "KITE"
+    }
+  },
+  {
+    "chainId": 2368,
+    "name": "KiteAI Testnet",
+    "shortName": "KiteAITestnet",
+    "nativeCurrency": {
+      "symbol": "KITE"
+    }
+  },
+  {
+    "chainId": 2370,
+    "name": "Nexis Network Testnet",
+    "shortName": "nzt",
+    "nativeCurrency": {
+      "symbol": "NZT"
+    }
+  },
+  {
+    "chainId": 2390,
+    "name": "TAC Turin",
+    "shortName": "tacchain_2390-1",
+    "nativeCurrency": {
+      "symbol": "TAC"
+    }
+  },
+  {
+    "chainId": 2391,
+    "name": "TAC Saint Petersburg",
+    "shortName": "tacchain_2391-1",
+    "nativeCurrency": {
+      "symbol": "TAC"
+    }
+  },
+  {
+    "chainId": 2399,
+    "name": "BOMB Chain Testnet",
+    "shortName": "bombt",
+    "nativeCurrency": {
+      "symbol": "tBOMB"
+    }
+  },
+  {
+    "chainId": 2400,
+    "name": "TCG Verse Mainnet",
+    "shortName": "TCGV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 2410,
+    "name": "K2 Mainnet",
+    "shortName": "K2-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2415,
+    "name": "XODEX",
+    "shortName": "xodex",
+    "nativeCurrency": {
+      "symbol": "XODEX"
+    }
+  },
+  {
+    "chainId": 2420,
+    "name": "Rufus",
+    "shortName": "rufus",
+    "nativeCurrency": {
+      "symbol": "ELON"
+    }
+  },
+  {
+    "chainId": 2424,
+    "name": "inEVM Testnet",
+    "shortName": "inevm-testnet",
+    "nativeCurrency": {
+      "symbol": "INJ"
+    }
+  },
+  {
+    "chainId": 2425,
+    "name": "King Of Legends Mainnet",
+    "shortName": "kcc",
+    "nativeCurrency": {
+      "symbol": "KCC"
+    }
+  },
+  {
+    "chainId": 2426,
+    "name": "Standard Testnet",
+    "shortName": "stndtestnet",
+    "nativeCurrency": {
+      "symbol": "STND"
+    }
+  },
+  {
+    "chainId": 2440,
+    "name": "Atleta Network",
+    "shortName": "atla",
+    "nativeCurrency": {
+      "symbol": "ATLA"
+    }
+  },
+  {
+    "chainId": 2442,
+    "name": "Polygon zkEVM Cardona Testnet",
+    "shortName": "zkevm-testnet-cardona",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2458,
+    "name": "Hybrid Chain Network Testnet",
+    "shortName": "thrc",
+    "nativeCurrency": {
+      "symbol": "tHRC"
+    }
+  },
+  {
+    "chainId": 2468,
+    "name": "Hybrid Chain Network Mainnet",
+    "shortName": "hrc",
+    "nativeCurrency": {
+      "symbol": "HRC"
+    }
+  },
+  {
+    "chainId": 2477,
+    "name": "6Degree of Outreach",
+    "shortName": "6do",
+    "nativeCurrency": {
+      "symbol": "6DO"
+    }
+  },
+  {
+    "chainId": 2484,
+    "name": "Unicorn Ultra Nebulas Testnet",
+    "shortName": "u2u_nebulas",
+    "nativeCurrency": {
+      "symbol": "U2U"
+    }
+  },
+  {
+    "chainId": 2488,
+    "name": "NOW Chain Mainnet",
+    "shortName": "now",
+    "nativeCurrency": {
+      "symbol": "NOW"
+    }
+  },
+  {
+    "chainId": 2511,
+    "name": "Karak Goerli",
+    "shortName": "karak-goerli",
+    "nativeCurrency": {
+      "symbol": "KRK"
+    }
+  },
+  {
+    "chainId": 2512,
+    "name": "K2 Testnet",
+    "shortName": "K2-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2522,
+    "name": "Fraxtal Testnet",
+    "shortName": "fraxtal-testnet",
+    "nativeCurrency": {
+      "symbol": "FRAX"
+    }
+  },
+  {
+    "chainId": 2523,
+    "name": "Fraxtal Hoodi Testnet",
+    "shortName": "fraxtal-hoodi-testnet",
+    "nativeCurrency": {
+      "symbol": "FRAX"
+    }
+  },
+  {
+    "chainId": 2525,
+    "name": "inEVM Mainnet",
+    "shortName": "inevm",
+    "nativeCurrency": {
+      "symbol": "INJ"
+    }
+  },
+  {
+    "chainId": 2552,
+    "name": "Bahamut horizon",
+    "shortName": "horizon",
+    "nativeCurrency": {
+      "symbol": "FTN"
+    }
+  },
+  {
+    "chainId": 2559,
+    "name": "Kortho Mainnet",
+    "shortName": "ktoc",
+    "nativeCurrency": {
+      "symbol": "KTO"
+    }
+  },
+  {
+    "chainId": 2569,
+    "name": "TechPay Mainnet",
+    "shortName": "tpc",
+    "nativeCurrency": {
+      "symbol": "TPC"
+    }
+  },
+  {
+    "chainId": 2582,
+    "name": "H2 Chain Mainnet",
+    "shortName": "h2",
+    "nativeCurrency": {
+      "symbol": "H2"
+    }
+  },
+  {
+    "chainId": 2605,
+    "name": "Pho Blockchain Mainnet",
+    "shortName": "pho",
+    "nativeCurrency": {
+      "symbol": "PHO"
+    }
+  },
+  {
+    "chainId": 2606,
+    "name": "PoCRNet",
+    "shortName": "pocrnet",
+    "nativeCurrency": {
+      "symbol": "CRC"
+    }
+  },
+  {
+    "chainId": 2611,
+    "name": "Redlight Chain Mainnet",
+    "shortName": "REDLC",
+    "nativeCurrency": {
+      "symbol": "REDLC"
+    }
+  },
+  {
+    "chainId": 2612,
+    "name": "EZChain C-Chain Mainnet",
+    "shortName": "EZChain",
+    "nativeCurrency": {
+      "symbol": "EZC"
+    }
+  },
+  {
+    "chainId": 2613,
+    "name": "EZChain C-Chain Testnet",
+    "shortName": "Fuji-EZChain",
+    "nativeCurrency": {
+      "symbol": "EZC"
+    }
+  },
+  {
+    "chainId": 2625,
+    "name": "Whitechain Testnet",
+    "shortName": "twbt",
+    "nativeCurrency": {
+      "symbol": "WBT"
+    }
+  },
+  {
+    "chainId": 2648,
+    "name": "AILayer Testnet",
+    "shortName": "ailayer-testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2649,
+    "name": "AILayer Mainnet",
+    "shortName": "ailayer-mainnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 2662,
+    "name": "APEX",
+    "shortName": "apexmainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2691,
+    "name": "Splendor Mainnet",
+    "shortName": "spld",
+    "nativeCurrency": {
+      "symbol": "SPLD"
+    }
+  },
+  {
+    "chainId": 2692,
+    "name": "Splendor Testnet",
+    "shortName": "spldt",
+    "nativeCurrency": {
+      "symbol": "SPLDT"
+    }
+  },
+  {
+    "chainId": 2710,
+    "name": "Morph Testnet",
+    "shortName": "tmorph",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2718,
+    "name": "K-LAOS",
+    "shortName": "k-laos",
+    "nativeCurrency": {
+      "symbol": "KLAOS"
+    }
+  },
+  {
+    "chainId": 2730,
+    "name": "XR Sepolia",
+    "shortName": "txr",
+    "nativeCurrency": {
+      "symbol": "tXR"
+    }
+  },
+  {
+    "chainId": 2731,
+    "name": "Elizabeth Testnet",
+    "shortName": "TIME",
+    "nativeCurrency": {
+      "symbol": "TIME"
+    }
+  },
+  {
+    "chainId": 2741,
+    "name": "Abstract",
+    "shortName": "abstract",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2748,
+    "name": "Nanon",
+    "shortName": "Nanon",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2777,
+    "name": "GM Network Mainnet",
+    "shortName": "gmnetwork-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2786,
+    "name": "Apertum",
+    "shortName": "aptm",
+    "nativeCurrency": {
+      "symbol": "APTM"
+    }
+  },
+  {
+    "chainId": 2810,
+    "name": "Morph Holesky",
+    "shortName": "hmorph",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2818,
+    "name": "Morph",
+    "shortName": "morph",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2868,
+    "name": "HyperAGI Mainnet",
+    "shortName": "hypt",
+    "nativeCurrency": {
+      "symbol": "HYPT"
+    }
+  },
+  {
+    "chainId": 2882,
+    "name": "Chips Network",
+    "shortName": "chips",
+    "nativeCurrency": {
+      "symbol": "IOTA"
+    }
+  },
+  {
+    "chainId": 2888,
+    "name": "Boba Network Goerli Testnet",
+    "shortName": "BobaGoerli",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2889,
+    "name": "Aarma Mainnet",
+    "shortName": "ARMA",
+    "nativeCurrency": {
+      "symbol": "ARMA"
+    }
+  },
+  {
+    "chainId": 2907,
+    "name": "Elux Chain",
+    "shortName": "ELUX",
+    "nativeCurrency": {
+      "symbol": "ELUX"
+    }
+  },
+  {
+    "chainId": 2911,
+    "name": "HYCHAIN",
+    "shortName": "hychain",
+    "nativeCurrency": {
+      "symbol": "TOPIA"
+    }
+  },
+  {
+    "chainId": 2941,
+    "name": "Xenon Chain Testnet",
+    "shortName": "xenon",
+    "nativeCurrency": {
+      "symbol": "tXEN"
+    }
+  },
+  {
+    "chainId": 2999,
+    "name": "BitYuan Mainnet",
+    "shortName": "bty",
+    "nativeCurrency": {
+      "symbol": "BTY"
+    }
+  },
+  {
+    "chainId": 3000,
+    "name": "CENNZnet Rata",
+    "shortName": "cennz-r",
+    "nativeCurrency": {
+      "symbol": "CPAY"
+    }
+  },
+  {
+    "chainId": 3001,
+    "name": "CENNZnet Nikau",
+    "shortName": "cennz-n",
+    "nativeCurrency": {
+      "symbol": "CPAY"
+    }
+  },
+  {
+    "chainId": 3003,
+    "name": "Canxium Mainnet",
+    "shortName": "cau",
+    "nativeCurrency": {
+      "symbol": "CAU"
+    }
+  },
+  {
+    "chainId": 3011,
+    "name": "PLAYA3ULL GAMES",
+    "shortName": "3ULL",
+    "nativeCurrency": {
+      "symbol": "3ULL"
+    }
+  },
+  {
+    "chainId": 3030,
+    "name": "BC Hyper Chain Mainnet",
+    "shortName": "BCHYPER",
+    "nativeCurrency": {
+      "symbol": "VTCN"
+    }
+  },
+  {
+    "chainId": 3031,
+    "name": "Orlando Chain",
+    "shortName": "ORL",
+    "nativeCurrency": {
+      "symbol": "ORL"
+    }
+  },
+  {
+    "chainId": 3033,
+    "name": "Rebus Testnet",
+    "shortName": "rebus-testnet",
+    "nativeCurrency": {
+      "symbol": "REBUS"
+    }
+  },
+  {
+    "chainId": 3068,
+    "name": "Bifrost Mainnet",
+    "shortName": "bfc",
+    "nativeCurrency": {
+      "symbol": "BFC"
+    }
+  },
+  {
+    "chainId": 3073,
+    "name": "Movement EVM",
+    "shortName": "move",
+    "nativeCurrency": {
+      "symbol": "MOVE"
+    }
+  },
+  {
+    "chainId": 3084,
+    "name": "XL Network Testnet",
+    "shortName": "nysl",
+    "nativeCurrency": {
+      "symbol": "XLN"
+    }
+  },
+  {
+    "chainId": 3100,
+    "name": "Immu3 EVM",
+    "shortName": "Immu3",
+    "nativeCurrency": {
+      "symbol": "IMMU"
+    }
+  },
+  {
+    "chainId": 3102,
+    "name": "Vulture EVM Beta",
+    "shortName": "VFI",
+    "nativeCurrency": {
+      "symbol": "VFI"
+    }
+  },
+  {
+    "chainId": 3109,
+    "name": "SatoshiVM Alpha Mainnet",
+    "shortName": "SAVM",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 3110,
+    "name": "SatoshiVM Testnet",
+    "shortName": "tSAVM",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 3111,
+    "name": "Alpha Chain Mainnet",
+    "shortName": "alpha",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3141,
+    "name": "Filecoin - Hyperspace testnet",
+    "shortName": "filecoin-hyperspace",
+    "nativeCurrency": {
+      "symbol": "tFIL"
+    }
+  },
+  {
+    "chainId": 3230,
+    "name": "C9XChain",
+    "shortName": "c9xchain",
+    "nativeCurrency": {
+      "symbol": "CXC"
+    }
+  },
+  {
+    "chainId": 3269,
+    "name": "Dubxcoin network",
+    "shortName": "dubx",
+    "nativeCurrency": {
+      "symbol": "DUBX"
+    }
+  },
+  {
+    "chainId": 3270,
+    "name": "Dubxcoin testnet",
+    "shortName": "testdubx",
+    "nativeCurrency": {
+      "symbol": "TDUBX"
+    }
+  },
+  {
+    "chainId": 3282,
+    "name": "Irys Mainnet Beta",
+    "shortName": "irys-mainnet-beta",
+    "nativeCurrency": {
+      "symbol": "IRYS"
+    }
+  },
+  {
+    "chainId": 3300,
+    "name": "Realio Testnet",
+    "shortName": "realiotestnet",
+    "nativeCurrency": {
+      "symbol": "RIO"
+    }
+  },
+  {
+    "chainId": 3301,
+    "name": "Realio",
+    "shortName": "realio",
+    "nativeCurrency": {
+      "symbol": "RIO"
+    }
+  },
+  {
+    "chainId": 3306,
+    "name": "Debounce Subnet Testnet",
+    "shortName": "debounce-devnet",
+    "nativeCurrency": {
+      "symbol": "DB"
+    }
+  },
+  {
+    "chainId": 3331,
+    "name": "ZCore Testnet",
+    "shortName": "zcrbeach",
+    "nativeCurrency": {
+      "symbol": "ZCR"
+    }
+  },
+  {
+    "chainId": 3332,
+    "name": "EthStorage L2 Mainnet",
+    "shortName": "esl2-m",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3333,
+    "name": "EthStorage Testnet",
+    "shortName": "es-t",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3334,
+    "name": "Web3Q Galileo",
+    "shortName": "w3q-g",
+    "nativeCurrency": {
+      "symbol": "W3Q"
+    }
+  },
+  {
+    "chainId": 3335,
+    "name": "QuarkChain L2 Beta Testnet",
+    "shortName": "qkcl2-b",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 3336,
+    "name": "EthStorage L2 Testnet",
+    "shortName": "esl2-t",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3337,
+    "name": "EthStorage Devnet",
+    "shortName": "es-d",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3338,
+    "name": "peaq",
+    "shortName": "PEAQ",
+    "nativeCurrency": {
+      "symbol": "PEAQ"
+    }
+  },
+  {
+    "chainId": 3339,
+    "name": "EthStorage L2 Devnet",
+    "shortName": "esl2-d",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3343,
+    "name": "Edge",
+    "shortName": "edge",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3344,
+    "name": "Pentagon Chain",
+    "shortName": "PentagonChain",
+    "nativeCurrency": {
+      "symbol": "PC"
+    }
+  },
+  {
+    "chainId": 3366,
+    "name": "Meroneum",
+    "shortName": "meron-testnet",
+    "nativeCurrency": {
+      "symbol": "MERON"
+    }
+  },
+  {
+    "chainId": 3369,
+    "name": "Meroneum Testnet",
+    "shortName": "meron",
+    "nativeCurrency": {
+      "symbol": "MERON"
+    }
+  },
+  {
+    "chainId": 3400,
+    "name": "Paribu Net Mainnet",
+    "shortName": "prb",
+    "nativeCurrency": {
+      "symbol": "PRB"
+    }
+  },
+  {
+    "chainId": 3409,
+    "name": "Pepe Unchained Deprecated",
+    "shortName": "pepudeprecated",
+    "nativeCurrency": {
+      "symbol": "PEPU"
+    }
+  },
+  {
+    "chainId": 3424,
+    "name": "EVOLVE Mainnet",
+    "shortName": "EVOm",
+    "nativeCurrency": {
+      "symbol": "EVO"
+    }
+  },
+  {
+    "chainId": 3434,
+    "name": "SecureChain Testnet",
+    "shortName": "SCAIt",
+    "nativeCurrency": {
+      "symbol": "SCAI"
+    }
+  },
+  {
+    "chainId": 3456,
+    "name": "LayerEdge testnet",
+    "shortName": "LayerEdge-testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 3490,
+    "name": "GTCSCAN",
+    "shortName": "gtc",
+    "nativeCurrency": {
+      "symbol": "GTC"
+    }
+  },
+  {
+    "chainId": 3500,
+    "name": "Paribu Net Testnet",
+    "shortName": "prbtestnet",
+    "nativeCurrency": {
+      "symbol": "PRB"
+    }
+  },
+  {
+    "chainId": 3501,
+    "name": "JFIN Chain",
+    "shortName": "JFIN",
+    "nativeCurrency": {
+      "symbol": "JFIN"
+    }
+  },
+  {
+    "chainId": 3502,
+    "name": "JFINPOS",
+    "shortName": "jzero",
+    "nativeCurrency": {
+      "symbol": "JPOS"
+    }
+  },
+  {
+    "chainId": 3601,
+    "name": "PandoProject Mainnet",
+    "shortName": "pando-mainnet",
+    "nativeCurrency": {
+      "symbol": "PTX"
+    }
+  },
+  {
+    "chainId": 3602,
+    "name": "PandoProject Testnet",
+    "shortName": "pando-testnet",
+    "nativeCurrency": {
+      "symbol": "PTX"
+    }
+  },
+  {
+    "chainId": 3630,
+    "name": "Tycooncoin",
+    "shortName": "TYCON",
+    "nativeCurrency": {
+      "symbol": "TYCO"
+    }
+  },
+  {
+    "chainId": 3636,
+    "name": "Botanix Testnet",
+    "shortName": "BTNXt",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 3637,
+    "name": "Botanix Mainnet",
+    "shortName": "BTNX",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 3639,
+    "name": "iChain Network",
+    "shortName": "ISLAMI",
+    "nativeCurrency": {
+      "symbol": "ISLAMI"
+    }
+  },
+  {
+    "chainId": 3645,
+    "name": "iChain Testnet",
+    "shortName": "ISLAMIT",
+    "nativeCurrency": {
+      "symbol": "ISLAMI"
+    }
+  },
+  {
+    "chainId": 3666,
+    "name": "Jouleverse Mainnet",
+    "shortName": "jouleverse",
+    "nativeCurrency": {
+      "symbol": "J"
+    }
+  },
+  {
+    "chainId": 3690,
+    "name": "Bittex Mainnet",
+    "shortName": "btx",
+    "nativeCurrency": {
+      "symbol": "BTX"
+    }
+  },
+  {
+    "chainId": 3693,
+    "name": "Empire Network",
+    "shortName": "empire",
+    "nativeCurrency": {
+      "symbol": "EMPIRE"
+    }
+  },
+  {
+    "chainId": 3698,
+    "name": "SenjePowers Testnet",
+    "shortName": "SPCt",
+    "nativeCurrency": {
+      "symbol": "SPC"
+    }
+  },
+  {
+    "chainId": 3699,
+    "name": "SenjePowers Mainnet",
+    "shortName": "SPCm",
+    "nativeCurrency": {
+      "symbol": "SPC"
+    }
+  },
+  {
+    "chainId": 3701,
+    "name": "Xpla Testnet",
+    "shortName": "xplatest",
+    "nativeCurrency": {
+      "symbol": "XPLA"
+    }
+  },
+  {
+    "chainId": 3721,
+    "name": "Xone Mainnet",
+    "shortName": "XOC",
+    "nativeCurrency": {
+      "symbol": "XOC"
+    }
+  },
+  {
+    "chainId": 3737,
+    "name": "Crossbell",
+    "shortName": "csb",
+    "nativeCurrency": {
+      "symbol": "CSB"
+    }
+  },
+  {
+    "chainId": 3776,
+    "name": "Astar zkEVM",
+    "shortName": "astrzk",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3797,
+    "name": "AlveyChain Mainnet",
+    "shortName": "alv",
+    "nativeCurrency": {
+      "symbol": "ALV"
+    }
+  },
+  {
+    "chainId": 3799,
+    "name": "Tangle Testnet",
+    "shortName": "tTangle",
+    "nativeCurrency": {
+      "symbol": "tTNT"
+    }
+  },
+  {
+    "chainId": 3838,
+    "name": "FAVO Mainnet",
+    "shortName": "favo",
+    "nativeCurrency": {
+      "symbol": "FAVO"
+    }
+  },
+  {
+    "chainId": 3885,
+    "name": "Firechain zkEVM Ghostrider",
+    "shortName": "firechain-zkEVM-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3888,
+    "name": "KalyChain Mainnet",
+    "shortName": "kalymainnet",
+    "nativeCurrency": {
+      "symbol": "KLC"
+    }
+  },
+  {
+    "chainId": 3889,
+    "name": "KalyChain Testnet",
+    "shortName": "kalytestnet",
+    "nativeCurrency": {
+      "symbol": "KLC"
+    }
+  },
+  {
+    "chainId": 3912,
+    "name": "DRAC Network",
+    "shortName": "drac",
+    "nativeCurrency": {
+      "symbol": "DRAC"
+    }
+  },
+  {
+    "chainId": 3939,
+    "name": "DOS Testnet",
+    "shortName": "dos-test",
+    "nativeCurrency": {
+      "symbol": "DOS"
+    }
+  },
+  {
+    "chainId": 3966,
+    "name": "DYNO Mainnet",
+    "shortName": "dyno",
+    "nativeCurrency": {
+      "symbol": "DYNO"
+    }
+  },
+  {
+    "chainId": 3967,
+    "name": "DYNO Testnet",
+    "shortName": "tdyno",
+    "nativeCurrency": {
+      "symbol": "tDYNO"
+    }
+  },
+  {
+    "chainId": 3969,
+    "name": "PayNetwork Mainnet",
+    "shortName": "paynetwork",
+    "nativeCurrency": {
+      "symbol": "Pay"
+    }
+  },
+  {
+    "chainId": 3993,
+    "name": "APEX Testnet",
+    "shortName": "apexsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3999,
+    "name": "YuanChain Mainnet",
+    "shortName": "ycc",
+    "nativeCurrency": {
+      "symbol": "YCC"
+    }
+  },
+  {
+    "chainId": 4000,
+    "name": "Ozone Chain Mainnet",
+    "shortName": "ozo",
+    "nativeCurrency": {
+      "symbol": "OZO"
+    }
+  },
+  {
+    "chainId": 4001,
+    "name": "Peperium Chain Testnet",
+    "shortName": "PERIUM",
+    "nativeCurrency": {
+      "symbol": "PERIUM"
+    }
+  },
+  {
+    "chainId": 4002,
+    "name": "Fantom Testnet",
+    "shortName": "tftm",
+    "nativeCurrency": {
+      "symbol": "FTM"
+    }
+  },
+  {
+    "chainId": 4003,
+    "name": "X1 Fastnet",
+    "shortName": "x1-fastnet",
+    "nativeCurrency": {
+      "symbol": "XN"
+    }
+  },
+  {
+    "chainId": 4040,
+    "name": "Carbonium Testnet Network",
+    "shortName": "tcbr",
+    "nativeCurrency": {
+      "symbol": "tCBR"
+    }
+  },
+  {
+    "chainId": 4048,
+    "name": "GANchain L1",
+    "shortName": "GANchain",
+    "nativeCurrency": {
+      "symbol": "GPU"
+    }
+  },
+  {
+    "chainId": 4051,
+    "name": "Bobaopera Testnet",
+    "shortName": "BobaoperaTestnet",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 4058,
+    "name": "Bahamut ocean",
+    "shortName": "ocean",
+    "nativeCurrency": {
+      "symbol": "FTN"
+    }
+  },
+  {
+    "chainId": 4061,
+    "name": "Nahmii 3 Mainnet",
+    "shortName": "Nahmii3Mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4062,
+    "name": "Nahmii 3 Testnet",
+    "shortName": "Nahmii3Testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4078,
+    "name": "Muster Mainnet",
+    "shortName": "muster",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4080,
+    "name": "Tobe Chain Testnet",
+    "shortName": "tbc",
+    "nativeCurrency": {
+      "symbol": "TOBE"
+    }
+  },
+  {
+    "chainId": 4088,
+    "name": "Zeroth Mainnet",
+    "shortName": "ZRH",
+    "nativeCurrency": {
+      "symbol": "ZRH"
+    }
+  },
+  {
+    "chainId": 4090,
+    "name": "Fastex Chain (Bahamut) Oasis Testnet",
+    "shortName": "Oasis",
+    "nativeCurrency": {
+      "symbol": "FTN"
+    }
+  },
+  {
+    "chainId": 4096,
+    "name": "Bitindi Testnet",
+    "shortName": "BNIt",
+    "nativeCurrency": {
+      "symbol": "$BNI"
+    }
+  },
+  {
+    "chainId": 4099,
+    "name": "Bitindi Mainnet",
+    "shortName": "BNIm",
+    "nativeCurrency": {
+      "symbol": "$BNI"
+    }
+  },
+  {
+    "chainId": 4102,
+    "name": "AIOZ Network Testnet",
+    "shortName": "aioz-testnet",
+    "nativeCurrency": {
+      "symbol": "AIOZ"
+    }
+  },
+  {
+    "chainId": 4114,
+    "name": "Citrea Mainnet",
+    "shortName": "citrea",
+    "nativeCurrency": {
+      "symbol": "cBTC"
+    }
+  },
+  {
+    "chainId": 4139,
+    "name": "Humans.ai Testnet",
+    "shortName": "humans_testnet",
+    "nativeCurrency": {
+      "symbol": "HEART"
+    }
+  },
+  {
+    "chainId": 4141,
+    "name": "Tipboxcoin Testnet",
+    "shortName": "TPBXt",
+    "nativeCurrency": {
+      "symbol": "TPBX"
+    }
+  },
+  {
+    "chainId": 4153,
+    "name": "RISE",
+    "shortName": "rise",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4157,
+    "name": "CrossFi Testnet",
+    "shortName": "crossfi-testnet",
+    "nativeCurrency": {
+      "symbol": "XFI"
+    }
+  },
+  {
+    "chainId": 4158,
+    "name": "CrossFi Mainnet",
+    "shortName": "crossfi",
+    "nativeCurrency": {
+      "symbol": "XFI"
+    }
+  },
+  {
+    "chainId": 4160,
+    "name": "Algorand",
+    "shortName": "algo",
+    "nativeCurrency": {
+      "symbol": "ALGO"
+    }
+  },
+  {
+    "chainId": 4162,
+    "name": "SX Rollup",
+    "shortName": "SXR",
+    "nativeCurrency": {
+      "symbol": "SX"
+    }
+  },
+  {
+    "chainId": 4181,
+    "name": "PHI Network V1",
+    "shortName": "PHIv1",
+    "nativeCurrency": {
+      "symbol": "Φ"
+    }
+  },
+  {
+    "chainId": 4200,
+    "name": "Merlin Mainnet",
+    "shortName": "Merlin-Mainnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 4201,
+    "name": "LUKSO Testnet",
+    "shortName": "lukso-testnet",
+    "nativeCurrency": {
+      "symbol": "LYXt"
+    }
+  },
+  {
+    "chainId": 4202,
+    "name": "Lisk Sepolia Testnet",
+    "shortName": "lisksep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4203,
+    "name": "Merlin Erigon Testnet",
+    "shortName": "Merlin-Testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 4207,
+    "name": "Layer Edge Mainnet",
+    "shortName": "LayerEdge",
+    "nativeCurrency": {
+      "symbol": "EDGEN"
+    }
+  },
+  {
+    "chainId": 4217,
+    "name": "Tempo Mainnet Presto",
+    "shortName": "tempo-presto",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 4242,
+    "name": "Nexi Mainnet",
+    "shortName": "nexi",
+    "nativeCurrency": {
+      "symbol": "NEXI"
+    }
+  },
+  {
+    "chainId": 4243,
+    "name": "Nexi V2 Mainnet",
+    "shortName": "NexiV2",
+    "nativeCurrency": {
+      "symbol": "NEXI"
+    }
+  },
+  {
+    "chainId": 4269,
+    "name": "Laika Testnet",
+    "shortName": "laika-testnet",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 4270,
+    "name": "IKChain Testnet",
+    "shortName": "ikchain-testnet",
+    "nativeCurrency": {
+      "symbol": "IKCr"
+    }
+  },
+  {
+    "chainId": 4289,
+    "name": "TPIX Chain",
+    "shortName": "tpix",
+    "nativeCurrency": {
+      "symbol": "TPIX"
+    }
+  },
+  {
+    "chainId": 4290,
+    "name": "TPIX Chain Testnet",
+    "shortName": "tpix-testnet",
+    "nativeCurrency": {
+      "symbol": "tTPIX"
+    }
+  },
+  {
+    "chainId": 4321,
+    "name": "Echos Chain",
+    "shortName": "echos",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 4326,
+    "name": "MegaETH Mainnet",
+    "shortName": "megaeth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4328,
+    "name": "Bobafuji Testnet",
+    "shortName": "BobaFujiTestnet",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 4337,
+    "name": "Beam",
+    "shortName": "beam",
+    "nativeCurrency": {
+      "symbol": "BEAM"
+    }
+  },
+  {
+    "chainId": 4352,
+    "name": "MemeCore",
+    "shortName": "m",
+    "nativeCurrency": {
+      "symbol": "M"
+    }
+  },
+  {
+    "chainId": 4400,
+    "name": "Credit Smart Chain Mainnet",
+    "shortName": "CreditEdge",
+    "nativeCurrency": {
+      "symbol": "CREDIT"
+    }
+  },
+  {
+    "chainId": 4422,
+    "name": "Testnet Pika",
+    "shortName": "PikaMinter",
+    "nativeCurrency": {
+      "symbol": "tPKA"
+    }
+  },
+  {
+    "chainId": 4442,
+    "name": "Denergy Testnet",
+    "shortName": "den-testnet",
+    "nativeCurrency": {
+      "symbol": "WATT"
+    }
+  },
+  {
+    "chainId": 4444,
+    "name": "Htmlcoin Mainnet",
+    "shortName": "html",
+    "nativeCurrency": {
+      "symbol": "HTML"
+    }
+  },
+  {
+    "chainId": 4457,
+    "name": "Oxin Chain",
+    "shortName": "oxin",
+    "nativeCurrency": {
+      "symbol": "OXIN"
+    }
+  },
+  {
+    "chainId": 4460,
+    "name": "Orderly Sepolia Testnet",
+    "shortName": "orderlyl2",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4488,
+    "name": "Hydra Chain",
+    "shortName": "HYDRA",
+    "nativeCurrency": {
+      "symbol": "HYDRA"
+    }
+  },
+  {
+    "chainId": 4544,
+    "name": "Emoney Network Testnet",
+    "shortName": "EmoneyTestnet",
+    "nativeCurrency": {
+      "symbol": "EMYC"
+    }
+  },
+  {
+    "chainId": 4545,
+    "name": "Emoney Network Mainnet",
+    "shortName": "emoney",
+    "nativeCurrency": {
+      "symbol": "EMYC"
+    }
+  },
+  {
+    "chainId": 4547,
+    "name": "TRUMPCHAIN",
+    "shortName": "TRUMPCHAIN",
+    "nativeCurrency": {
+      "symbol": "TRUMP"
+    }
+  },
+  {
+    "chainId": 4613,
+    "name": "VERY Mainnet",
+    "shortName": "very",
+    "nativeCurrency": {
+      "symbol": "VERY"
+    }
+  },
+  {
+    "chainId": 4646,
+    "name": "MST Mainnet",
+    "shortName": "mst",
+    "nativeCurrency": {
+      "symbol": "MSTC"
+    }
+  },
+  {
+    "chainId": 4653,
+    "name": "Gold Chain",
+    "shortName": "gold",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4661,
+    "name": "AppChain Testnet",
+    "shortName": "appchaintestnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4689,
+    "name": "IoTeX Network Mainnet",
+    "shortName": "iotex-mainnet",
+    "nativeCurrency": {
+      "symbol": "IOTX"
+    }
+  },
+  {
+    "chainId": 4690,
+    "name": "IoTeX Network Testnet",
+    "shortName": "iotex-testnet",
+    "nativeCurrency": {
+      "symbol": "IOTX"
+    }
+  },
+  {
+    "chainId": 4759,
+    "name": "MEVerse Chain Testnet",
+    "shortName": "TESTMEV",
+    "nativeCurrency": {
+      "symbol": "MEV"
+    }
+  },
+  {
+    "chainId": 4777,
+    "name": "BlackFort Exchange Network Testnet DEPRECATED",
+    "shortName": "TBXN",
+    "nativeCurrency": {
+      "symbol": "TBXN"
+    }
+  },
+  {
+    "chainId": 4786,
+    "name": "Evnode Testnet",
+    "shortName": "evnode",
+    "nativeCurrency": {
+      "symbol": "tEVO"
+    }
+  },
+  {
+    "chainId": 4801,
+    "name": "World Chain Sepolia Testnet",
+    "shortName": "wcsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4888,
+    "name": "BlackFort Exchange Network Testnet",
+    "shortName": "BXNT",
+    "nativeCurrency": {
+      "symbol": "BXNT"
+    }
+  },
+  {
+    "chainId": 4893,
+    "name": "Globel Chain",
+    "shortName": "GC",
+    "nativeCurrency": {
+      "symbol": "GC"
+    }
+  },
+  {
+    "chainId": 4913,
+    "name": "OEV Network",
+    "shortName": "oev-network",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4918,
+    "name": "Venidium Testnet",
+    "shortName": "txvm",
+    "nativeCurrency": {
+      "symbol": "XVM"
+    }
+  },
+  {
+    "chainId": 4919,
+    "name": "Venidium Mainnet",
+    "shortName": "xvm",
+    "nativeCurrency": {
+      "symbol": "XVM"
+    }
+  },
+  {
+    "chainId": 4999,
+    "name": "BlackFort Exchange Network Deprecated",
+    "shortName": "BXNdpr",
+    "nativeCurrency": {
+      "symbol": "BXNdpr"
+    }
+  },
+  {
+    "chainId": 5000,
+    "name": "Mantle",
+    "shortName": "mantle",
+    "nativeCurrency": {
+      "symbol": "MNT"
+    }
+  },
+  {
+    "chainId": 5001,
+    "name": "Mantle Testnet",
+    "shortName": "mantle-testnet",
+    "nativeCurrency": {
+      "symbol": "MNT"
+    }
+  },
+  {
+    "chainId": 5002,
+    "name": "Treasurenet Mainnet Alpha",
+    "shortName": "treasurenet",
+    "nativeCurrency": {
+      "symbol": "UNIT"
+    }
+  },
+  {
+    "chainId": 5003,
+    "name": "Mantle Sepolia Testnet",
+    "shortName": "mnt-sep",
+    "nativeCurrency": {
+      "symbol": "MNT"
+    }
+  },
+  {
+    "chainId": 5005,
+    "name": "Treasurenet Testnet",
+    "shortName": "tntest",
+    "nativeCurrency": {
+      "symbol": "UNIT"
+    }
+  },
+  {
+    "chainId": 5031,
+    "name": "Somnia Mainnet",
+    "shortName": "SomniaMainnet",
+    "nativeCurrency": {
+      "symbol": "SOMI"
+    }
+  },
+  {
+    "chainId": 5039,
+    "name": "ONIGIRI Test Subnet",
+    "shortName": "onigiritest",
+    "nativeCurrency": {
+      "symbol": "ONGR"
+    }
+  },
+  {
+    "chainId": 5040,
+    "name": "ONIGIRI Subnet",
+    "shortName": "onigiri",
+    "nativeCurrency": {
+      "symbol": "ONGR"
+    }
+  },
+  {
+    "chainId": 5050,
+    "name": "Skate Mainnet",
+    "shortName": "skate",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5051,
+    "name": "Nollie Skatechain Testnet",
+    "shortName": "nollie-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5080,
+    "name": "Pione Zero",
+    "shortName": "pzo",
+    "nativeCurrency": {
+      "symbol": "PZO"
+    }
+  },
+  {
+    "chainId": 5090,
+    "name": "Pione Chain Mainnet",
+    "shortName": "pio",
+    "nativeCurrency": {
+      "symbol": "PIO"
+    }
+  },
+  {
+    "chainId": 5100,
+    "name": "Syndicate Testnet",
+    "shortName": "syndicate-chain-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5101,
+    "name": "Syndicate Frame Chain",
+    "shortName": "syndicate-chain-frame",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5102,
+    "name": "SIC Testnet",
+    "shortName": "sic-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5103,
+    "name": "Coordinape Testnet",
+    "shortName": "coordinape-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5104,
+    "name": "Charmverse Testnet",
+    "shortName": "charmverse-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5105,
+    "name": "Superloyalty Testnet",
+    "shortName": "superloyalty-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5106,
+    "name": "Azra Testnet",
+    "shortName": "azra-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5112,
+    "name": "Ham",
+    "shortName": "ham",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5115,
+    "name": "Citrea Testnet",
+    "shortName": "citrea-testnet",
+    "nativeCurrency": {
+      "symbol": "cBTC"
+    }
+  },
+  {
+    "chainId": 5124,
+    "name": "Seismic Testnet",
+    "shortName": "seismic-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5151,
+    "name": "Moca Chain Testnet",
+    "shortName": "MOCA",
+    "nativeCurrency": {
+      "symbol": "MOCA"
+    }
+  },
+  {
+    "chainId": 5165,
+    "name": "Bahamut",
+    "shortName": "ftn",
+    "nativeCurrency": {
+      "symbol": "FTN"
+    }
+  },
+  {
+    "chainId": 5169,
+    "name": "Smart Layer Network",
+    "shortName": "SLN",
+    "nativeCurrency": {
+      "symbol": "SU"
+    }
+  },
+  {
+    "chainId": 5177,
+    "name": "TLChain Network Mainnet",
+    "shortName": "tlc",
+    "nativeCurrency": {
+      "symbol": "TLC"
+    }
+  },
+  {
+    "chainId": 5197,
+    "name": "EraSwap Mainnet",
+    "shortName": "es",
+    "nativeCurrency": {
+      "symbol": "ES"
+    }
+  },
+  {
+    "chainId": 5232,
+    "name": "LiterMark Chain",
+    "shortName": "lmk",
+    "nativeCurrency": {
+      "symbol": "LMK"
+    }
+  },
+  {
+    "chainId": 5234,
+    "name": "Humanode Mainnet",
+    "shortName": "hmnd",
+    "nativeCurrency": {
+      "symbol": "eHMND"
+    }
+  },
+  {
+    "chainId": 5290,
+    "name": "Firechain Mainnet Old",
+    "shortName": "_old_fire",
+    "nativeCurrency": {
+      "symbol": "FIRE"
+    }
+  },
+  {
+    "chainId": 5315,
+    "name": "Uzmi Network Mainnet",
+    "shortName": "UZMI",
+    "nativeCurrency": {
+      "symbol": "UZMI"
+    }
+  },
+  {
+    "chainId": 5317,
+    "name": "OpTrust Testnet",
+    "shortName": "toptrust",
+    "nativeCurrency": {
+      "symbol": "tBNB"
+    }
+  },
+  {
+    "chainId": 5321,
+    "name": "ITX Testnet",
+    "shortName": "itx-testnet",
+    "nativeCurrency": {
+      "symbol": "ITX"
+    }
+  },
+  {
+    "chainId": 5330,
+    "name": "Superseed",
+    "shortName": "sseed",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5333,
+    "name": "Netsbo",
+    "shortName": "nets",
+    "nativeCurrency": {
+      "symbol": "NETS"
+    }
+  },
+  {
+    "chainId": 5353,
+    "name": "Tritanium Testnet",
+    "shortName": "ttrn",
+    "nativeCurrency": {
+      "symbol": "tTRN"
+    }
+  },
+  {
+    "chainId": 5371,
+    "name": "Settlus",
+    "shortName": "setl",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5372,
+    "name": "Settlus Testnet",
+    "shortName": "settlus-testnet",
+    "nativeCurrency": {
+      "symbol": "SETL"
+    }
+  },
+  {
+    "chainId": 5373,
+    "name": "Settlus Sepolia Testnet",
+    "shortName": "setl-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5424,
+    "name": "edeXa Mainnet",
+    "shortName": "edx",
+    "nativeCurrency": {
+      "symbol": "EDX"
+    }
+  },
+  {
+    "chainId": 5433,
+    "name": "Inertia Scan",
+    "shortName": "IRTA",
+    "nativeCurrency": {
+      "symbol": "IRTA"
+    }
+  },
+  {
+    "chainId": 5439,
+    "name": "Egochain",
+    "shortName": "egax",
+    "nativeCurrency": {
+      "symbol": "EGAX"
+    }
+  },
+  {
+    "chainId": 5464,
+    "name": "SagaEVM",
+    "shortName": "sagaevm",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 5511,
+    "name": "PointPay Mainnet",
+    "shortName": "PP",
+    "nativeCurrency": {
+      "symbol": "PXP"
+    }
+  },
+  {
+    "chainId": 5522,
+    "name": "VEX EVM TESTNET",
+    "shortName": "VEX",
+    "nativeCurrency": {
+      "symbol": "VEX"
+    }
+  },
+  {
+    "chainId": 5545,
+    "name": "DuckChain Mainnet",
+    "shortName": "Duck-Chain-Mainnet",
+    "nativeCurrency": {
+      "symbol": "TON"
+    }
+  },
+  {
+    "chainId": 5551,
+    "name": "Nahmii 2 Mainnet",
+    "shortName": "Nahmii",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5553,
+    "name": "Nahmii 2 Testnet",
+    "shortName": "NahmiiTestnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5555,
+    "name": "Chain Verse Mainnet",
+    "shortName": "cverse",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 5589,
+    "name": "Jamton",
+    "shortName": "jamton",
+    "nativeCurrency": {
+      "symbol": "DOTON"
+    }
+  },
+  {
+    "chainId": 5611,
+    "name": "opBNB Testnet",
+    "shortName": "obnbt",
+    "nativeCurrency": {
+      "symbol": "tBNB"
+    }
+  },
+  {
+    "chainId": 5615,
+    "name": "Arcturus Testneet",
+    "shortName": "arcturus-testnet",
+    "nativeCurrency": {
+      "symbol": "tARC"
+    }
+  },
+  {
+    "chainId": 5616,
+    "name": "Arcturus Chain Testnet",
+    "shortName": "ARCT",
+    "nativeCurrency": {
+      "symbol": "tARCT"
+    }
+  },
+  {
+    "chainId": 5656,
+    "name": "QIE Blockchain",
+    "shortName": "QIE",
+    "nativeCurrency": {
+      "symbol": "QIE"
+    }
+  },
+  {
+    "chainId": 5675,
+    "name": "Filenova Testnet",
+    "shortName": "tfilenova",
+    "nativeCurrency": {
+      "symbol": "tFIL"
+    }
+  },
+  {
+    "chainId": 5678,
+    "name": "Tanssi Demo",
+    "shortName": "tango",
+    "nativeCurrency": {
+      "symbol": "TANGO"
+    }
+  },
+  {
+    "chainId": 5700,
+    "name": "Syscoin Tanenbaum Testnet",
+    "shortName": "tsys",
+    "nativeCurrency": {
+      "symbol": "tSYS"
+    }
+  },
+  {
+    "chainId": 5729,
+    "name": "Hika Network Testnet",
+    "shortName": "hik",
+    "nativeCurrency": {
+      "symbol": "HIK"
+    }
+  },
+  {
+    "chainId": 5758,
+    "name": "SatoshiChain Testnet",
+    "shortName": "satst",
+    "nativeCurrency": {
+      "symbol": "SATS"
+    }
+  },
+  {
+    "chainId": 5777,
+    "name": "Ganache",
+    "shortName": "ggui",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5845,
+    "name": "Tangle",
+    "shortName": "tangle",
+    "nativeCurrency": {
+      "symbol": "TNT"
+    }
+  },
+  {
+    "chainId": 5851,
+    "name": "Ontology Testnet",
+    "shortName": "OntologyTestnet",
+    "nativeCurrency": {
+      "symbol": "ONG"
+    }
+  },
+  {
+    "chainId": 5858,
+    "name": "Chang Chain Foundation Mainnet",
+    "shortName": "ChangChain",
+    "nativeCurrency": {
+      "symbol": "CTH"
+    }
+  },
+  {
+    "chainId": 5869,
+    "name": "Wegochain Rubidium Mainnet",
+    "shortName": "rbd",
+    "nativeCurrency": {
+      "symbol": "RBD"
+    }
+  },
+  {
+    "chainId": 5887,
+    "name": "MANTRACHAIN Testnet",
+    "shortName": "dukong",
+    "nativeCurrency": {
+      "symbol": "MANTRA"
+    }
+  },
+  {
+    "chainId": 5888,
+    "name": "MANTRACHAIN Mainnet",
+    "shortName": "mantrachain",
+    "nativeCurrency": {
+      "symbol": "OM"
+    }
+  },
+  {
+    "chainId": 6000,
+    "name": "BounceBit Testnet",
+    "shortName": "bouncebit-testnet",
+    "nativeCurrency": {
+      "symbol": "BB"
+    }
+  },
+  {
+    "chainId": 6001,
+    "name": "BounceBit Mainnet",
+    "shortName": "bouncebit-mainnet",
+    "nativeCurrency": {
+      "symbol": "BB"
+    }
+  },
+  {
+    "chainId": 6060,
+    "name": "BC Hyper Chain Testnet",
+    "shortName": "BCH",
+    "nativeCurrency": {
+      "symbol": "TVTCN"
+    }
+  },
+  {
+    "chainId": 6065,
+    "name": "Tres Testnet",
+    "shortName": "TRESTEST",
+    "nativeCurrency": {
+      "symbol": "TRES"
+    }
+  },
+  {
+    "chainId": 6066,
+    "name": "Tres Mainnet",
+    "shortName": "TRESMAIN",
+    "nativeCurrency": {
+      "symbol": "TRES"
+    }
+  },
+  {
+    "chainId": 6102,
+    "name": "Cascadia Testnet",
+    "shortName": "cascadia",
+    "nativeCurrency": {
+      "symbol": "tCC"
+    }
+  },
+  {
+    "chainId": 6118,
+    "name": "UPTN Testnet",
+    "shortName": "UPTN-TEST",
+    "nativeCurrency": {
+      "symbol": "UPTN"
+    }
+  },
+  {
+    "chainId": 6119,
+    "name": "UPTN",
+    "shortName": "UPTN",
+    "nativeCurrency": {
+      "symbol": "UPTN"
+    }
+  },
+  {
+    "chainId": 6122,
+    "name": "Tea Mainnet",
+    "shortName": "tea",
+    "nativeCurrency": {
+      "symbol": "TEA"
+    }
+  },
+  {
+    "chainId": 6278,
+    "name": "Rails",
+    "shortName": "rails",
+    "nativeCurrency": {
+      "symbol": "STEAMX"
+    }
+  },
+  {
+    "chainId": 6283,
+    "name": "LAOS",
+    "shortName": "laosnetwork",
+    "nativeCurrency": {
+      "symbol": "LAOS"
+    }
+  },
+  {
+    "chainId": 6320,
+    "name": "NFB Chain Testnet",
+    "shortName": "nfbchaintest",
+    "nativeCurrency": {
+      "symbol": "NFBCT"
+    }
+  },
+  {
+    "chainId": 6321,
+    "name": "Aura Euphoria Testnet",
+    "shortName": "eaura",
+    "nativeCurrency": {
+      "symbol": "eAura"
+    }
+  },
+  {
+    "chainId": 6322,
+    "name": "Aura Mainnet",
+    "shortName": "aura",
+    "nativeCurrency": {
+      "symbol": "AURA"
+    }
+  },
+  {
+    "chainId": 6342,
+    "name": "MegaETH Testnet (Deprecated)",
+    "shortName": "megatest-deprecated",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6343,
+    "name": "MegaETH Testnet",
+    "shortName": "megatest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6363,
+    "name": "Digit Soul Smart Chain",
+    "shortName": "DGS",
+    "nativeCurrency": {
+      "symbol": "DGC"
+    }
+  },
+  {
+    "chainId": 6398,
+    "name": "Connext Sepolia",
+    "shortName": "connext-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6502,
+    "name": "Peerpay",
+    "shortName": "Peerpay",
+    "nativeCurrency": {
+      "symbol": "P2P"
+    }
+  },
+  {
+    "chainId": 6550,
+    "name": "Flamma Testnet",
+    "shortName": "FlammaTestnet",
+    "nativeCurrency": {
+      "symbol": "FLA"
+    }
+  },
+  {
+    "chainId": 6552,
+    "name": "Scolcoin WeiChain Testnet",
+    "shortName": "SRC-test",
+    "nativeCurrency": {
+      "symbol": "SCOL"
+    }
+  },
+  {
+    "chainId": 6565,
+    "name": "Fox Testnet Network",
+    "shortName": "fox",
+    "nativeCurrency": {
+      "symbol": "tFOX"
+    }
+  },
+  {
+    "chainId": 6626,
+    "name": "Pixie Chain Mainnet",
+    "shortName": "pixie-chain",
+    "nativeCurrency": {
+      "symbol": "PIX"
+    }
+  },
+  {
+    "chainId": 6660,
+    "name": "Latest Chain Testnet",
+    "shortName": "LATESTt",
+    "nativeCurrency": {
+      "symbol": "LATEST"
+    }
+  },
+  {
+    "chainId": 6661,
+    "name": "Cybria Mainnet",
+    "shortName": "cyba",
+    "nativeCurrency": {
+      "symbol": "CYBA"
+    }
+  },
+  {
+    "chainId": 6666,
+    "name": "Cybria Testnet",
+    "shortName": "tcyba",
+    "nativeCurrency": {
+      "symbol": "CYBA"
+    }
+  },
+  {
+    "chainId": 6667,
+    "name": "Storchain",
+    "shortName": "str",
+    "nativeCurrency": {
+      "symbol": "STR"
+    }
+  },
+  {
+    "chainId": 6678,
+    "name": "Edge Matrix Chain",
+    "shortName": "EMC",
+    "nativeCurrency": {
+      "symbol": "EMC"
+    }
+  },
+  {
+    "chainId": 6688,
+    "name": "IRIShub",
+    "shortName": "iris",
+    "nativeCurrency": {
+      "symbol": "ERIS"
+    }
+  },
+  {
+    "chainId": 6699,
+    "name": "OX Chain",
+    "shortName": "ox-chain",
+    "nativeCurrency": {
+      "symbol": "OX"
+    }
+  },
+  {
+    "chainId": 6701,
+    "name": "PAXB Mainnet",
+    "shortName": "PAXB",
+    "nativeCurrency": {
+      "symbol": "PAXB"
+    }
+  },
+  {
+    "chainId": 6779,
+    "name": "Compverse Mainnet",
+    "shortName": "compverse",
+    "nativeCurrency": {
+      "symbol": "CPV"
+    }
+  },
+  {
+    "chainId": 6789,
+    "name": "Gold Smart Chain Mainnet",
+    "shortName": "STANDm",
+    "nativeCurrency": {
+      "symbol": "STAND"
+    }
+  },
+  {
+    "chainId": 6800,
+    "name": "BM Chain",
+    "shortName": "bmx",
+    "nativeCurrency": {
+      "symbol": "BMX"
+    }
+  },
+  {
+    "chainId": 6801,
+    "name": "BM Chain Testnet",
+    "shortName": "bmx-testnet",
+    "nativeCurrency": {
+      "symbol": "BMX"
+    }
+  },
+  {
+    "chainId": 6805,
+    "name": "RACE Mainnet",
+    "shortName": "raceeth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6806,
+    "name": "RACE Testnet",
+    "shortName": "racesep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6868,
+    "name": "Pools Mainnet",
+    "shortName": "POOLS",
+    "nativeCurrency": {
+      "symbol": "POOLS"
+    }
+  },
+  {
+    "chainId": 6880,
+    "name": "MTT Network",
+    "shortName": "mtt-network",
+    "nativeCurrency": {
+      "symbol": "MTT"
+    }
+  },
+  {
+    "chainId": 6900,
+    "name": "Nibiru cataclysm-1",
+    "shortName": "cataclysm-1",
+    "nativeCurrency": {
+      "symbol": "NIBI"
+    }
+  },
+  {
+    "chainId": 6911,
+    "name": "Nibiru testnet-2",
+    "shortName": "nibiru-testnet-2",
+    "nativeCurrency": {
+      "symbol": "NIBI"
+    }
+  },
+  {
+    "chainId": 6913,
+    "name": "billions-testnet",
+    "shortName": "billionstest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6934,
+    "name": "Xylume TestNet",
+    "shortName": "xyl",
+    "nativeCurrency": {
+      "symbol": "XYL"
+    }
+  },
+  {
+    "chainId": 6940,
+    "name": "Monolythium Testnet",
+    "shortName": "lyth-testnet",
+    "nativeCurrency": {
+      "symbol": "LYTH"
+    }
+  },
+  {
+    "chainId": 6941,
+    "name": "Monolythium",
+    "shortName": "lyth",
+    "nativeCurrency": {
+      "symbol": "LYTH"
+    }
+  },
+  {
+    "chainId": 6942,
+    "name": "Laika Mainnet",
+    "shortName": "laika",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 6969,
+    "name": "Tomb Chain Mainnet",
+    "shortName": "tombchain",
+    "nativeCurrency": {
+      "symbol": "TOMB"
+    }
+  },
+  {
+    "chainId": 6999,
+    "name": "PolySmartChain",
+    "shortName": "psc",
+    "nativeCurrency": {
+      "symbol": "PSC"
+    }
+  },
+  {
+    "chainId": 7000,
+    "name": "ZetaChain Mainnet",
+    "shortName": "zetachain-mainnet",
+    "nativeCurrency": {
+      "symbol": "ZETA"
+    }
+  },
+  {
+    "chainId": 7001,
+    "name": "ZetaChain Testnet",
+    "shortName": "zetachain-testnet",
+    "nativeCurrency": {
+      "symbol": "ZETA"
+    }
+  },
+  {
+    "chainId": 7007,
+    "name": "BST Chain",
+    "shortName": "BSTC",
+    "nativeCurrency": {
+      "symbol": "BSTC"
+    }
+  },
+  {
+    "chainId": 7027,
+    "name": "Ella the heart",
+    "shortName": "ELLA",
+    "nativeCurrency": {
+      "symbol": "ELLA"
+    }
+  },
+  {
+    "chainId": 7070,
+    "name": "Planq Mainnet",
+    "shortName": "planq",
+    "nativeCurrency": {
+      "symbol": "PLQ"
+    }
+  },
+  {
+    "chainId": 7077,
+    "name": "Planq Atlas Testnet",
+    "shortName": "planq-atlas-testnet",
+    "nativeCurrency": {
+      "symbol": "tPLQ"
+    }
+  },
+  {
+    "chainId": 7099,
+    "name": "Bharat Blockchain Network",
+    "shortName": "bbnt",
+    "nativeCurrency": {
+      "symbol": "BBN"
+    }
+  },
+  {
+    "chainId": 7100,
+    "name": "Nume",
+    "shortName": "nume",
+    "nativeCurrency": {
+      "symbol": "DAI"
+    }
+  },
+  {
+    "chainId": 7117,
+    "name": "0XL3",
+    "shortName": "0xl3",
+    "nativeCurrency": {
+      "symbol": "XL3"
+    }
+  },
+  {
+    "chainId": 7118,
+    "name": "Help The Homeless",
+    "shortName": "hth",
+    "nativeCurrency": {
+      "symbol": "HTH"
+    }
+  },
+  {
+    "chainId": 7171,
+    "name": "Bitrock Mainnet",
+    "shortName": "bitrock",
+    "nativeCurrency": {
+      "symbol": "BROCK"
+    }
+  },
+  {
+    "chainId": 7181,
+    "name": "UXLINK One Testnet",
+    "shortName": "uxlink1-sep",
+    "nativeCurrency": {
+      "symbol": "UXLINK"
+    }
+  },
+  {
+    "chainId": 7200,
+    "name": "exSat Mainnet",
+    "shortName": "xsat",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 7208,
+    "name": "Nexera Mainnet",
+    "shortName": "nxra-mainnet",
+    "nativeCurrency": {
+      "symbol": "NXRA"
+    }
+  },
+  {
+    "chainId": 7210,
+    "name": "Nibiru testnet-1",
+    "shortName": "nibiru-testnet-1",
+    "nativeCurrency": {
+      "symbol": "NIBI"
+    }
+  },
+  {
+    "chainId": 7222,
+    "name": "Nibiru devnet-3",
+    "shortName": "nibiru-devnet-3",
+    "nativeCurrency": {
+      "symbol": "NIBI"
+    }
+  },
+  {
+    "chainId": 7233,
+    "name": "InitVerse Mainnet",
+    "shortName": "INI",
+    "nativeCurrency": {
+      "symbol": "INI"
+    }
+  },
+  {
+    "chainId": 7234,
+    "name": "InitVerse genesis testnet",
+    "shortName": "INICHAIN",
+    "nativeCurrency": {
+      "symbol": "INI"
+    }
+  },
+  {
+    "chainId": 7244,
+    "name": "ZEUS Testnet",
+    "shortName": "ZEUS-Testnet",
+    "nativeCurrency": {
+      "symbol": "ZEUSX"
+    }
+  },
+  {
+    "chainId": 7300,
+    "name": "XPLA Verse",
+    "shortName": "XPLAVERSE",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 7331,
+    "name": "KLYNTAR",
+    "shortName": "kly",
+    "nativeCurrency": {
+      "symbol": "KLY"
+    }
+  },
+  {
+    "chainId": 7332,
+    "name": "Horizen EON Mainnet",
+    "shortName": "EON",
+    "nativeCurrency": {
+      "symbol": "ZEN"
+    }
+  },
+  {
+    "chainId": 7336,
+    "name": "Pruv Testnet",
+    "shortName": "pruvtestnet",
+    "nativeCurrency": {
+      "symbol": "PRUV"
+    }
+  },
+  {
+    "chainId": 7337,
+    "name": "Pruv Mainnet",
+    "shortName": "pruvmainnet",
+    "nativeCurrency": {
+      "symbol": "PRUV"
+    }
+  },
+  {
+    "chainId": 7341,
+    "name": "Shyft Mainnet",
+    "shortName": "shyft",
+    "nativeCurrency": {
+      "symbol": "SHYFT"
+    }
+  },
+  {
+    "chainId": 7368,
+    "name": "Rarimo",
+    "shortName": "rarimo",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7447,
+    "name": "TokClaw Blockchain",
+    "shortName": "TokClaw",
+    "nativeCurrency": {
+      "symbol": "FEE"
+    }
+  },
+  {
+    "chainId": 7484,
+    "name": "Raba Network Mainnet",
+    "shortName": "raba",
+    "nativeCurrency": {
+      "symbol": "RABA"
+    }
+  },
+  {
+    "chainId": 7518,
+    "name": "MEVerse Chain Mainnet",
+    "shortName": "MEV",
+    "nativeCurrency": {
+      "symbol": "MEV"
+    }
+  },
+  {
+    "chainId": 7531,
+    "name": "Rome Palatine",
+    "shortName": "rome-palatine",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 7532,
+    "name": "Rome Mainnet 0 Aventine",
+    "shortName": "rome-mainnet-0-aventine",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 7560,
+    "name": "Cyber Mainnet",
+    "shortName": "cyeth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7575,
+    "name": "ADIL Testnet",
+    "shortName": "tadil",
+    "nativeCurrency": {
+      "symbol": "ADIL"
+    }
+  },
+  {
+    "chainId": 7576,
+    "name": "Adil Chain V2 Mainnet",
+    "shortName": "adil",
+    "nativeCurrency": {
+      "symbol": "ADIL"
+    }
+  },
+  {
+    "chainId": 7667,
+    "name": "CarrChain Mainnet",
+    "shortName": "CarrChain-Mainnet",
+    "nativeCurrency": {
+      "symbol": "CARR"
+    }
+  },
+  {
+    "chainId": 7668,
+    "name": "The Root Network - Mainnet",
+    "shortName": "trn-mainnet",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 7672,
+    "name": "The Root Network - Porcini Testnet",
+    "shortName": "trn-porcini",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 7700,
+    "name": "Canto",
+    "shortName": "canto",
+    "nativeCurrency": {
+      "symbol": "CANTO"
+    }
+  },
+  {
+    "chainId": 7701,
+    "name": "Canto Tesnet",
+    "shortName": "TestnetCanto",
+    "nativeCurrency": {
+      "symbol": "CANTO"
+    }
+  },
+  {
+    "chainId": 7744,
+    "name": "Phron Testnet",
+    "shortName": "phr",
+    "nativeCurrency": {
+      "symbol": "TPHR"
+    }
+  },
+  {
+    "chainId": 7770,
+    "name": "PandaSea Testnet",
+    "shortName": "Pandasea-Testnet",
+    "nativeCurrency": {
+      "symbol": "PANDA"
+    }
+  },
+  {
+    "chainId": 7771,
+    "name": "Bitrock Testnet",
+    "shortName": "tbitrock",
+    "nativeCurrency": {
+      "symbol": "BROCK"
+    }
+  },
+  {
+    "chainId": 7774,
+    "name": "GDCC MAINNET",
+    "shortName": "GdccMainnet",
+    "nativeCurrency": {
+      "symbol": "GDCC"
+    }
+  },
+  {
+    "chainId": 7775,
+    "name": "GDCC TESTNET",
+    "shortName": "GDCC",
+    "nativeCurrency": {
+      "symbol": "GDCC"
+    }
+  },
+  {
+    "chainId": 7776,
+    "name": "PandaSea Mainnet",
+    "shortName": "pandaSea-mainnet",
+    "nativeCurrency": {
+      "symbol": "PANDA"
+    }
+  },
+  {
+    "chainId": 7777,
+    "name": "Rise of the Warbots Testnet",
+    "shortName": "RiseOfTheWarbotsTestnet",
+    "nativeCurrency": {
+      "symbol": "NMAC"
+    }
+  },
+  {
+    "chainId": 7778,
+    "name": "Orenium Mainnet Protocol",
+    "shortName": "ore",
+    "nativeCurrency": {
+      "symbol": "ORE"
+    }
+  },
+  {
+    "chainId": 7788,
+    "name": "Draw Coin",
+    "shortName": "drw",
+    "nativeCurrency": {
+      "symbol": "DRW"
+    }
+  },
+  {
+    "chainId": 7791,
+    "name": "DiamondzChain",
+    "shortName": "dzx",
+    "nativeCurrency": {
+      "symbol": "SDM"
+    }
+  },
+  {
+    "chainId": 7798,
+    "name": "OpenEX LONG Testnet",
+    "shortName": "oex",
+    "nativeCurrency": {
+      "symbol": "USDT"
+    }
+  },
+  {
+    "chainId": 7860,
+    "name": "MaalChain Testnet",
+    "shortName": "maal-test",
+    "nativeCurrency": {
+      "symbol": "MAAL"
+    }
+  },
+  {
+    "chainId": 7862,
+    "name": "MaalChain V2",
+    "shortName": "maal-v2",
+    "nativeCurrency": {
+      "symbol": "MAAL"
+    }
+  },
+  {
+    "chainId": 7863,
+    "name": "MaalChain Testnet V2",
+    "shortName": "maal-test-v2",
+    "nativeCurrency": {
+      "symbol": "MAAL"
+    }
+  },
+  {
+    "chainId": 7865,
+    "name": "Powerloom Mainnet",
+    "shortName": "power",
+    "nativeCurrency": {
+      "symbol": "POWER"
+    }
+  },
+  {
+    "chainId": 7869,
+    "name": "Powerloom Mainnet V2",
+    "shortName": "powerloom",
+    "nativeCurrency": {
+      "symbol": "POWER"
+    }
+  },
+  {
+    "chainId": 7878,
+    "name": "Hazlor Testnet",
+    "shortName": "tscas",
+    "nativeCurrency": {
+      "symbol": "TSCAS"
+    }
+  },
+  {
+    "chainId": 7879,
+    "name": "Vexon Testnet",
+    "shortName": "vexon",
+    "nativeCurrency": {
+      "symbol": "tVEX"
+    }
+  },
+  {
+    "chainId": 7887,
+    "name": "Kinto Mainnet",
+    "shortName": "kintoMainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7895,
+    "name": "ARDENIUM Athena",
+    "shortName": "ard",
+    "nativeCurrency": {
+      "symbol": "tARD"
+    }
+  },
+  {
+    "chainId": 7897,
+    "name": "arena-z",
+    "shortName": "arena-z",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7923,
+    "name": "Dot Blox",
+    "shortName": "DTBX",
+    "nativeCurrency": {
+      "symbol": "DTBX"
+    }
+  },
+  {
+    "chainId": 7924,
+    "name": "MO Mainnet",
+    "shortName": "MO",
+    "nativeCurrency": {
+      "symbol": "MO"
+    }
+  },
+  {
+    "chainId": 7957,
+    "name": "Exorium Testnet",
+    "shortName": "texor",
+    "nativeCurrency": {
+      "symbol": "tEXOR"
+    }
+  },
+  {
+    "chainId": 7979,
+    "name": "DOS Chain",
+    "shortName": "dos",
+    "nativeCurrency": {
+      "symbol": "DOS"
+    }
+  },
+  {
+    "chainId": 7991,
+    "name": "Peeryn",
+    "shortName": "pyn",
+    "nativeCurrency": {
+      "symbol": "PYN"
+    }
+  },
+  {
+    "chainId": 8000,
+    "name": "Teleport",
+    "shortName": "teleport",
+    "nativeCurrency": {
+      "symbol": "TELE"
+    }
+  },
+  {
+    "chainId": 8001,
+    "name": "Teleport Testnet",
+    "shortName": "teleport-testnet",
+    "nativeCurrency": {
+      "symbol": "TELE"
+    }
+  },
+  {
+    "chainId": 8004,
+    "name": "ProbeChain Mainnet",
+    "shortName": "probe",
+    "nativeCurrency": {
+      "symbol": "PROBE"
+    }
+  },
+  {
+    "chainId": 8008,
+    "name": "Polynomial",
+    "shortName": "polynomial",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8017,
+    "name": "iSunCoin Mainnet",
+    "shortName": "isc",
+    "nativeCurrency": {
+      "symbol": "ISC"
+    }
+  },
+  {
+    "chainId": 8029,
+    "name": "MDGL Testnet",
+    "shortName": "mdgl",
+    "nativeCurrency": {
+      "symbol": "MDGLT"
+    }
+  },
+  {
+    "chainId": 8047,
+    "name": "BOAT Mainnet",
+    "shortName": "boat",
+    "nativeCurrency": {
+      "symbol": "BOAT"
+    }
+  },
+  {
+    "chainId": 8054,
+    "name": "Karak Sepolia",
+    "shortName": "karak-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8080,
+    "name": "Shardeum Liberty 1.X",
+    "shortName": "Liberty10",
+    "nativeCurrency": {
+      "symbol": "SHM"
+    }
+  },
+  {
+    "chainId": 8081,
+    "name": "Shardeum Liberty 2.X",
+    "shortName": "Liberty20",
+    "nativeCurrency": {
+      "symbol": "SHM"
+    }
+  },
+  {
+    "chainId": 8082,
+    "name": "Shardeum Sphinx 1.X",
+    "shortName": "Sphinx10",
+    "nativeCurrency": {
+      "symbol": "SHM"
+    }
+  },
+  {
+    "chainId": 8083,
+    "name": "Shardeum Testnet",
+    "shortName": "ShardeumTestnet",
+    "nativeCurrency": {
+      "symbol": "SHM"
+    }
+  },
+  {
+    "chainId": 8086,
+    "name": "Bitcoin Chain",
+    "shortName": "Bitcoin",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 8087,
+    "name": "E-Dollar",
+    "shortName": "E-Dollar",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 8098,
+    "name": "StreamuX Blockchain",
+    "shortName": "StreamuX",
+    "nativeCurrency": {
+      "symbol": "SmuX"
+    }
+  },
+  {
+    "chainId": 8099,
+    "name": "Bharat Blockchain Network Mainnet",
+    "shortName": "bbn",
+    "nativeCurrency": {
+      "symbol": "BBN"
+    }
+  },
+  {
+    "chainId": 8108,
+    "name": "ZenChain",
+    "shortName": "zen",
+    "nativeCurrency": {
+      "symbol": "ZTC"
+    }
+  },
+  {
+    "chainId": 8118,
+    "name": "Shardeum",
+    "shortName": "Shardeum",
+    "nativeCurrency": {
+      "symbol": "SHM"
+    }
+  },
+  {
+    "chainId": 8131,
+    "name": "Qitmeer Network Testnet",
+    "shortName": "meertest",
+    "nativeCurrency": {
+      "symbol": "MEER-T"
+    }
+  },
+  {
+    "chainId": 8132,
+    "name": "Qitmeer Network Mixnet",
+    "shortName": "meermix",
+    "nativeCurrency": {
+      "symbol": "MEER-M"
+    }
+  },
+  {
+    "chainId": 8133,
+    "name": "Qitmeer Network Privnet",
+    "shortName": "meerpriv",
+    "nativeCurrency": {
+      "symbol": "MEER-P"
+    }
+  },
+  {
+    "chainId": 8134,
+    "name": "Amana",
+    "shortName": "amana",
+    "nativeCurrency": {
+      "symbol": "MEER"
+    }
+  },
+  {
+    "chainId": 8135,
+    "name": "Flana",
+    "shortName": "flana",
+    "nativeCurrency": {
+      "symbol": "MEER"
+    }
+  },
+  {
+    "chainId": 8136,
+    "name": "Mizana",
+    "shortName": "mizana",
+    "nativeCurrency": {
+      "symbol": "MEER"
+    }
+  },
+  {
+    "chainId": 8150,
+    "name": "Alpen Testnet",
+    "shortName": "alpen-testnet",
+    "nativeCurrency": {
+      "symbol": "sBTC"
+    }
+  },
+  {
+    "chainId": 8181,
+    "name": "Testnet BeOne Chain",
+    "shortName": "tBOC",
+    "nativeCurrency": {
+      "symbol": "tBOC"
+    }
+  },
+  {
+    "chainId": 8192,
+    "name": "Torus Mainnet",
+    "shortName": "tqf",
+    "nativeCurrency": {
+      "symbol": "TQF"
+    }
+  },
+  {
+    "chainId": 8194,
+    "name": "Torus Testnet",
+    "shortName": "ttqf",
+    "nativeCurrency": {
+      "symbol": "TTQF"
+    }
+  },
+  {
+    "chainId": 8217,
+    "name": "Kaia Mainnet",
+    "shortName": "kaia-mainnet",
+    "nativeCurrency": {
+      "symbol": "KAIA"
+    }
+  },
+  {
+    "chainId": 8227,
+    "name": "Space Subnet",
+    "shortName": "space",
+    "nativeCurrency": {
+      "symbol": "FUEL"
+    }
+  },
+  {
+    "chainId": 8272,
+    "name": "Blockton Blockchain",
+    "shortName": "BTON",
+    "nativeCurrency": {
+      "symbol": "BTON"
+    }
+  },
+  {
+    "chainId": 8282,
+    "name": "StableNet Mainnet",
+    "shortName": "stablenet",
+    "nativeCurrency": {
+      "symbol": "WKRC"
+    }
+  },
+  {
+    "chainId": 8283,
+    "name": "StableNet Testnet",
+    "shortName": "stablenet-testnet",
+    "nativeCurrency": {
+      "symbol": "WKRC"
+    }
+  },
+  {
+    "chainId": 8285,
+    "name": "KorthoTest",
+    "shortName": "Kortho",
+    "nativeCurrency": {
+      "symbol": "KTO"
+    }
+  },
+  {
+    "chainId": 8329,
+    "name": "Lorenzo",
+    "shortName": "lrz",
+    "nativeCurrency": {
+      "symbol": "stBTC"
+    }
+  },
+  {
+    "chainId": 8333,
+    "name": "B3",
+    "shortName": "b3",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8386,
+    "name": "XProtocol",
+    "shortName": "xprotocol",
+    "nativeCurrency": {
+      "symbol": "KICK"
+    }
+  },
+  {
+    "chainId": 8387,
+    "name": "Dracones Financial Services",
+    "shortName": "fuck",
+    "nativeCurrency": {
+      "symbol": "FUCK"
+    }
+  },
+  {
+    "chainId": 8408,
+    "name": "ZenChain Testnet",
+    "shortName": "zentest",
+    "nativeCurrency": {
+      "symbol": "ZTC"
+    }
+  },
+  {
+    "chainId": 8428,
+    "name": "THAT Mainnet",
+    "shortName": "THAT",
+    "nativeCurrency": {
+      "symbol": "THAT"
+    }
+  },
+  {
+    "chainId": 8453,
+    "name": "Base",
+    "shortName": "base",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8545,
+    "name": "Chakra Testnet",
+    "shortName": "ChakraTN",
+    "nativeCurrency": {
+      "symbol": "CKR"
+    }
+  },
+  {
+    "chainId": 8569,
+    "name": "New Reality Blockchain",
+    "shortName": "newrl",
+    "nativeCurrency": {
+      "symbol": "NEWRL"
+    }
+  },
+  {
+    "chainId": 8654,
+    "name": "Toki Network",
+    "shortName": "toki",
+    "nativeCurrency": {
+      "symbol": "TOKI"
+    }
+  },
+  {
+    "chainId": 8655,
+    "name": "Toki Testnet",
+    "shortName": "toki-testnet",
+    "nativeCurrency": {
+      "symbol": "TOKI"
+    }
+  },
+  {
+    "chainId": 8668,
+    "name": "Hela Official Runtime Mainnet",
+    "shortName": "hela",
+    "nativeCurrency": {
+      "symbol": "HLUSD"
+    }
+  },
+  {
+    "chainId": 8700,
+    "name": "Autonomys Chronos Testnet",
+    "shortName": "ATN",
+    "nativeCurrency": {
+      "symbol": "AI3"
+    }
+  },
+  {
+    "chainId": 8723,
+    "name": "TOOL Global Mainnet",
+    "shortName": "olo",
+    "nativeCurrency": {
+      "symbol": "OLO"
+    }
+  },
+  {
+    "chainId": 8724,
+    "name": "TOOL Global Testnet",
+    "shortName": "tolo",
+    "nativeCurrency": {
+      "symbol": "OLO"
+    }
+  },
+  {
+    "chainId": 8726,
+    "name": "Storagechain Mainnet",
+    "shortName": "stor",
+    "nativeCurrency": {
+      "symbol": "STOR"
+    }
+  },
+  {
+    "chainId": 8727,
+    "name": "Storagechain Testnet",
+    "shortName": "tstor",
+    "nativeCurrency": {
+      "symbol": "STOR"
+    }
+  },
+  {
+    "chainId": 8732,
+    "name": "Bullions Smart Chain",
+    "shortName": "bln",
+    "nativeCurrency": {
+      "symbol": "BLN"
+    }
+  },
+  {
+    "chainId": 8738,
+    "name": "Alph Network",
+    "shortName": "alph",
+    "nativeCurrency": {
+      "symbol": "ALPH"
+    }
+  },
+  {
+    "chainId": 8768,
+    "name": "TMY Chain",
+    "shortName": "tmy",
+    "nativeCurrency": {
+      "symbol": "TMY"
+    }
+  },
+  {
+    "chainId": 8801,
+    "name": "Okto Testnet",
+    "shortName": "okto-testnet",
+    "nativeCurrency": {
+      "symbol": "OKTO"
+    }
+  },
+  {
+    "chainId": 8811,
+    "name": "Haven1",
+    "shortName": "haven1",
+    "nativeCurrency": {
+      "symbol": "H1"
+    }
+  },
+  {
+    "chainId": 8822,
+    "name": "IOTA EVM",
+    "shortName": "iotaevm",
+    "nativeCurrency": {
+      "symbol": "IOTA"
+    }
+  },
+  {
+    "chainId": 8844,
+    "name": "Hydra Chain Testnet",
+    "shortName": "THYDRA",
+    "nativeCurrency": {
+      "symbol": "tHYDRA"
+    }
+  },
+  {
+    "chainId": 8848,
+    "name": "MARO Blockchain Mainnet",
+    "shortName": "maro",
+    "nativeCurrency": {
+      "symbol": "MARO"
+    }
+  },
+  {
+    "chainId": 8866,
+    "name": "SuperLumio",
+    "shortName": "superlumio",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8869,
+    "name": "Lif3 Chain",
+    "shortName": "lif3-mainnet",
+    "nativeCurrency": {
+      "symbol": "LIF3"
+    }
+  },
+  {
+    "chainId": 8880,
+    "name": "Unique",
+    "shortName": "unq",
+    "nativeCurrency": {
+      "symbol": "UNQ"
+    }
+  },
+  {
+    "chainId": 8881,
+    "name": "Quartz by Unique",
+    "shortName": "qtz",
+    "nativeCurrency": {
+      "symbol": "QTZ"
+    }
+  },
+  {
+    "chainId": 8882,
+    "name": "Opal testnet by Unique",
+    "shortName": "opl",
+    "nativeCurrency": {
+      "symbol": "UNQ"
+    }
+  },
+  {
+    "chainId": 8883,
+    "name": "Sapphire by Unique",
+    "shortName": "sph",
+    "nativeCurrency": {
+      "symbol": "QTZ"
+    }
+  },
+  {
+    "chainId": 8886,
+    "name": "Avenium Testnet",
+    "shortName": "tave",
+    "nativeCurrency": {
+      "symbol": "tAVE"
+    }
+  },
+  {
+    "chainId": 8888,
+    "name": "XANAChain",
+    "shortName": "XANAChain",
+    "nativeCurrency": {
+      "symbol": "XETA"
+    }
+  },
+  {
+    "chainId": 8889,
+    "name": "Vyvo Smart Chain",
+    "shortName": "vsc",
+    "nativeCurrency": {
+      "symbol": "VSC"
+    }
+  },
+  {
+    "chainId": 8890,
+    "name": "Orenium Testnet Protocol",
+    "shortName": "tore",
+    "nativeCurrency": {
+      "symbol": "tORE"
+    }
+  },
+  {
+    "chainId": 8898,
+    "name": "Mammoth Mainnet",
+    "shortName": "mmt",
+    "nativeCurrency": {
+      "symbol": "MMT"
+    }
+  },
+  {
+    "chainId": 8899,
+    "name": "JIBCHAIN L1",
+    "shortName": "jbc",
+    "nativeCurrency": {
+      "symbol": "JBC"
+    }
+  },
+  {
+    "chainId": 8911,
+    "name": "Algen",
+    "shortName": "alg",
+    "nativeCurrency": {
+      "symbol": "ALG"
+    }
+  },
+  {
+    "chainId": 8912,
+    "name": "Algen Testnet",
+    "shortName": "algTest",
+    "nativeCurrency": {
+      "symbol": "ALG"
+    }
+  },
+  {
+    "chainId": 8921,
+    "name": "Algen Layer2",
+    "shortName": "algl2",
+    "nativeCurrency": {
+      "symbol": "ALG"
+    }
+  },
+  {
+    "chainId": 8922,
+    "name": "Algen Layer2 Testnet",
+    "shortName": "algl2Test",
+    "nativeCurrency": {
+      "symbol": "ALG"
+    }
+  },
+  {
+    "chainId": 8989,
+    "name": "Giant Mammoth Mainnet",
+    "shortName": "gmmt",
+    "nativeCurrency": {
+      "symbol": "GMMT"
+    }
+  },
+  {
+    "chainId": 8995,
+    "name": "bloxberg",
+    "shortName": "berg",
+    "nativeCurrency": {
+      "symbol": "U+25B3"
+    }
+  },
+  {
+    "chainId": 9000,
+    "name": "Evmos Testnet",
+    "shortName": "evmos-testnet",
+    "nativeCurrency": {
+      "symbol": "tEVMOS"
+    }
+  },
+  {
+    "chainId": 9001,
+    "name": "Evmos",
+    "shortName": "evmos",
+    "nativeCurrency": {
+      "symbol": "EVMOS"
+    }
+  },
+  {
+    "chainId": 9003,
+    "name": "Qubetics Alpha Testnet",
+    "shortName": "QubeticsAlpha",
+    "nativeCurrency": {
+      "symbol": "TICS"
+    }
+  },
+  {
+    "chainId": 9007,
+    "name": "Shido Testnet Block",
+    "shortName": "ShidoTestnet",
+    "nativeCurrency": {
+      "symbol": "SHIDO"
+    }
+  },
+  {
+    "chainId": 9008,
+    "name": "Shido Network",
+    "shortName": "Shido",
+    "nativeCurrency": {
+      "symbol": "SHIDO"
+    }
+  },
+  {
+    "chainId": 9012,
+    "name": "BerylBit Mainnet",
+    "shortName": "brb",
+    "nativeCurrency": {
+      "symbol": "BRB"
+    }
+  },
+  {
+    "chainId": 9024,
+    "name": "Nexa Testnet Block",
+    "shortName": "NexaTestnet",
+    "nativeCurrency": {
+      "symbol": "NEXB"
+    }
+  },
+  {
+    "chainId": 9025,
+    "name": "Nexa Mainnet Block",
+    "shortName": "Nexa",
+    "nativeCurrency": {
+      "symbol": "NEXB"
+    }
+  },
+  {
+    "chainId": 9029,
+    "name": "Qubetics Testnet",
+    "shortName": "Qubetics",
+    "nativeCurrency": {
+      "symbol": "TICS"
+    }
+  },
+  {
+    "chainId": 9030,
+    "name": "Qubetics Mainnet",
+    "shortName": "QubeticsMainnet",
+    "nativeCurrency": {
+      "symbol": "TICS"
+    }
+  },
+  {
+    "chainId": 9069,
+    "name": "Apex Fusion - Nexus Mainnet",
+    "shortName": "AP3X",
+    "nativeCurrency": {
+      "symbol": "AP3X"
+    }
+  },
+  {
+    "chainId": 9070,
+    "name": "Apex Fusion - Nexus testnet",
+    "shortName": "tAP3X",
+    "nativeCurrency": {
+      "symbol": "tAP3X"
+    }
+  },
+  {
+    "chainId": 9090,
+    "name": "Inco Gentry Testnet",
+    "shortName": "inco-gentry",
+    "nativeCurrency": {
+      "symbol": "INCO"
+    }
+  },
+  {
+    "chainId": 9091,
+    "name": "KPA Smart Chain Testnet",
+    "shortName": "KPA",
+    "nativeCurrency": {
+      "symbol": "tKPA"
+    }
+  },
+  {
+    "chainId": 9100,
+    "name": "Genesis Coin",
+    "shortName": "GENEC",
+    "nativeCurrency": {
+      "symbol": "GNC"
+    }
+  },
+  {
+    "chainId": 9108,
+    "name": "Destra Dubai Testnet",
+    "shortName": "Destra",
+    "nativeCurrency": {
+      "symbol": "SYNC"
+    }
+  },
+  {
+    "chainId": 9134,
+    "name": "GIWA",
+    "shortName": "giwa",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9170,
+    "name": "Rinia Testnet Old",
+    "shortName": "_old_tfire",
+    "nativeCurrency": {
+      "symbol": "FIRE"
+    }
+  },
+  {
+    "chainId": 9223,
+    "name": "Codefin Mainnet",
+    "shortName": "COF",
+    "nativeCurrency": {
+      "symbol": "COF"
+    }
+  },
+  {
+    "chainId": 9302,
+    "name": "Galactica-Reticulum",
+    "shortName": "GNET",
+    "nativeCurrency": {
+      "symbol": "GNET"
+    }
+  },
+  {
+    "chainId": 9339,
+    "name": "Dogcoin Testnet",
+    "shortName": "DOGSt",
+    "nativeCurrency": {
+      "symbol": "DOGS"
+    }
+  },
+  {
+    "chainId": 9369,
+    "name": "Z Chain",
+    "shortName": "z",
+    "nativeCurrency": {
+      "symbol": "Z"
+    }
+  },
+  {
+    "chainId": 9372,
+    "name": "Oasys Testnet",
+    "shortName": "OAS_TEST",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 9393,
+    "name": "Dela Sepolia Testnet",
+    "shortName": "delasep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9395,
+    "name": "Evoke Mainnet",
+    "shortName": "MTHN",
+    "nativeCurrency": {
+      "symbol": "MTHN"
+    }
+  },
+  {
+    "chainId": 9496,
+    "name": "Load Alphanet",
+    "shortName": "tload",
+    "nativeCurrency": {
+      "symbol": "tLOAD"
+    }
+  },
+  {
+    "chainId": 9511,
+    "name": "Colossus Sepolia Testnet",
+    "shortName": "colsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9527,
+    "name": "Rangers Protocol Testnet Robin",
+    "shortName": "trpg",
+    "nativeCurrency": {
+      "symbol": "tRPG"
+    }
+  },
+  {
+    "chainId": 9528,
+    "name": "QEasyWeb3 Testnet",
+    "shortName": "QETTest",
+    "nativeCurrency": {
+      "symbol": "QET"
+    }
+  },
+  {
+    "chainId": 9559,
+    "name": "Neonlink Testnet",
+    "shortName": "testneon",
+    "nativeCurrency": {
+      "symbol": "tNEON"
+    }
+  },
+  {
+    "chainId": 9696,
+    "name": "Rebus Mainnet",
+    "shortName": "rebus",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9700,
+    "name": "Oort MainnetDev",
+    "shortName": "MainnetDev",
+    "nativeCurrency": {
+      "symbol": "OORT"
+    }
+  },
+  {
+    "chainId": 9728,
+    "name": "Boba BNB Testnet",
+    "shortName": "BobaBnbTestnet",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 9745,
+    "name": "Plasma Mainnet",
+    "shortName": "plasma",
+    "nativeCurrency": {
+      "symbol": "XPL"
+    }
+  },
+  {
+    "chainId": 9746,
+    "name": "Plasma Testnet",
+    "shortName": "plasma-testnet",
+    "nativeCurrency": {
+      "symbol": "XPL"
+    }
+  },
+  {
+    "chainId": 9747,
+    "name": "Plasma Devnet",
+    "shortName": "plasma-devnet",
+    "nativeCurrency": {
+      "symbol": "XPL"
+    }
+  },
+  {
+    "chainId": 9768,
+    "name": "MainnetZ Testnet",
+    "shortName": "NetZt",
+    "nativeCurrency": {
+      "symbol": "NetZ"
+    }
+  },
+  {
+    "chainId": 9770,
+    "name": "Nepachain",
+    "shortName": "Nepachain",
+    "nativeCurrency": {
+      "symbol": "NPC"
+    }
+  },
+  {
+    "chainId": 9779,
+    "name": "PepeNetwork Mainnet",
+    "shortName": "pn",
+    "nativeCurrency": {
+      "symbol": "WPEPE"
+    }
+  },
+  {
+    "chainId": 9788,
+    "name": "Tabi Testnetv2",
+    "shortName": "tabitestv2",
+    "nativeCurrency": {
+      "symbol": "TABI"
+    }
+  },
+  {
+    "chainId": 9789,
+    "name": "Tabi Testnet",
+    "shortName": "tabitest",
+    "nativeCurrency": {
+      "symbol": "TABI"
+    }
+  },
+  {
+    "chainId": 9790,
+    "name": "Carbon EVM",
+    "shortName": "carbon",
+    "nativeCurrency": {
+      "symbol": "SWTH"
+    }
+  },
+  {
+    "chainId": 9792,
+    "name": "Carbon EVM Testnet",
+    "shortName": "carbon-testnet",
+    "nativeCurrency": {
+      "symbol": "SWTH"
+    }
+  },
+  {
+    "chainId": 9797,
+    "name": "OptimusZ7 Mainnet",
+    "shortName": "OZ7m",
+    "nativeCurrency": {
+      "symbol": "OZ7"
+    }
+  },
+  {
+    "chainId": 9818,
+    "name": "IMPERIUM TESTNET",
+    "shortName": "tIMP",
+    "nativeCurrency": {
+      "symbol": "tIMP"
+    }
+  },
+  {
+    "chainId": 9819,
+    "name": "IMPERIUM MAINNET",
+    "shortName": "IMP",
+    "nativeCurrency": {
+      "symbol": "IMP"
+    }
+  },
+  {
+    "chainId": 9876,
+    "name": "BinaryChain Testnet",
+    "shortName": "binarytestnet",
+    "nativeCurrency": {
+      "symbol": "BNRY"
+    }
+  },
+  {
+    "chainId": 9888,
+    "name": "Dogelayer Mainnet",
+    "shortName": "Dogelayer",
+    "nativeCurrency": {
+      "symbol": "DOGE"
+    }
+  },
+  {
+    "chainId": 9889,
+    "name": "pointledger",
+    "shortName": "pointledger",
+    "nativeCurrency": {
+      "symbol": "PLG"
+    }
+  },
+  {
+    "chainId": 9897,
+    "name": "arena-z-testnet-deprecated",
+    "shortName": "arena-z-testnet-deprecated",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9898,
+    "name": "Larissa Chain",
+    "shortName": "lrs",
+    "nativeCurrency": {
+      "symbol": "LRS"
+    }
+  },
+  {
+    "chainId": 9899,
+    "name": "Arena-Z-Testnet",
+    "shortName": "arena-z-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9901,
+    "name": "Zytron Linea Mainnet",
+    "shortName": "zytron-linea",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9911,
+    "name": "Espento Mainnet",
+    "shortName": "spent",
+    "nativeCurrency": {
+      "symbol": "SPENT"
+    }
+  },
+  {
+    "chainId": 9922,
+    "name": "JingleX L2",
+    "shortName": "jnx",
+    "nativeCurrency": {
+      "symbol": "JNX"
+    }
+  },
+  {
+    "chainId": 9966,
+    "name": "UXER TESTNET NETWORK",
+    "shortName": "uxer",
+    "nativeCurrency": {
+      "symbol": "tUXER"
+    }
+  },
+  {
+    "chainId": 9977,
+    "name": "Mind Smart Chain Testnet",
+    "shortName": "tMIND",
+    "nativeCurrency": {
+      "symbol": "tMIND"
+    }
+  },
+  {
+    "chainId": 9980,
+    "name": "Combo Mainnet",
+    "shortName": "combo-mainnet",
+    "nativeCurrency": {
+      "symbol": "BNB"
+    }
+  },
+  {
+    "chainId": 9981,
+    "name": "Volley Mainnet",
+    "shortName": "volley-mainnet",
+    "nativeCurrency": {
+      "symbol": "V2X"
+    }
+  },
+  {
+    "chainId": 9982,
+    "name": "MFEV CHAIN MAINNET",
+    "shortName": "mfevscan",
+    "nativeCurrency": {
+      "symbol": "MFEV"
+    }
+  },
+  {
+    "chainId": 9990,
+    "name": "Agung Network",
+    "shortName": "AGNG",
+    "nativeCurrency": {
+      "symbol": "AGNG"
+    }
+  },
+  {
+    "chainId": 9996,
+    "name": "Mind Smart Chain Mainnet",
+    "shortName": "MIND",
+    "nativeCurrency": {
+      "symbol": "MIND"
+    }
+  },
+  {
+    "chainId": 9997,
+    "name": "AltLayer Testnet",
+    "shortName": "alt-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 9998,
+    "name": "Ztc Mainnet",
+    "shortName": "ZTC",
+    "nativeCurrency": {
+      "symbol": "ZTC"
+    }
+  },
+  {
+    "chainId": 9999,
+    "name": "myOwn Testnet",
+    "shortName": "myn",
+    "nativeCurrency": {
+      "symbol": "MYN"
+    }
+  },
+  {
+    "chainId": 10000,
+    "name": "Smart Bitcoin Cash",
+    "shortName": "smartbch",
+    "nativeCurrency": {
+      "symbol": "BCH"
+    }
+  },
+  {
+    "chainId": 10001,
+    "name": "Smart Bitcoin Cash Testnet",
+    "shortName": "smartbchtest",
+    "nativeCurrency": {
+      "symbol": "BCHT"
+    }
+  },
+  {
+    "chainId": 10010,
+    "name": "Warden Testnet",
+    "shortName": "ward",
+    "nativeCurrency": {
+      "symbol": "WARD"
+    }
+  },
+  {
+    "chainId": 10011,
+    "name": "DeepSafe Beta Mainnet",
+    "shortName": "DeepSafe",
+    "nativeCurrency": {
+      "symbol": "DEF"
+    }
+  },
+  {
+    "chainId": 10024,
+    "name": "Gon Chain",
+    "shortName": "gon",
+    "nativeCurrency": {
+      "symbol": "GT"
+    }
+  },
+  {
+    "chainId": 10025,
+    "name": "AEON Chain",
+    "shortName": "aeon",
+    "nativeCurrency": {
+      "symbol": "AEON"
+    }
+  },
+  {
+    "chainId": 10066,
+    "name": "Chain Opera Testnet",
+    "shortName": "chainopera-testnet",
+    "nativeCurrency": {
+      "symbol": "CO"
+    }
+  },
+  {
+    "chainId": 10081,
+    "name": "Japan Open Chain Testnet",
+    "shortName": "joct",
+    "nativeCurrency": {
+      "symbol": "JOCT"
+    }
+  },
+  {
+    "chainId": 10085,
+    "name": "Volcano Chain Mainnet",
+    "shortName": "volcanochain",
+    "nativeCurrency": {
+      "symbol": "VC"
+    }
+  },
+  {
+    "chainId": 10086,
+    "name": "SJATSH",
+    "shortName": "SJ",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 10096,
+    "name": "MetaNova Verse",
+    "shortName": "mnv",
+    "nativeCurrency": {
+      "symbol": "MNV"
+    }
+  },
+  {
+    "chainId": 10101,
+    "name": "Blockchain Genesis Mainnet",
+    "shortName": "GEN",
+    "nativeCurrency": {
+      "symbol": "GEN"
+    }
+  },
+  {
+    "chainId": 10143,
+    "name": "Monad Testnet",
+    "shortName": "mon-testnet",
+    "nativeCurrency": {
+      "symbol": "MON"
+    }
+  },
+  {
+    "chainId": 10200,
+    "name": "Gnosis Chiado Testnet",
+    "shortName": "chi",
+    "nativeCurrency": {
+      "symbol": "XDAI"
+    }
+  },
+  {
+    "chainId": 10201,
+    "name": "MaxxChain Mainnet",
+    "shortName": "PWR",
+    "nativeCurrency": {
+      "symbol": "PWR"
+    }
+  },
+  {
+    "chainId": 10218,
+    "name": "Tea Sepolia Testnet",
+    "shortName": "teasep",
+    "nativeCurrency": {
+      "symbol": "TEA"
+    }
+  },
+  {
+    "chainId": 10222,
+    "name": "GLScan",
+    "shortName": "glc",
+    "nativeCurrency": {
+      "symbol": "GLC"
+    }
+  },
+  {
+    "chainId": 10242,
+    "name": "Arthera Mainnet",
+    "shortName": "aa",
+    "nativeCurrency": {
+      "symbol": "AA"
+    }
+  },
+  {
+    "chainId": 10243,
+    "name": "Arthera Testnet",
+    "shortName": "aat",
+    "nativeCurrency": {
+      "symbol": "AA"
+    }
+  },
+  {
+    "chainId": 10248,
+    "name": "0XTade",
+    "shortName": "0xt",
+    "nativeCurrency": {
+      "symbol": "0XT"
+    }
+  },
+  {
+    "chainId": 10321,
+    "name": "TAO EVM Mainnet",
+    "shortName": "TAOm",
+    "nativeCurrency": {
+      "symbol": "TAO"
+    }
+  },
+  {
+    "chainId": 10324,
+    "name": "TAO EVM Testnet",
+    "shortName": "TAOt",
+    "nativeCurrency": {
+      "symbol": "TAO"
+    }
+  },
+  {
+    "chainId": 10395,
+    "name": "WorldLand Testnet",
+    "shortName": "TWLC",
+    "nativeCurrency": {
+      "symbol": "WLC"
+    }
+  },
+  {
+    "chainId": 10507,
+    "name": "Numbers Mainnet",
+    "shortName": "Jade",
+    "nativeCurrency": {
+      "symbol": "NUM"
+    }
+  },
+  {
+    "chainId": 10508,
+    "name": "Numbers Testnet",
+    "shortName": "Snow",
+    "nativeCurrency": {
+      "symbol": "NUM"
+    }
+  },
+  {
+    "chainId": 10791,
+    "name": "TrustBitcoin Mainnet",
+    "shortName": "trustbtc",
+    "nativeCurrency": {
+      "symbol": "TBC"
+    }
+  },
+  {
+    "chainId": 10823,
+    "name": "CryptoCoinPay",
+    "shortName": "CCP",
+    "nativeCurrency": {
+      "symbol": "CCP"
+    }
+  },
+  {
+    "chainId": 10849,
+    "name": "Lamina1",
+    "shortName": "lamina1",
+    "nativeCurrency": {
+      "symbol": "L1"
+    }
+  },
+  {
+    "chainId": 10850,
+    "name": "Lamina1 Identity",
+    "shortName": "lamina1id",
+    "nativeCurrency": {
+      "symbol": "L1ID"
+    }
+  },
+  {
+    "chainId": 10888,
+    "name": "GameSwift Chain Testnet",
+    "shortName": "gameswift-chain-testnet",
+    "nativeCurrency": {
+      "symbol": "tGS"
+    }
+  },
+  {
+    "chainId": 10904,
+    "name": "Ault Blockchain Testnet",
+    "shortName": "ault-testnet",
+    "nativeCurrency": {
+      "symbol": "AULT"
+    }
+  },
+  {
+    "chainId": 10920,
+    "name": "Fuse Flash Testnet",
+    "shortName": "fuseflash",
+    "nativeCurrency": {
+      "symbol": "FUSE"
+    }
+  },
+  {
+    "chainId": 10946,
+    "name": "Quadrans Blockchain",
+    "shortName": "quadrans",
+    "nativeCurrency": {
+      "symbol": "QDC"
+    }
+  },
+  {
+    "chainId": 10947,
+    "name": "Quadrans Blockchain Testnet",
+    "shortName": "quadranstestnet",
+    "nativeCurrency": {
+      "symbol": "tQDC"
+    }
+  },
+  {
+    "chainId": 11000,
+    "name": "KB Chain",
+    "shortName": "KBC",
+    "nativeCurrency": {
+      "symbol": "KBC"
+    }
+  },
+  {
+    "chainId": 11011,
+    "name": "Shape Sepolia Testnet",
+    "shortName": "shapesep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11100,
+    "name": "Bool Network Beta Mainnet",
+    "shortName": "BOL",
+    "nativeCurrency": {
+      "symbol": "BOL"
+    }
+  },
+  {
+    "chainId": 11110,
+    "name": "Astra",
+    "shortName": "astra",
+    "nativeCurrency": {
+      "symbol": "ASA"
+    }
+  },
+  {
+    "chainId": 11111,
+    "name": "WAGMI",
+    "shortName": "WAGMI",
+    "nativeCurrency": {
+      "symbol": "WGM"
+    }
+  },
+  {
+    "chainId": 11115,
+    "name": "Astra Testnet",
+    "shortName": "astra-testnet",
+    "nativeCurrency": {
+      "symbol": "tASA"
+    }
+  },
+  {
+    "chainId": 11119,
+    "name": "HashBit Mainnet",
+    "shortName": "hbit",
+    "nativeCurrency": {
+      "symbol": "HBIT"
+    }
+  },
+  {
+    "chainId": 11124,
+    "name": "Abstract Sepolia Testnet",
+    "shortName": "abstract-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11221,
+    "name": "Shine Chain",
+    "shortName": "SC20",
+    "nativeCurrency": {
+      "symbol": "SC20"
+    }
+  },
+  {
+    "chainId": 11227,
+    "name": "Jiritsu Testnet Subnet",
+    "shortName": "jiritsutes",
+    "nativeCurrency": {
+      "symbol": "TZW"
+    }
+  },
+  {
+    "chainId": 11235,
+    "name": "Haqq Network",
+    "shortName": "ISLM",
+    "nativeCurrency": {
+      "symbol": "ISLM"
+    }
+  },
+  {
+    "chainId": 11343,
+    "name": "StateMesh Testnet",
+    "shortName": "mesh-test",
+    "nativeCurrency": {
+      "symbol": "MESH"
+    }
+  },
+  {
+    "chainId": 11437,
+    "name": "Shyft Testnet",
+    "shortName": "shyftt",
+    "nativeCurrency": {
+      "symbol": "SHYFTT"
+    }
+  },
+  {
+    "chainId": 11451,
+    "name": "eGold Chain",
+    "shortName": "egoldchain",
+    "nativeCurrency": {
+      "symbol": "XAU"
+    }
+  },
+  {
+    "chainId": 11501,
+    "name": "GEB Mainnet",
+    "shortName": "geb",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 11503,
+    "name": "BEVM Testnet",
+    "shortName": "bevm-test",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 11504,
+    "name": "GEB Signet",
+    "shortName": "geb-signet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 11521,
+    "name": "SatsChain",
+    "shortName": "satschain",
+    "nativeCurrency": {
+      "symbol": "SATS"
+    }
+  },
+  {
+    "chainId": 11612,
+    "name": "Sardis Testnet",
+    "shortName": "SRDXt",
+    "nativeCurrency": {
+      "symbol": "SRDX"
+    }
+  },
+  {
+    "chainId": 11811,
+    "name": "ARK Mainnet",
+    "shortName": "ark",
+    "nativeCurrency": {
+      "symbol": "ARK"
+    }
+  },
+  {
+    "chainId": 11812,
+    "name": "ARK Testnet",
+    "shortName": "ark-testnet",
+    "nativeCurrency": {
+      "symbol": "DARK"
+    }
+  },
+  {
+    "chainId": 11820,
+    "name": "Artela Mainnet",
+    "shortName": "artela-mainnet",
+    "nativeCurrency": {
+      "symbol": "ART"
+    }
+  },
+  {
+    "chainId": 11822,
+    "name": "Artela Testnet",
+    "shortName": "Artela",
+    "nativeCurrency": {
+      "symbol": "ART"
+    }
+  },
+  {
+    "chainId": 11888,
+    "name": "Santiment Intelligence Network DEPRECATED",
+    "shortName": "SANold",
+    "nativeCurrency": {
+      "symbol": "SANold"
+    }
+  },
+  {
+    "chainId": 11891,
+    "name": "Polygon Supernet Arianee",
+    "shortName": "Arianee",
+    "nativeCurrency": {
+      "symbol": "ARIA20"
+    }
+  },
+  {
+    "chainId": 12001,
+    "name": "Fuse Testnet",
+    "shortName": "fuseZK",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12009,
+    "name": "SatoshiChain Mainnet",
+    "shortName": "sats",
+    "nativeCurrency": {
+      "symbol": "SATS"
+    }
+  },
+  {
+    "chainId": 12020,
+    "name": "Aternos",
+    "shortName": "ATR",
+    "nativeCurrency": {
+      "symbol": "ATR"
+    }
+  },
+  {
+    "chainId": 12051,
+    "name": "Singularity ZERO Testnet",
+    "shortName": "tZERO",
+    "nativeCurrency": {
+      "symbol": "tZERO"
+    }
+  },
+  {
+    "chainId": 12052,
+    "name": "Singularity ZERO Mainnet",
+    "shortName": "ZERO",
+    "nativeCurrency": {
+      "symbol": "ZERO"
+    }
+  },
+  {
+    "chainId": 12123,
+    "name": "BRC Chain Mainnet",
+    "shortName": "BRC",
+    "nativeCurrency": {
+      "symbol": "BRC"
+    }
+  },
+  {
+    "chainId": 12216,
+    "name": "L2 Protocol Mainnet",
+    "shortName": "l2p",
+    "nativeCurrency": {
+      "symbol": "L2P"
+    }
+  },
+  {
+    "chainId": 12306,
+    "name": "Fibonacci Mainnet",
+    "shortName": "fibo",
+    "nativeCurrency": {
+      "symbol": "FIBO"
+    }
+  },
+  {
+    "chainId": 12321,
+    "name": "BLG Testnet",
+    "shortName": "blgchain",
+    "nativeCurrency": {
+      "symbol": "BLG"
+    }
+  },
+  {
+    "chainId": 12323,
+    "name": "Huddle01 dRTC Chain",
+    "shortName": "huddle01",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12324,
+    "name": "L3X Protocol",
+    "shortName": "l3x",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12325,
+    "name": "L3X Protocol Testnet",
+    "shortName": "l3x-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12345,
+    "name": "Step Testnet",
+    "shortName": "steptest",
+    "nativeCurrency": {
+      "symbol": "FITFI"
+    }
+  },
+  {
+    "chainId": 12358,
+    "name": "GDPR Mainnet",
+    "shortName": "gdpr",
+    "nativeCurrency": {
+      "symbol": "GDPR"
+    }
+  },
+  {
+    "chainId": 12553,
+    "name": "RSS3 VSL Mainnet",
+    "shortName": "rss3",
+    "nativeCurrency": {
+      "symbol": "RSS3"
+    }
+  },
+  {
+    "chainId": 12715,
+    "name": "Rikeza Network Testnet",
+    "shortName": "tRIK",
+    "nativeCurrency": {
+      "symbol": "RIK"
+    }
+  },
+  {
+    "chainId": 12781,
+    "name": "Playdapp Testnet",
+    "shortName": "PDA-TESTNET",
+    "nativeCurrency": {
+      "symbol": "PDA"
+    }
+  },
+  {
+    "chainId": 12890,
+    "name": "Quantum Chain Testnet",
+    "shortName": "tqnet",
+    "nativeCurrency": {
+      "symbol": "tQNET"
+    }
+  },
+  {
+    "chainId": 12898,
+    "name": "PlayFair Testnet Subnet",
+    "shortName": "playfair",
+    "nativeCurrency": {
+      "symbol": "BTLT"
+    }
+  },
+  {
+    "chainId": 13000,
+    "name": "SPS",
+    "shortName": "SPS",
+    "nativeCurrency": {
+      "symbol": "ECG"
+    }
+  },
+  {
+    "chainId": 13308,
+    "name": "Credit Smart Chain",
+    "shortName": "Credit",
+    "nativeCurrency": {
+      "symbol": "CREDIT"
+    }
+  },
+  {
+    "chainId": 13337,
+    "name": "Beam Testnet",
+    "shortName": "beam-testnet",
+    "nativeCurrency": {
+      "symbol": "BEAM"
+    }
+  },
+  {
+    "chainId": 13370,
+    "name": "Cannon Testnet",
+    "shortName": "cannon",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 13371,
+    "name": "Immutable zkEVM",
+    "shortName": "imx",
+    "nativeCurrency": {
+      "symbol": "IMX"
+    }
+  },
+  {
+    "chainId": 13381,
+    "name": "Phoenix Mainnet",
+    "shortName": "Phoenix",
+    "nativeCurrency": {
+      "symbol": "PHX"
+    }
+  },
+  {
+    "chainId": 13396,
+    "name": "Masa",
+    "shortName": "masa",
+    "nativeCurrency": {
+      "symbol": "MASA"
+    }
+  },
+  {
+    "chainId": 13473,
+    "name": "Immutable zkEVM Testnet",
+    "shortName": "imx-testnet",
+    "nativeCurrency": {
+      "symbol": "tIMX"
+    }
+  },
+  {
+    "chainId": 13505,
+    "name": "Gravity Alpha Testnet Sepolia",
+    "shortName": "gravitysep",
+    "nativeCurrency": {
+      "symbol": "G"
+    }
+  },
+  {
+    "chainId": 13600,
+    "name": "Kronobit Mainnet",
+    "shortName": "KNB",
+    "nativeCurrency": {
+      "symbol": "KNB"
+    }
+  },
+  {
+    "chainId": 13746,
+    "name": "Game7 Testnet",
+    "shortName": "g7t",
+    "nativeCurrency": {
+      "symbol": "TG7T"
+    }
+  },
+  {
+    "chainId": 13766,
+    "name": "Trexx",
+    "shortName": "trexx",
+    "nativeCurrency": {
+      "symbol": "TRX"
+    }
+  },
+  {
+    "chainId": 13812,
+    "name": "Susono",
+    "shortName": "sus",
+    "nativeCurrency": {
+      "symbol": "OPN"
+    }
+  },
+  {
+    "chainId": 14000,
+    "name": "SPS Testnet",
+    "shortName": "SPS-Test",
+    "nativeCurrency": {
+      "symbol": "ECG"
+    }
+  },
+  {
+    "chainId": 14088,
+    "name": "Zeroth Testnet",
+    "shortName": "ZRHt",
+    "nativeCurrency": {
+      "symbol": "ZRHt"
+    }
+  },
+  {
+    "chainId": 14149,
+    "name": "Bitharvest Chain Mainnet",
+    "shortName": "BitharvestMainnet",
+    "nativeCurrency": {
+      "symbol": "BTH"
+    }
+  },
+  {
+    "chainId": 14235,
+    "name": "Bitlazer",
+    "shortName": "bitlazer",
+    "nativeCurrency": {
+      "symbol": "lzrBTC"
+    }
+  },
+  {
+    "chainId": 14324,
+    "name": "EVOLVE Testnet",
+    "shortName": "evo",
+    "nativeCurrency": {
+      "symbol": "EVO"
+    }
+  },
+  {
+    "chainId": 14333,
+    "name": "Vitruveo Testnet",
+    "shortName": "vitruveo-test",
+    "nativeCurrency": {
+      "symbol": "tVTRU"
+    }
+  },
+  {
+    "chainId": 14601,
+    "name": "Sonic Testnet",
+    "shortName": "sonic-testnet",
+    "nativeCurrency": {
+      "symbol": "S"
+    }
+  },
+  {
+    "chainId": 14800,
+    "name": "Vana Moksha Testnet",
+    "shortName": "vana-moksha",
+    "nativeCurrency": {
+      "symbol": "VANA"
+    }
+  },
+  {
+    "chainId": 14801,
+    "name": "Vana Satori Testnet",
+    "shortName": "satori",
+    "nativeCurrency": {
+      "symbol": "DAT"
+    }
+  },
+  {
+    "chainId": 14853,
+    "name": "Humanode Testnet 5 Israfel",
+    "shortName": "hmnd-t5",
+    "nativeCurrency": {
+      "symbol": "eHMND"
+    }
+  },
+  {
+    "chainId": 15000,
+    "name": "Quai Network Testnet",
+    "shortName": "quai-testnet",
+    "nativeCurrency": {
+      "symbol": "QUAI"
+    }
+  },
+  {
+    "chainId": 15003,
+    "name": "Immutable zkEVM Devnet",
+    "shortName": "imx-devnet",
+    "nativeCurrency": {
+      "symbol": "dIMX"
+    }
+  },
+  {
+    "chainId": 15257,
+    "name": "Poodl Testnet",
+    "shortName": "poodlt",
+    "nativeCurrency": {
+      "symbol": "POODL"
+    }
+  },
+  {
+    "chainId": 15259,
+    "name": "Poodl Mainnet",
+    "shortName": "poodle",
+    "nativeCurrency": {
+      "symbol": "POODL"
+    }
+  },
+  {
+    "chainId": 15430,
+    "name": "KYMTC Mainnet",
+    "shortName": "KYMTC",
+    "nativeCurrency": {
+      "symbol": "KYMTC"
+    }
+  },
+  {
+    "chainId": 15551,
+    "name": "LoopNetwork Mainnet",
+    "shortName": "loop",
+    "nativeCurrency": {
+      "symbol": "LOOP"
+    }
+  },
+  {
+    "chainId": 15555,
+    "name": "Trust EVM Testnet",
+    "shortName": "TrustTestnet",
+    "nativeCurrency": {
+      "symbol": "EVM"
+    }
+  },
+  {
+    "chainId": 15557,
+    "name": "EOS EVM Network Testnet",
+    "shortName": "eos-testnet",
+    "nativeCurrency": {
+      "symbol": "EOS"
+    }
+  },
+  {
+    "chainId": 15885,
+    "name": "Bitroot Testnet",
+    "shortName": "bitroot-testnet",
+    "nativeCurrency": {
+      "symbol": "BRT"
+    }
+  },
+  {
+    "chainId": 15888,
+    "name": "Bitroot",
+    "shortName": "bitroot",
+    "nativeCurrency": {
+      "symbol": "BRT"
+    }
+  },
+  {
+    "chainId": 16000,
+    "name": "MetaDot Mainnet",
+    "shortName": "mtt",
+    "nativeCurrency": {
+      "symbol": "MTT"
+    }
+  },
+  {
+    "chainId": 16001,
+    "name": "MetaDot Testnet",
+    "shortName": "mtttest",
+    "nativeCurrency": {
+      "symbol": "MTTest"
+    }
+  },
+  {
+    "chainId": 16116,
+    "name": "DeFiVerse Mainnet",
+    "shortName": "DFV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 16166,
+    "name": "Cypherium Mainnet",
+    "shortName": "cph",
+    "nativeCurrency": {
+      "symbol": "CPH"
+    }
+  },
+  {
+    "chainId": 16180,
+    "name": "PLYR PHI",
+    "shortName": "plyr-phi",
+    "nativeCurrency": {
+      "symbol": "PLYR"
+    }
+  },
+  {
+    "chainId": 16182,
+    "name": "Eventum Testnet",
+    "shortName": "eventum-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 16350,
+    "name": "Incentiv Devnet",
+    "shortName": "tIncentiv",
+    "nativeCurrency": {
+      "symbol": "INC"
+    }
+  },
+  {
+    "chainId": 16481,
+    "name": "Pivotal Sepolia",
+    "shortName": "pivotal-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 16507,
+    "name": "Genesys Mainnet",
+    "shortName": "Genesys",
+    "nativeCurrency": {
+      "symbol": "GSYS"
+    }
+  },
+  {
+    "chainId": 16600,
+    "name": "0G-Newton-Testnet",
+    "shortName": "0gai-testnet",
+    "nativeCurrency": {
+      "symbol": "A0GI"
+    }
+  },
+  {
+    "chainId": 16601,
+    "name": "0G-Galileo-Testnet",
+    "shortName": "0gai-galileo-testnet",
+    "nativeCurrency": {
+      "symbol": "A0GI"
+    }
+  },
+  {
+    "chainId": 16602,
+    "name": "0G-Testnet-Galileo",
+    "shortName": "0g-testnet-galileo",
+    "nativeCurrency": {
+      "symbol": "0G"
+    }
+  },
+  {
+    "chainId": 16661,
+    "name": "0G Mainnet",
+    "shortName": "0g",
+    "nativeCurrency": {
+      "symbol": "0G"
+    }
+  },
+  {
+    "chainId": 16688,
+    "name": "IRIShub Testnet",
+    "shortName": "nyancat",
+    "nativeCurrency": {
+      "symbol": "ERIS"
+    }
+  },
+  {
+    "chainId": 16718,
+    "name": "AirDAO Mainnet",
+    "shortName": "airdao",
+    "nativeCurrency": {
+      "symbol": "AMB"
+    }
+  },
+  {
+    "chainId": 16888,
+    "name": "IVAR Chain Testnet",
+    "shortName": "tivar",
+    "nativeCurrency": {
+      "symbol": "tIVAR"
+    }
+  },
+  {
+    "chainId": 17000,
+    "name": "Holesky",
+    "shortName": "holesky",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 17001,
+    "name": "Redstone Holesky Testnet",
+    "shortName": "redstone-holesky",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 17069,
+    "name": "Garnet Holesky",
+    "shortName": "garnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 17071,
+    "name": "Onchain Points",
+    "shortName": "pop",
+    "nativeCurrency": {
+      "symbol": "POP"
+    }
+  },
+  {
+    "chainId": 17117,
+    "name": "DeFiVerse Testnet",
+    "shortName": "DFV-testnet",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 17171,
+    "name": "G8Chain Mainnet",
+    "shortName": "G8Cm",
+    "nativeCurrency": {
+      "symbol": "G8C"
+    }
+  },
+  {
+    "chainId": 17172,
+    "name": "Eclipse Subnet",
+    "shortName": "eclipse",
+    "nativeCurrency": {
+      "symbol": "ECLP"
+    }
+  },
+  {
+    "chainId": 17180,
+    "name": "Palette Chain Testnet",
+    "shortName": "PCT",
+    "nativeCurrency": {
+      "symbol": "PLT"
+    }
+  },
+  {
+    "chainId": 17217,
+    "name": "KONET Mainnet",
+    "shortName": "KONET",
+    "nativeCurrency": {
+      "symbol": "KONET"
+    }
+  },
+  {
+    "chainId": 17735,
+    "name": "Esports Chain",
+    "shortName": "Esports",
+    "nativeCurrency": {
+      "symbol": "ESPT"
+    }
+  },
+  {
+    "chainId": 17771,
+    "name": "DMD Diamond",
+    "shortName": "dmd",
+    "nativeCurrency": {
+      "symbol": "DMD"
+    }
+  },
+  {
+    "chainId": 17777,
+    "name": "EOS EVM Network",
+    "shortName": "eos",
+    "nativeCurrency": {
+      "symbol": "EOS"
+    }
+  },
+  {
+    "chainId": 18000,
+    "name": "Frontier of Dreams Testnet",
+    "shortName": "ZKST",
+    "nativeCurrency": {
+      "symbol": "ZKST"
+    }
+  },
+  {
+    "chainId": 18122,
+    "name": "Smart Trade Networks",
+    "shortName": "STN",
+    "nativeCurrency": {
+      "symbol": "STN"
+    }
+  },
+  {
+    "chainId": 18159,
+    "name": "Proof Of Memes",
+    "shortName": "pom",
+    "nativeCurrency": {
+      "symbol": "POM"
+    }
+  },
+  {
+    "chainId": 18181,
+    "name": "G8Chain Testnet",
+    "shortName": "G8Ct",
+    "nativeCurrency": {
+      "symbol": "G8C"
+    }
+  },
+  {
+    "chainId": 18231,
+    "name": "unreal-old",
+    "shortName": "unreal-old",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 18233,
+    "name": "unreal",
+    "shortName": "unreal",
+    "nativeCurrency": {
+      "symbol": "reETH"
+    }
+  },
+  {
+    "chainId": 18686,
+    "name": "MXC zkEVM Moonchain",
+    "shortName": "MXCzkEVM",
+    "nativeCurrency": {
+      "symbol": "MXC"
+    }
+  },
+  {
+    "chainId": 18880,
+    "name": "EXPchain Testnet",
+    "shortName": "expchain",
+    "nativeCurrency": {
+      "symbol": "tZKJ"
+    }
+  },
+  {
+    "chainId": 18881,
+    "name": "Ultra EVM Network Testnet",
+    "shortName": "ultra-testnet",
+    "nativeCurrency": {
+      "symbol": "UOS"
+    }
+  },
+  {
+    "chainId": 18888,
+    "name": "Titan (TKX)",
+    "shortName": "titan_tkx",
+    "nativeCurrency": {
+      "symbol": "TKX"
+    }
+  },
+  {
+    "chainId": 18889,
+    "name": "Titan (TKX) Testnet",
+    "shortName": "titan_tkx-testnet",
+    "nativeCurrency": {
+      "symbol": "TKX"
+    }
+  },
+  {
+    "chainId": 19011,
+    "name": "HOME Verse Mainnet",
+    "shortName": "HMV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 19077,
+    "name": "BlockX Atlantis Testnet",
+    "shortName": "tbcx",
+    "nativeCurrency": {
+      "symbol": "BCX"
+    }
+  },
+  {
+    "chainId": 19180,
+    "name": "LocaChain Mainnet",
+    "shortName": "locachain",
+    "nativeCurrency": {
+      "symbol": "LCC"
+    }
+  },
+  {
+    "chainId": 19191,
+    "name": "BlockX Mainnet",
+    "shortName": "bcx",
+    "nativeCurrency": {
+      "symbol": "BCX"
+    }
+  },
+  {
+    "chainId": 19224,
+    "name": "Decentraconnect Social",
+    "shortName": "DCSMs",
+    "nativeCurrency": {
+      "symbol": "DCSM"
+    }
+  },
+  {
+    "chainId": 19478,
+    "name": "Trustivon Testnet",
+    "shortName": "trustivon",
+    "nativeCurrency": {
+      "symbol": "TC"
+    }
+  },
+  {
+    "chainId": 19515,
+    "name": "SEC Testnet",
+    "shortName": "SEPt",
+    "nativeCurrency": {
+      "symbol": "SEP"
+    }
+  },
+  {
+    "chainId": 19516,
+    "name": "SEC Mainnet",
+    "shortName": "SECm",
+    "nativeCurrency": {
+      "symbol": "SEP"
+    }
+  },
+  {
+    "chainId": 19527,
+    "name": "Magnet Network",
+    "shortName": "mgt",
+    "nativeCurrency": {
+      "symbol": "DOT"
+    }
+  },
+  {
+    "chainId": 19546,
+    "name": "Zytron Linea Testnet",
+    "shortName": "zytron-linea-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 19600,
+    "name": "LBRY Mainnet",
+    "shortName": "LBRY",
+    "nativeCurrency": {
+      "symbol": "LBC"
+    }
+  },
+  {
+    "chainId": 19777,
+    "name": "Astra Sepolia",
+    "shortName": "astra-sepolia",
+    "nativeCurrency": {
+      "symbol": "ATX"
+    }
+  },
+  {
+    "chainId": 19845,
+    "name": "BTCIX Network",
+    "shortName": "btcix",
+    "nativeCurrency": {
+      "symbol": "BTCIX"
+    }
+  },
+  {
+    "chainId": 19991,
+    "name": "Ultra EVM Network",
+    "shortName": "ultra",
+    "nativeCurrency": {
+      "symbol": "UOS"
+    }
+  },
+  {
+    "chainId": 19998,
+    "name": "SuperAIChain Mainnet",
+    "shortName": "sup",
+    "nativeCurrency": {
+      "symbol": "SUP"
+    }
+  },
+  {
+    "chainId": 20001,
+    "name": "Camelark Mainnet",
+    "shortName": "Camelark",
+    "nativeCurrency": {
+      "symbol": "ETHW"
+    }
+  },
+  {
+    "chainId": 20010,
+    "name": "Mandala Chain",
+    "shortName": "mandala",
+    "nativeCurrency": {
+      "symbol": "KPG"
+    }
+  },
+  {
+    "chainId": 20011,
+    "name": "Mandala Chain Testnet",
+    "shortName": "mandala-testnet",
+    "nativeCurrency": {
+      "symbol": "KPGT"
+    }
+  },
+  {
+    "chainId": 20041,
+    "name": "Niza Chain Mainnet",
+    "shortName": "niza",
+    "nativeCurrency": {
+      "symbol": "NIZA"
+    }
+  },
+  {
+    "chainId": 20073,
+    "name": "Niza Chain Testnet",
+    "shortName": "niza_testnet",
+    "nativeCurrency": {
+      "symbol": "NIZA"
+    }
+  },
+  {
+    "chainId": 20143,
+    "name": "Monad Devnet",
+    "shortName": "mon-devnet",
+    "nativeCurrency": {
+      "symbol": "MON"
+    }
+  },
+  {
+    "chainId": 20441,
+    "name": "XUSD ONE StableChain Mainnet",
+    "shortName": "xusd",
+    "nativeCurrency": {
+      "symbol": "X1"
+    }
+  },
+  {
+    "chainId": 20729,
+    "name": "Callisto Testnet",
+    "shortName": "CLOTestnet",
+    "nativeCurrency": {
+      "symbol": "CLO"
+    }
+  },
+  {
+    "chainId": 20736,
+    "name": "P12 Chain",
+    "shortName": "p12",
+    "nativeCurrency": {
+      "symbol": "hP2"
+    }
+  },
+  {
+    "chainId": 20765,
+    "name": "Jono11 Subnet",
+    "shortName": "jono11",
+    "nativeCurrency": {
+      "symbol": "JONO"
+    }
+  },
+  {
+    "chainId": 20993,
+    "name": "Fluent Developer Preview",
+    "shortName": "fluent-dev-net",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 21000,
+    "name": "Action Mainnet",
+    "shortName": "ACTN",
+    "nativeCurrency": {
+      "symbol": "ACTN"
+    }
+  },
+  {
+    "chainId": 21004,
+    "name": "C4EI",
+    "shortName": "c4ei",
+    "nativeCurrency": {
+      "symbol": "C4EI"
+    }
+  },
+  {
+    "chainId": 21097,
+    "name": "Rivest Testnet",
+    "shortName": "rivest-testnet",
+    "nativeCurrency": {
+      "symbol": "tINCO"
+    }
+  },
+  {
+    "chainId": 21133,
+    "name": "All About Healthy",
+    "shortName": "aah",
+    "nativeCurrency": {
+      "symbol": "AAH"
+    }
+  },
+  {
+    "chainId": 21210,
+    "name": "1Money Network Mainnet",
+    "shortName": "1money",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 21211,
+    "name": "1Money Sidechain Mainnet",
+    "shortName": "1money-sc",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 21223,
+    "name": "DCpay Mainnet",
+    "shortName": "DCPm",
+    "nativeCurrency": {
+      "symbol": "DCP"
+    }
+  },
+  {
+    "chainId": 21224,
+    "name": "DCpay Testnet",
+    "shortName": "DCPt",
+    "nativeCurrency": {
+      "symbol": "DCP"
+    }
+  },
+  {
+    "chainId": 21337,
+    "name": "CENNZnet Azalea",
+    "shortName": "cennz-a",
+    "nativeCurrency": {
+      "symbol": "CPAY"
+    }
+  },
+  {
+    "chainId": 21363,
+    "name": "Lestnet",
+    "shortName": "leth",
+    "nativeCurrency": {
+      "symbol": "LETH"
+    }
+  },
+  {
+    "chainId": 21816,
+    "name": "omChain Mainnet",
+    "shortName": "omc",
+    "nativeCurrency": {
+      "symbol": "OMC"
+    }
+  },
+  {
+    "chainId": 21912,
+    "name": "BSL Mainnet",
+    "shortName": "onf",
+    "nativeCurrency": {
+      "symbol": "ONF"
+    }
+  },
+  {
+    "chainId": 22023,
+    "name": "Taycan",
+    "shortName": "SFL",
+    "nativeCurrency": {
+      "symbol": "SFL"
+    }
+  },
+  {
+    "chainId": 22040,
+    "name": "AirDAO Testnet",
+    "shortName": "airdao-test",
+    "nativeCurrency": {
+      "symbol": "AMB"
+    }
+  },
+  {
+    "chainId": 22222,
+    "name": "Nautilus Mainnet",
+    "shortName": "NAUTCHAIN",
+    "nativeCurrency": {
+      "symbol": "ZBC"
+    }
+  },
+  {
+    "chainId": 22324,
+    "name": "GoldXChain Testnet",
+    "shortName": "goldx-testnet",
+    "nativeCurrency": {
+      "symbol": "GOLDX"
+    }
+  },
+  {
+    "chainId": 22776,
+    "name": "MAP Protocol",
+    "shortName": "mapo",
+    "nativeCurrency": {
+      "symbol": "MAPO"
+    }
+  },
+  {
+    "chainId": 22888,
+    "name": "Access Network",
+    "shortName": "access",
+    "nativeCurrency": {
+      "symbol": "ACCESS"
+    }
+  },
+  {
+    "chainId": 23006,
+    "name": "Antofy Testnet",
+    "shortName": "ABNt",
+    "nativeCurrency": {
+      "symbol": "ABN"
+    }
+  },
+  {
+    "chainId": 23023,
+    "name": "PremiumBlock",
+    "shortName": "pblk",
+    "nativeCurrency": {
+      "symbol": "PBLK"
+    }
+  },
+  {
+    "chainId": 23118,
+    "name": "Opside Testnet",
+    "shortName": "opside",
+    "nativeCurrency": {
+      "symbol": "IDE"
+    }
+  },
+  {
+    "chainId": 23232,
+    "name": "Gotas Social",
+    "shortName": "gotas",
+    "nativeCurrency": {
+      "symbol": "GOTAS"
+    }
+  },
+  {
+    "chainId": 23294,
+    "name": "Oasis Sapphire",
+    "shortName": "sapphire",
+    "nativeCurrency": {
+      "symbol": "ROSE"
+    }
+  },
+  {
+    "chainId": 23295,
+    "name": "Oasis Sapphire Testnet",
+    "shortName": "sapphire-testnet",
+    "nativeCurrency": {
+      "symbol": "TEST"
+    }
+  },
+  {
+    "chainId": 23451,
+    "name": "DreyerX Mainnet",
+    "shortName": "dreyerx",
+    "nativeCurrency": {
+      "symbol": "DRX"
+    }
+  },
+  {
+    "chainId": 23452,
+    "name": "DreyerX Testnet",
+    "shortName": "dreyerx-testnet",
+    "nativeCurrency": {
+      "symbol": "DRX"
+    }
+  },
+  {
+    "chainId": 23888,
+    "name": "Blast Testnet",
+    "shortName": "blastT",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 24076,
+    "name": "KYMTC Testnet",
+    "shortName": "tKYMTC",
+    "nativeCurrency": {
+      "symbol": "KYMTC"
+    }
+  },
+  {
+    "chainId": 24116,
+    "name": "Amauti",
+    "shortName": "railst",
+    "nativeCurrency": {
+      "symbol": "STEAMX"
+    }
+  },
+  {
+    "chainId": 24125,
+    "name": "Nexurachain",
+    "shortName": "XURAm",
+    "nativeCurrency": {
+      "symbol": "XURA"
+    }
+  },
+  {
+    "chainId": 24484,
+    "name": "Webchain",
+    "shortName": "web",
+    "nativeCurrency": {
+      "symbol": "WEB"
+    }
+  },
+  {
+    "chainId": 24734,
+    "name": "MintMe.com Coin",
+    "shortName": "mintme",
+    "nativeCurrency": {
+      "symbol": "MINTME"
+    }
+  },
+  {
+    "chainId": 24816,
+    "name": "Recall",
+    "shortName": "recall",
+    "nativeCurrency": {
+      "symbol": "RECALL"
+    }
+  },
+  {
+    "chainId": 25186,
+    "name": "LiquidLayer Mainnet",
+    "shortName": "LILA",
+    "nativeCurrency": {
+      "symbol": "LILA"
+    }
+  },
+  {
+    "chainId": 25327,
+    "name": "Everclear Mainnet",
+    "shortName": "Everclear",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 25363,
+    "name": "Fluent",
+    "shortName": "fluent",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 25821,
+    "name": "H2 Chain Testnet Lambda",
+    "shortName": "h2-lambda",
+    "nativeCurrency": {
+      "symbol": "H2"
+    }
+  },
+  {
+    "chainId": 25839,
+    "name": "AlveyChain Testnet",
+    "shortName": "talv",
+    "nativeCurrency": {
+      "symbol": "tALV"
+    }
+  },
+  {
+    "chainId": 25888,
+    "name": "Hammer Chain Mainnet",
+    "shortName": "GOLDT",
+    "nativeCurrency": {
+      "symbol": "GOLDT"
+    }
+  },
+  {
+    "chainId": 25925,
+    "name": "KUB Testnet",
+    "shortName": "kubt",
+    "nativeCurrency": {
+      "symbol": "tKUB"
+    }
+  },
+  {
+    "chainId": 26026,
+    "name": "Ferrum Testnet",
+    "shortName": "frm",
+    "nativeCurrency": {
+      "symbol": "tFRM"
+    }
+  },
+  {
+    "chainId": 26100,
+    "name": "Ferrum Quantum Portal Network",
+    "shortName": "qpn",
+    "nativeCurrency": {
+      "symbol": "qpFRM"
+    }
+  },
+  {
+    "chainId": 26217,
+    "name": "Integra",
+    "shortName": "integra",
+    "nativeCurrency": {
+      "symbol": "IRL"
+    }
+  },
+  {
+    "chainId": 26218,
+    "name": "Integra Testnet Ormos",
+    "shortName": "integra-testnet",
+    "nativeCurrency": {
+      "symbol": "IRL"
+    }
+  },
+  {
+    "chainId": 26482,
+    "name": "DucatusX Testnet",
+    "shortName": "ducatusx-testnet",
+    "nativeCurrency": {
+      "symbol": "DUCX"
+    }
+  },
+  {
+    "chainId": 26483,
+    "name": "DucatusX",
+    "shortName": "ducatusx",
+    "nativeCurrency": {
+      "symbol": "DUCX"
+    }
+  },
+  {
+    "chainId": 26514,
+    "name": "Horizen Mainnet",
+    "shortName": "horizen",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 26600,
+    "name": "Hertz Network Mainnet",
+    "shortName": "HTZ",
+    "nativeCurrency": {
+      "symbol": "HTZ"
+    }
+  },
+  {
+    "chainId": 26863,
+    "name": "OasisChain Mainnet",
+    "shortName": "OAC",
+    "nativeCurrency": {
+      "symbol": "OAC"
+    }
+  },
+  {
+    "chainId": 26888,
+    "name": "AB Core Testnet",
+    "shortName": "tABCore",
+    "nativeCurrency": {
+      "symbol": "AB"
+    }
+  },
+  {
+    "chainId": 26988,
+    "name": "Newton Finance Testnet",
+    "shortName": "tNewFi",
+    "nativeCurrency": {
+      "symbol": "NEW"
+    }
+  },
+  {
+    "chainId": 27125,
+    "name": "XferChain Testnet",
+    "shortName": "DPt",
+    "nativeCurrency": {
+      "symbol": "Dapo"
+    }
+  },
+  {
+    "chainId": 27181,
+    "name": "KLAOS Nova",
+    "shortName": "klaosnova",
+    "nativeCurrency": {
+      "symbol": "KLAOS"
+    }
+  },
+  {
+    "chainId": 27483,
+    "name": "Nanon Sepolia",
+    "shortName": "Nanon-Testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 27827,
+    "name": "zeroone Mainnet Subnet",
+    "shortName": "zeroonemai",
+    "nativeCurrency": {
+      "symbol": "ZERO"
+    }
+  },
+  {
+    "chainId": 28125,
+    "name": "XferChain Mainnet",
+    "shortName": "DPm",
+    "nativeCurrency": {
+      "symbol": "Dapo"
+    }
+  },
+  {
+    "chainId": 28516,
+    "name": "Vizing Testnet",
+    "shortName": "Vizing-Testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 28518,
+    "name": "Vizing Mainnet",
+    "shortName": "Vizing",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 28528,
+    "name": "Optimism Bedrock (Goerli Alpha Testnet)",
+    "shortName": "obgor",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 28540,
+    "name": "Rivool",
+    "shortName": "rivool",
+    "nativeCurrency": {
+      "symbol": "RVO"
+    }
+  },
+  {
+    "chainId": 28882,
+    "name": "Boba Sepolia",
+    "shortName": "BobaSepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 29112,
+    "name": "HYCHAIN Testnet",
+    "shortName": "hychain-testnet",
+    "nativeCurrency": {
+      "symbol": "TOPIA"
+    }
+  },
+  {
+    "chainId": 29223,
+    "name": "Nexa MetaNet",
+    "shortName": "nexameta",
+    "nativeCurrency": {
+      "symbol": "NEXA"
+    }
+  },
+  {
+    "chainId": 29225,
+    "name": "Nexa MetaTest",
+    "shortName": "nexatest",
+    "nativeCurrency": {
+      "symbol": "NEXA"
+    }
+  },
+  {
+    "chainId": 29536,
+    "name": "KaiChain Testnet",
+    "shortName": "tkec",
+    "nativeCurrency": {
+      "symbol": "KEC"
+    }
+  },
+  {
+    "chainId": 29548,
+    "name": "MCH Verse Mainnet",
+    "shortName": "MCHV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 30000,
+    "name": "qChain Mainnet",
+    "shortName": "qchain",
+    "nativeCurrency": {
+      "symbol": "QCO"
+    }
+  },
+  {
+    "chainId": 30067,
+    "name": "Piece testnet",
+    "shortName": "Piece",
+    "nativeCurrency": {
+      "symbol": "ECE"
+    }
+  },
+  {
+    "chainId": 30088,
+    "name": "MiYou Mainnet",
+    "shortName": "MiYou",
+    "nativeCurrency": {
+      "symbol": "MY"
+    }
+  },
+  {
+    "chainId": 30103,
+    "name": "Cerium Testnet",
+    "shortName": "ceri",
+    "nativeCurrency": {
+      "symbol": "CAU"
+    }
+  },
+  {
+    "chainId": 30303,
+    "name": "Ethiq",
+    "shortName": "ethiq",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 30730,
+    "name": "Movement EVM Legacy",
+    "shortName": "moveleg",
+    "nativeCurrency": {
+      "symbol": "MOVE"
+    }
+  },
+  {
+    "chainId": 30731,
+    "name": "Movement EVM Devnet",
+    "shortName": "movedev",
+    "nativeCurrency": {
+      "symbol": "MOVE"
+    }
+  },
+  {
+    "chainId": 30732,
+    "name": "Movement EVM Testnet",
+    "shortName": "movetest",
+    "nativeCurrency": {
+      "symbol": "MOVE"
+    }
+  },
+  {
+    "chainId": 30939,
+    "name": "Dilithium3 Testnet",
+    "shortName": "dlt-testnet",
+    "nativeCurrency": {
+      "symbol": "DLT"
+    }
+  },
+  {
+    "chainId": 31102,
+    "name": "Ethersocial Network",
+    "shortName": "esn",
+    "nativeCurrency": {
+      "symbol": "ESN"
+    }
+  },
+  {
+    "chainId": 31223,
+    "name": "CloudTx Mainnet",
+    "shortName": "CLDTX",
+    "nativeCurrency": {
+      "symbol": "CLD"
+    }
+  },
+  {
+    "chainId": 31224,
+    "name": "CloudTx Testnet",
+    "shortName": "CLD",
+    "nativeCurrency": {
+      "symbol": "CLD"
+    }
+  },
+  {
+    "chainId": 31337,
+    "name": "GoChain Testnet",
+    "shortName": "got",
+    "nativeCurrency": {
+      "symbol": "GO"
+    }
+  },
+  {
+    "chainId": 31414,
+    "name": "Evoke Testnet",
+    "shortName": "tmthn",
+    "nativeCurrency": {
+      "symbol": "MTHN"
+    }
+  },
+  {
+    "chainId": 31415,
+    "name": "Wirex Pay Mainnet",
+    "shortName": "wpay",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 31611,
+    "name": "Mezo Testnet",
+    "shortName": "mezo-testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 31612,
+    "name": "Mezo",
+    "shortName": "mezo",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 31753,
+    "name": "Xchain Mainnet (Deprecated)",
+    "shortName": "INTD_deprecated",
+    "nativeCurrency": {
+      "symbol": "INTD"
+    }
+  },
+  {
+    "chainId": 31754,
+    "name": "Xchain Testnet (Deprecated)",
+    "shortName": "tINTD_deprecated",
+    "nativeCurrency": {
+      "symbol": "INTD"
+    }
+  },
+  {
+    "chainId": 32001,
+    "name": "W3Gamez Holesky Testnet",
+    "shortName": "w3gamez",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 32323,
+    "name": "BasedAI",
+    "shortName": "basedai",
+    "nativeCurrency": {
+      "symbol": "BASED"
+    }
+  },
+  {
+    "chainId": 32382,
+    "name": "Santiment Intelligence Network",
+    "shortName": "SANR",
+    "nativeCurrency": {
+      "symbol": "SANR"
+    }
+  },
+  {
+    "chainId": 32520,
+    "name": "Bitgert Mainnet",
+    "shortName": "Brise",
+    "nativeCurrency": {
+      "symbol": "Brise"
+    }
+  },
+  {
+    "chainId": 32659,
+    "name": "Fusion Mainnet",
+    "shortName": "fsn",
+    "nativeCurrency": {
+      "symbol": "FSN"
+    }
+  },
+  {
+    "chainId": 32769,
+    "name": "Zilliqa 2",
+    "shortName": "zil",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 32770,
+    "name": "Zilliqa 2 EVM proto-mainnet",
+    "shortName": "zq2-proto-mainnet",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 32990,
+    "name": "Zilliqa EVM Isolated Server",
+    "shortName": "zil-isolated-server",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 33033,
+    "name": "Entangle Mainnet",
+    "shortName": "ngl",
+    "nativeCurrency": {
+      "symbol": "NGL"
+    }
+  },
+  {
+    "chainId": 33101,
+    "name": "Zilliqa 2 Testnet",
+    "shortName": "zil-testnet",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 33103,
+    "name": "Zilliqa 2 EVM proto-testnet",
+    "shortName": "zq2-proto-testnet",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 33111,
+    "name": "Curtis",
+    "shortName": "curtis",
+    "nativeCurrency": {
+      "symbol": "APE"
+    }
+  },
+  {
+    "chainId": 33133,
+    "name": "Entangle Testnet",
+    "shortName": "tngl",
+    "nativeCurrency": {
+      "symbol": "NGL"
+    }
+  },
+  {
+    "chainId": 33139,
+    "name": "ApeChain",
+    "shortName": "apechain",
+    "nativeCurrency": {
+      "symbol": "APE"
+    }
+  },
+  {
+    "chainId": 33210,
+    "name": "Cloudverse Subnet",
+    "shortName": "cloudverse",
+    "nativeCurrency": {
+      "symbol": "XCLOUD"
+    }
+  },
+  {
+    "chainId": 33333,
+    "name": "Aves Mainnet",
+    "shortName": "avs",
+    "nativeCurrency": {
+      "symbol": "AVS"
+    }
+  },
+  {
+    "chainId": 33385,
+    "name": "Zilliqa EVM Devnet",
+    "shortName": "zil-devnet",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 33401,
+    "name": "SlingShot",
+    "shortName": "slingshot",
+    "nativeCurrency": {
+      "symbol": "SLING"
+    }
+  },
+  {
+    "chainId": 33431,
+    "name": "Edge Testnet",
+    "shortName": "edge-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 33469,
+    "name": "Zilliqa 2 EVM devnet",
+    "shortName": "zq2-devnet",
+    "nativeCurrency": {
+      "symbol": "ZIL"
+    }
+  },
+  {
+    "chainId": 33710,
+    "name": "R5 Network Testnet",
+    "shortName": "tr5",
+    "nativeCurrency": {
+      "symbol": "TR5"
+    }
+  },
+  {
+    "chainId": 33979,
+    "name": "Funki",
+    "shortName": "funki",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 33999,
+    "name": "Pencils Protocol Sepolia Testnet",
+    "shortName": "dapp-sepolia",
+    "nativeCurrency": {
+      "symbol": "DAPPST"
+    }
+  },
+  {
+    "chainId": 34443,
+    "name": "Mode",
+    "shortName": "mode",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 34504,
+    "name": "ZEUS Mainnet",
+    "shortName": "ZEUSX",
+    "nativeCurrency": {
+      "symbol": "ZEUSX"
+    }
+  },
+  {
+    "chainId": 35011,
+    "name": "J2O Taro",
+    "shortName": "j2o",
+    "nativeCurrency": {
+      "symbol": "taro"
+    }
+  },
+  {
+    "chainId": 35147,
+    "name": "CoinAfrica",
+    "shortName": "coina",
+    "nativeCurrency": {
+      "symbol": "COINA"
+    }
+  },
+  {
+    "chainId": 35441,
+    "name": "Q Mainnet",
+    "shortName": "q",
+    "nativeCurrency": {
+      "symbol": "QGOV"
+    }
+  },
+  {
+    "chainId": 35443,
+    "name": "Q Testnet",
+    "shortName": "q-testnet",
+    "nativeCurrency": {
+      "symbol": "Q"
+    }
+  },
+  {
+    "chainId": 36888,
+    "name": "AB Core Mainnet",
+    "shortName": "abcore",
+    "nativeCurrency": {
+      "symbol": "AB"
+    }
+  },
+  {
+    "chainId": 36900,
+    "name": "ADI Chain",
+    "shortName": "adi",
+    "nativeCurrency": {
+      "symbol": "ADI"
+    }
+  },
+  {
+    "chainId": 36968,
+    "name": "AMA Testnet",
+    "shortName": "AMA-TESTNET",
+    "nativeCurrency": {
+      "symbol": "AMA"
+    }
+  },
+  {
+    "chainId": 36969,
+    "name": "AMA Mainnet",
+    "shortName": "AMA",
+    "nativeCurrency": {
+      "symbol": "AMA"
+    }
+  },
+  {
+    "chainId": 37111,
+    "name": "Lens Testnet",
+    "shortName": "lens-sepolia",
+    "nativeCurrency": {
+      "symbol": "GRASS"
+    }
+  },
+  {
+    "chainId": 38400,
+    "name": "ConnectorManager",
+    "shortName": "cmrpg",
+    "nativeCurrency": {
+      "symbol": "cmRPG"
+    }
+  },
+  {
+    "chainId": 38401,
+    "name": "ConnectorManager Robin",
+    "shortName": "ttrpg",
+    "nativeCurrency": {
+      "symbol": "ttRPG"
+    }
+  },
+  {
+    "chainId": 38833,
+    "name": "Igra Network",
+    "shortName": "igra",
+    "nativeCurrency": {
+      "symbol": "iKAS"
+    }
+  },
+  {
+    "chainId": 38836,
+    "name": "Igra Testnet",
+    "shortName": "igra-galleon-testnet",
+    "nativeCurrency": {
+      "symbol": "iKAS"
+    }
+  },
+  {
+    "chainId": 39656,
+    "name": "PRM Mainnet",
+    "shortName": "prm",
+    "nativeCurrency": {
+      "symbol": "PRM"
+    }
+  },
+  {
+    "chainId": 39797,
+    "name": "Energi Mainnet",
+    "shortName": "nrg",
+    "nativeCurrency": {
+      "symbol": "NRG"
+    }
+  },
+  {
+    "chainId": 39815,
+    "name": "OHO Mainnet",
+    "shortName": "oho",
+    "nativeCurrency": {
+      "symbol": "OHO"
+    }
+  },
+  {
+    "chainId": 40000,
+    "name": "DIV Chain",
+    "shortName": "divc",
+    "nativeCurrency": {
+      "symbol": "DIVC"
+    }
+  },
+  {
+    "chainId": 41455,
+    "name": "Aleph Zero EVM",
+    "shortName": "aleph-zero",
+    "nativeCurrency": {
+      "symbol": "AZERO"
+    }
+  },
+  {
+    "chainId": 41500,
+    "name": "Opulent-X BETA",
+    "shortName": "ox-beta",
+    "nativeCurrency": {
+      "symbol": "OXYN"
+    }
+  },
+  {
+    "chainId": 41923,
+    "name": "EDU Chain",
+    "shortName": "edu-chain",
+    "nativeCurrency": {
+      "symbol": "EDU"
+    }
+  },
+  {
+    "chainId": 42000,
+    "name": "Helios Chain Testnet",
+    "shortName": "HLS",
+    "nativeCurrency": {
+      "symbol": "HLS"
+    }
+  },
+  {
+    "chainId": 42001,
+    "name": "PMON Chain",
+    "shortName": "pmon",
+    "nativeCurrency": {
+      "symbol": "PMON"
+    }
+  },
+  {
+    "chainId": 42026,
+    "name": "Donatuz",
+    "shortName": "donatuz",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 42069,
+    "name": "pegglecoin",
+    "shortName": "PC",
+    "nativeCurrency": {
+      "symbol": "peggle"
+    }
+  },
+  {
+    "chainId": 42070,
+    "name": "WMC Testnet",
+    "shortName": "wmtx",
+    "nativeCurrency": {
+      "symbol": "WMTx"
+    }
+  },
+  {
+    "chainId": 42072,
+    "name": "AgentLayer Testnet",
+    "shortName": "agent",
+    "nativeCurrency": {
+      "symbol": "AGENT"
+    }
+  },
+  {
+    "chainId": 42096,
+    "name": "Heurist Testnet",
+    "shortName": "HEU",
+    "nativeCurrency": {
+      "symbol": "HEU"
+    }
+  },
+  {
+    "chainId": 42161,
+    "name": "Arbitrum One",
+    "shortName": "arb1",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 42170,
+    "name": "Arbitrum Nova",
+    "shortName": "arb-nova",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 42220,
+    "name": "Celo Mainnet",
+    "shortName": "celo",
+    "nativeCurrency": {
+      "symbol": "CELO"
+    }
+  },
+  {
+    "chainId": 42261,
+    "name": "Oasis Emerald Testnet",
+    "shortName": "emerald-testnet",
+    "nativeCurrency": {
+      "symbol": "TEST"
+    }
+  },
+  {
+    "chainId": 42262,
+    "name": "Oasis Emerald",
+    "shortName": "emerald",
+    "nativeCurrency": {
+      "symbol": "ROSE"
+    }
+  },
+  {
+    "chainId": 42355,
+    "name": "GoldXChain Mainnet",
+    "shortName": "goldx",
+    "nativeCurrency": {
+      "symbol": "GOLDX"
+    }
+  },
+  {
+    "chainId": 42420,
+    "name": "Asset Chain Mainnet",
+    "shortName": "assetchain",
+    "nativeCurrency": {
+      "symbol": "RWA"
+    }
+  },
+  {
+    "chainId": 42421,
+    "name": "Asset Chain Testnet",
+    "shortName": "rwa",
+    "nativeCurrency": {
+      "symbol": "RWA"
+    }
+  },
+  {
+    "chainId": 42429,
+    "name": "Tempo Testnet Andantino (Deprecated)",
+    "shortName": "tempo-andantino",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 42431,
+    "name": "Tempo Testnet Moderato",
+    "shortName": "tempo-moderato",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 42766,
+    "name": "ZKFair Mainnet",
+    "shortName": "ZKFair-Mainnet",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 42793,
+    "name": "Etherlink Mainnet",
+    "shortName": "etlk",
+    "nativeCurrency": {
+      "symbol": "XTZ"
+    }
+  },
+  {
+    "chainId": 42801,
+    "name": "Gesoten Verse Testnet",
+    "shortName": "GST",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 42888,
+    "name": "Kinto Testnet",
+    "shortName": "keth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 43110,
+    "name": "Athereum",
+    "shortName": "avaeth",
+    "nativeCurrency": {
+      "symbol": "ATH"
+    }
+  },
+  {
+    "chainId": 43111,
+    "name": "Hemi",
+    "shortName": "hemi",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 43113,
+    "name": "Avalanche Fuji Testnet",
+    "shortName": "Fuji",
+    "nativeCurrency": {
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "chainId": 43114,
+    "name": "Avalanche C-Chain",
+    "shortName": "avax",
+    "nativeCurrency": {
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "chainId": 43288,
+    "name": "Boba Avax",
+    "shortName": "bobaavax",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 43419,
+    "name": "GUNZ",
+    "shortName": "gunz-mainnet",
+    "nativeCurrency": {
+      "symbol": "GUN"
+    }
+  },
+  {
+    "chainId": 43521,
+    "name": "Formicarium",
+    "shortName": "form",
+    "nativeCurrency": {
+      "symbol": "M"
+    }
+  },
+  {
+    "chainId": 43851,
+    "name": "ZKFair Testnet",
+    "shortName": "ZKFair-Testnet",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 44444,
+    "name": "Frenchain",
+    "shortName": "FREN",
+    "nativeCurrency": {
+      "symbol": "FREN"
+    }
+  },
+  {
+    "chainId": 44445,
+    "name": "Quantum Network",
+    "shortName": "QTM",
+    "nativeCurrency": {
+      "symbol": "QTM"
+    }
+  },
+  {
+    "chainId": 44787,
+    "name": "Celo Alfajores Testnet",
+    "shortName": "ALFA",
+    "nativeCurrency": {
+      "symbol": "CELO"
+    }
+  },
+  {
+    "chainId": 45000,
+    "name": "Autobahn Network",
+    "shortName": "AutobahnNetwork",
+    "nativeCurrency": {
+      "symbol": "TXL"
+    }
+  },
+  {
+    "chainId": 45003,
+    "name": "Juneo JUNE-Chain",
+    "shortName": "JUNE",
+    "nativeCurrency": {
+      "symbol": "JUNE"
+    }
+  },
+  {
+    "chainId": 45004,
+    "name": "Juneo DAI1-Chain",
+    "shortName": "DAI1",
+    "nativeCurrency": {
+      "symbol": "DAI1"
+    }
+  },
+  {
+    "chainId": 45005,
+    "name": "Juneo USDT1-Chain",
+    "shortName": "USDT1",
+    "nativeCurrency": {
+      "symbol": "USDT1"
+    }
+  },
+  {
+    "chainId": 45006,
+    "name": "Juneo USD1-Chain",
+    "shortName": "USD1",
+    "nativeCurrency": {
+      "symbol": "USD1"
+    }
+  },
+  {
+    "chainId": 45007,
+    "name": "Juneo mBTC1-Chain",
+    "shortName": "mBTC1",
+    "nativeCurrency": {
+      "symbol": "mBTC1"
+    }
+  },
+  {
+    "chainId": 45008,
+    "name": "Juneo GLD1-Chain",
+    "shortName": "GLD1",
+    "nativeCurrency": {
+      "symbol": "GLD1"
+    }
+  },
+  {
+    "chainId": 45009,
+    "name": "Juneo LTC1-Chain",
+    "shortName": "LTC1",
+    "nativeCurrency": {
+      "symbol": "LTC1"
+    }
+  },
+  {
+    "chainId": 45010,
+    "name": "Juneo DOGE1-Chain",
+    "shortName": "DOGE1",
+    "nativeCurrency": {
+      "symbol": "DOGE1"
+    }
+  },
+  {
+    "chainId": 45011,
+    "name": "Juneo EUR1-Chain",
+    "shortName": "EUR1",
+    "nativeCurrency": {
+      "symbol": "EUR1"
+    }
+  },
+  {
+    "chainId": 45012,
+    "name": "Juneo SGD1-Chain",
+    "shortName": "SGD1",
+    "nativeCurrency": {
+      "symbol": "SGD1"
+    }
+  },
+  {
+    "chainId": 45013,
+    "name": "Juneo BCH1-Chain",
+    "shortName": "BCH1",
+    "nativeCurrency": {
+      "symbol": "BCH1"
+    }
+  },
+  {
+    "chainId": 45014,
+    "name": "Juneo LINK1-Chain",
+    "shortName": "LINK1",
+    "nativeCurrency": {
+      "symbol": "LINK1"
+    }
+  },
+  {
+    "chainId": 45056,
+    "name": "Billions",
+    "shortName": "Billions",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 45454,
+    "name": "Swamps L2",
+    "shortName": "SWP",
+    "nativeCurrency": {
+      "symbol": "SWP"
+    }
+  },
+  {
+    "chainId": 45510,
+    "name": "Deelance Mainnet",
+    "shortName": "dee",
+    "nativeCurrency": {
+      "symbol": "DEE"
+    }
+  },
+  {
+    "chainId": 45513,
+    "name": "Blessnet",
+    "shortName": "bless",
+    "nativeCurrency": {
+      "symbol": "BLESS"
+    }
+  },
+  {
+    "chainId": 46630,
+    "name": "Robinhood Chain Testnet",
+    "shortName": "rh-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 46688,
+    "name": "Fusion Testnet",
+    "shortName": "tfsn",
+    "nativeCurrency": {
+      "symbol": "T-FSN"
+    }
+  },
+  {
+    "chainId": 47763,
+    "name": "Neo X Mainnet",
+    "shortName": "neox-mainnet",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 47803,
+    "name": "ReDeFi Layer 1",
+    "shortName": "bax",
+    "nativeCurrency": {
+      "symbol": "BAX"
+    }
+  },
+  {
+    "chainId": 47805,
+    "name": "REI Network",
+    "shortName": "REI",
+    "nativeCurrency": {
+      "symbol": "REI"
+    }
+  },
+  {
+    "chainId": 48795,
+    "name": "Space Subnet Testnet",
+    "shortName": "spacetestnet",
+    "nativeCurrency": {
+      "symbol": "FUEL"
+    }
+  },
+  {
+    "chainId": 48898,
+    "name": "Zircuit Garfield Testnet",
+    "shortName": "zircuit-garfield-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 48899,
+    "name": "Zircuit Testnet",
+    "shortName": "zircuit-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 48900,
+    "name": "Zircuit Mainnet",
+    "shortName": "zircuit-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 49049,
+    "name": "Wireshape Floripa Testnet",
+    "shortName": "floripa",
+    "nativeCurrency": {
+      "symbol": "WIRE"
+    }
+  },
+  {
+    "chainId": 49088,
+    "name": "Bifrost Testnet",
+    "shortName": "tbfc",
+    "nativeCurrency": {
+      "symbol": "BFC"
+    }
+  },
+  {
+    "chainId": 49321,
+    "name": "GUNZ Testnet",
+    "shortName": "Stork",
+    "nativeCurrency": {
+      "symbol": "GUN"
+    }
+  },
+  {
+    "chainId": 49797,
+    "name": "Energi Testnet",
+    "shortName": "tnrg",
+    "nativeCurrency": {
+      "symbol": "NRG"
+    }
+  },
+  {
+    "chainId": 50000,
+    "name": "Citronus",
+    "shortName": "citro",
+    "nativeCurrency": {
+      "symbol": "CITRO"
+    }
+  },
+  {
+    "chainId": 50001,
+    "name": "Liveplex OracleEVM",
+    "shortName": "LOE",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 50005,
+    "name": "Yooldo Verse Mainnet",
+    "shortName": "YVM",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 50006,
+    "name": "Yooldo Verse Testnet",
+    "shortName": "YVT",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 50021,
+    "name": "GTON Testnet",
+    "shortName": "tgton",
+    "nativeCurrency": {
+      "symbol": "GCD"
+    }
+  },
+  {
+    "chainId": 50104,
+    "name": "Sophon",
+    "shortName": "sophon",
+    "nativeCurrency": {
+      "symbol": "SOPH"
+    }
+  },
+  {
+    "chainId": 50312,
+    "name": "Somnia Testnet",
+    "shortName": "SomniaTestnet",
+    "nativeCurrency": {
+      "symbol": "STT"
+    }
+  },
+  {
+    "chainId": 50341,
+    "name": "Reddio Testnet",
+    "shortName": "reddio-devnet",
+    "nativeCurrency": {
+      "symbol": "RDO"
+    }
+  },
+  {
+    "chainId": 50342,
+    "name": "Reddio",
+    "shortName": "reddio",
+    "nativeCurrency": {
+      "symbol": "RDO"
+    }
+  },
+  {
+    "chainId": 50505,
+    "name": "STB Testnet",
+    "shortName": "stb-testnet",
+    "nativeCurrency": {
+      "symbol": "STB"
+    }
+  },
+  {
+    "chainId": 50888,
+    "name": "Erbie Mainnet",
+    "shortName": "Erbie",
+    "nativeCurrency": {
+      "symbol": "ERB"
+    }
+  },
+  {
+    "chainId": 51178,
+    "name": "Lumoz Testnet Alpha",
+    "shortName": "Lumoz-Testnet",
+    "nativeCurrency": {
+      "symbol": "MOZ"
+    }
+  },
+  {
+    "chainId": 51712,
+    "name": "Sardis Mainnet",
+    "shortName": "SRDXm",
+    "nativeCurrency": {
+      "symbol": "SRDX"
+    }
+  },
+  {
+    "chainId": 51888,
+    "name": "Memento Mainnet",
+    "shortName": "memento-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 52014,
+    "name": "Electroneum Mainnet",
+    "shortName": "etn-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETN"
+    }
+  },
+  {
+    "chainId": 52225,
+    "name": "Cytonic Settlement Layer Testnet",
+    "shortName": "CSL",
+    "nativeCurrency": {
+      "symbol": "CCC"
+    }
+  },
+  {
+    "chainId": 52226,
+    "name": "Cytonic Ethereum Testnet",
+    "shortName": "CEVM",
+    "nativeCurrency": {
+      "symbol": "CCC"
+    }
+  },
+  {
+    "chainId": 53277,
+    "name": "DOID",
+    "shortName": "DOID",
+    "nativeCurrency": {
+      "symbol": "DOID"
+    }
+  },
+  {
+    "chainId": 53302,
+    "name": "Superseed Sepolia Testnet",
+    "shortName": "seedsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 53456,
+    "name": "BirdLayer",
+    "shortName": "birdlayer",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 53457,
+    "name": "DODOchain testnet",
+    "shortName": "dodochain",
+    "nativeCurrency": {
+      "symbol": "DODO"
+    }
+  },
+  {
+    "chainId": 53935,
+    "name": "DFK Chain",
+    "shortName": "DFK",
+    "nativeCurrency": {
+      "symbol": "JEWEL"
+    }
+  },
+  {
+    "chainId": 54170,
+    "name": "Graphite Testnet",
+    "shortName": "graphiteTest",
+    "nativeCurrency": {
+      "symbol": "@G"
+    }
+  },
+  {
+    "chainId": 54176,
+    "name": "OverProtocol Mainnet",
+    "shortName": "overprotocol",
+    "nativeCurrency": {
+      "symbol": "OVER"
+    }
+  },
+  {
+    "chainId": 54211,
+    "name": "Haqq Chain Testnet",
+    "shortName": "ISLMT",
+    "nativeCurrency": {
+      "symbol": "ISLMT"
+    }
+  },
+  {
+    "chainId": 54321,
+    "name": "Toronet Testnet",
+    "shortName": "ToronetTestnet",
+    "nativeCurrency": {
+      "symbol": "TOROE"
+    }
+  },
+  {
+    "chainId": 55004,
+    "name": "Titan",
+    "shortName": "teth",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 55007,
+    "name": "Titan Sepolia",
+    "shortName": "titan-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 55244,
+    "name": "Superposition",
+    "shortName": "spn",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 55377,
+    "name": "DUST Testnet",
+    "shortName": "dust-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 55378,
+    "name": "DUST Mainnet",
+    "shortName": "dust-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 55551,
+    "name": "Photon Aurora Testnet",
+    "shortName": "pton",
+    "nativeCurrency": {
+      "symbol": "PTON"
+    }
+  },
+  {
+    "chainId": 55555,
+    "name": "REI Chain Mainnet",
+    "shortName": "reichain",
+    "nativeCurrency": {
+      "symbol": "REI"
+    }
+  },
+  {
+    "chainId": 55556,
+    "name": "REI Chain Testnet",
+    "shortName": "trei",
+    "nativeCurrency": {
+      "symbol": "tREI"
+    }
+  },
+  {
+    "chainId": 55614,
+    "name": "Flamma Mainnet",
+    "shortName": "FlammaMainnet",
+    "nativeCurrency": {
+      "symbol": "FLA"
+    }
+  },
+  {
+    "chainId": 55930,
+    "name": "DataHaven Mainnet",
+    "shortName": "datahaven",
+    "nativeCurrency": {
+      "symbol": "HAVE"
+    }
+  },
+  {
+    "chainId": 55931,
+    "name": "DataHaven Testnet",
+    "shortName": "datahaven-testnet",
+    "nativeCurrency": {
+      "symbol": "MOCK"
+    }
+  },
+  {
+    "chainId": 56026,
+    "name": "Lambda Chain Mainnet",
+    "shortName": "lambda",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 56288,
+    "name": "Boba BNB Mainnet",
+    "shortName": "BobaBnb",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 56400,
+    "name": "Testnet Zeroone Subnet",
+    "shortName": "testnetzer",
+    "nativeCurrency": {
+      "symbol": "ZERO"
+    }
+  },
+  {
+    "chainId": 56789,
+    "name": "VELO Labs Mainnet",
+    "shortName": "VELO",
+    "nativeCurrency": {
+      "symbol": "NOVA"
+    }
+  },
+  {
+    "chainId": 56797,
+    "name": "DOID Testnet",
+    "shortName": "doidTestnet",
+    "nativeCurrency": {
+      "symbol": "DOID"
+    }
+  },
+  {
+    "chainId": 57000,
+    "name": "Rollux Testnet",
+    "shortName": "tsys-rollux",
+    "nativeCurrency": {
+      "symbol": "TSYS"
+    }
+  },
+  {
+    "chainId": 57054,
+    "name": "Sonic Blaze Testnet",
+    "shortName": "blaze",
+    "nativeCurrency": {
+      "symbol": "S"
+    }
+  },
+  {
+    "chainId": 57073,
+    "name": "Ink",
+    "shortName": "ink",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 57451,
+    "name": "COINSEC Network",
+    "shortName": "coinsecnetwork",
+    "nativeCurrency": {
+      "symbol": "SEC"
+    }
+  },
+  {
+    "chainId": 58008,
+    "name": "Sepolia PGN (Public Goods Network)",
+    "shortName": "sepPGN",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 58680,
+    "name": "Lumoz Quidditch Testnet",
+    "shortName": "Lumoz-Quidditch-Testnet",
+    "nativeCurrency": {
+      "symbol": "MOZ"
+    }
+  },
+  {
+    "chainId": 59140,
+    "name": "Linea Goerli",
+    "shortName": "linea-goerli",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 59141,
+    "name": "Linea Sepolia",
+    "shortName": "linea-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 59144,
+    "name": "Linea",
+    "shortName": "linea",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 59902,
+    "name": "Metis Sepolia Testnet",
+    "shortName": "metis-sepolia",
+    "nativeCurrency": {
+      "symbol": "tMETIS"
+    }
+  },
+  {
+    "chainId": 59971,
+    "name": "Genesys Code Mainnet",
+    "shortName": "gcode",
+    "nativeCurrency": {
+      "symbol": "GCODE"
+    }
+  },
+  {
+    "chainId": 60000,
+    "name": "Thinkium Testnet Chain 0",
+    "shortName": "TKM-test0",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 60001,
+    "name": "Thinkium Testnet Chain 1",
+    "shortName": "TKM-test1",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 60002,
+    "name": "Thinkium Testnet Chain 2",
+    "shortName": "TKM-test2",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 60103,
+    "name": "Thinkium Testnet Chain 103",
+    "shortName": "TKM-test103",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 60600,
+    "name": "POTOS Testnet",
+    "shortName": "potos-testnet",
+    "nativeCurrency": {
+      "symbol": "POT"
+    }
+  },
+  {
+    "chainId": 60603,
+    "name": "POTOS Mainnet",
+    "shortName": "potos",
+    "nativeCurrency": {
+      "symbol": "POT"
+    }
+  },
+  {
+    "chainId": 60808,
+    "name": "BOB",
+    "shortName": "bob",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 60850,
+    "name": "Perennial Sepolia",
+    "shortName": "perennial-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 61022,
+    "name": "Orange Chain Mainnet",
+    "shortName": "Orange-Chain-Mainnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 61166,
+    "name": "Treasure",
+    "shortName": "treasure",
+    "nativeCurrency": {
+      "symbol": "MAGIC"
+    }
+  },
+  {
+    "chainId": 61406,
+    "name": "KaiChain",
+    "shortName": "kec",
+    "nativeCurrency": {
+      "symbol": "KEC"
+    }
+  },
+  {
+    "chainId": 61564,
+    "name": "Gelatine Network",
+    "shortName": "jello",
+    "nativeCurrency": {
+      "symbol": "JELLO"
+    }
+  },
+  {
+    "chainId": 61800,
+    "name": "AxelChain Dev-Net",
+    "shortName": "aium-dev",
+    "nativeCurrency": {
+      "symbol": "AIUM"
+    }
+  },
+  {
+    "chainId": 61803,
+    "name": "Etica Mainnet",
+    "shortName": "Etica",
+    "nativeCurrency": {
+      "symbol": "EGAZ"
+    }
+  },
+  {
+    "chainId": 61916,
+    "name": "DoKEN Super Chain Mainnet",
+    "shortName": "DoKEN",
+    "nativeCurrency": {
+      "symbol": "DKN"
+    }
+  },
+  {
+    "chainId": 62049,
+    "name": "OPTOPIA Testnet",
+    "shortName": "OPTOPIA-Testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 62050,
+    "name": "Optopia Mainnet",
+    "shortName": "Optopia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 62092,
+    "name": "TikTrix Testnet",
+    "shortName": "tiktrix-testnet",
+    "nativeCurrency": {
+      "symbol": "tTTX"
+    }
+  },
+  {
+    "chainId": 62298,
+    "name": "Citrea Devnet",
+    "shortName": "citrea-devnet",
+    "nativeCurrency": {
+      "symbol": "cBTC"
+    }
+  },
+  {
+    "chainId": 62320,
+    "name": "Celo Baklava Testnet",
+    "shortName": "BKLV",
+    "nativeCurrency": {
+      "symbol": "CELO"
+    }
+  },
+  {
+    "chainId": 62606,
+    "name": "Apollo Mainnet",
+    "shortName": "APOLLO",
+    "nativeCurrency": {
+      "symbol": "APOLLO"
+    }
+  },
+  {
+    "chainId": 62621,
+    "name": "MultiVAC Mainnet",
+    "shortName": "mtv",
+    "nativeCurrency": {
+      "symbol": "MTV"
+    }
+  },
+  {
+    "chainId": 62831,
+    "name": "PLYR TAU Testnet",
+    "shortName": "plyr-tau-testnet",
+    "nativeCurrency": {
+      "symbol": "PLYR"
+    }
+  },
+  {
+    "chainId": 62850,
+    "name": "LAOS Sigma Testnet",
+    "shortName": "laossigma",
+    "nativeCurrency": {
+      "symbol": "SIGMA"
+    }
+  },
+  {
+    "chainId": 63000,
+    "name": "eSync Network Mainnet",
+    "shortName": "esync-mainnet",
+    "nativeCurrency": {
+      "symbol": "ECS"
+    }
+  },
+  {
+    "chainId": 63001,
+    "name": "eCredits Testnet",
+    "shortName": "ecs-testnet-old",
+    "nativeCurrency": {
+      "symbol": "ECS"
+    }
+  },
+  {
+    "chainId": 63002,
+    "name": "eSync Network Testnet",
+    "shortName": "esync-testnet",
+    "nativeCurrency": {
+      "symbol": "ECS"
+    }
+  },
+  {
+    "chainId": 63157,
+    "name": "Geist Mainnet",
+    "shortName": "geist",
+    "nativeCurrency": {
+      "symbol": "GHST"
+    }
+  },
+  {
+    "chainId": 64002,
+    "name": "XCHAIN Testnet",
+    "shortName": "xct",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 65349,
+    "name": "CratD2C Testnet Deprecated",
+    "shortName": "cratd2c-testnet-deprecated",
+    "nativeCurrency": {
+      "symbol": "CRAT"
+    }
+  },
+  {
+    "chainId": 65357,
+    "name": "Vecno Mainnet",
+    "shortName": "ve",
+    "nativeCurrency": {
+      "symbol": "VE"
+    }
+  },
+  {
+    "chainId": 65450,
+    "name": "Scolcoin Mainnet",
+    "shortName": "SRC",
+    "nativeCurrency": {
+      "symbol": "SCOL"
+    }
+  },
+  {
+    "chainId": 65535,
+    "name": "CyberChain Mainnet",
+    "shortName": "xcc",
+    "nativeCurrency": {
+      "symbol": "XCC"
+    }
+  },
+  {
+    "chainId": 65536,
+    "name": "Automata Mainnet",
+    "shortName": "automatamainnet",
+    "nativeCurrency": {
+      "symbol": "ATA"
+    }
+  },
+  {
+    "chainId": 66665,
+    "name": "Creator Chain Testnet",
+    "shortName": "ceth",
+    "nativeCurrency": {
+      "symbol": "CETH"
+    }
+  },
+  {
+    "chainId": 66666,
+    "name": "Bitasset Chain Testnet Ploutos",
+    "shortName": "bac-ploutos",
+    "nativeCurrency": {
+      "symbol": "BAC"
+    }
+  },
+  {
+    "chainId": 66988,
+    "name": "Janus Testnet",
+    "shortName": "janusnetwork-testnet",
+    "nativeCurrency": {
+      "symbol": "JNS"
+    }
+  },
+  {
+    "chainId": 67390,
+    "name": "SiriusNet",
+    "shortName": "mcl",
+    "nativeCurrency": {
+      "symbol": "MCD"
+    }
+  },
+  {
+    "chainId": 67588,
+    "name": "Cosmic Chain",
+    "shortName": "Cosmic",
+    "nativeCurrency": {
+      "symbol": "COSMIC"
+    }
+  },
+  {
+    "chainId": 68414,
+    "name": "Henesys",
+    "shortName": "nxpc",
+    "nativeCurrency": {
+      "symbol": "NXPC"
+    }
+  },
+  {
+    "chainId": 68770,
+    "name": "DM2 Verse Mainnet",
+    "shortName": "dm2",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 68775,
+    "name": "DM2 Verse Testnet",
+    "shortName": "dm2t",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 69000,
+    "name": "Animechain Mainnet",
+    "shortName": "anime",
+    "nativeCurrency": {
+      "symbol": "ANIME"
+    }
+  },
+  {
+    "chainId": 69420,
+    "name": "Condrieu",
+    "shortName": "cndr",
+    "nativeCurrency": {
+      "symbol": "CTE"
+    }
+  },
+  {
+    "chainId": 70000,
+    "name": "Thinkium Mainnet Chain 0",
+    "shortName": "TKM0",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 70001,
+    "name": "Thinkium Mainnet Chain 1",
+    "shortName": "TKM1",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 70002,
+    "name": "Thinkium Mainnet Chain 2",
+    "shortName": "TKM2",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 70007,
+    "name": "Seven Chain",
+    "shortName": "seven",
+    "nativeCurrency": {
+      "symbol": "SEVEN"
+    }
+  },
+  {
+    "chainId": 70103,
+    "name": "Thinkium Mainnet Chain 103",
+    "shortName": "TKM103",
+    "nativeCurrency": {
+      "symbol": "TKM"
+    }
+  },
+  {
+    "chainId": 70700,
+    "name": "Proof of Play - Apex",
+    "shortName": "pop-apex",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 70701,
+    "name": "Proof of Play - Boss",
+    "shortName": "pop-boss",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 71111,
+    "name": "GuapcoinX",
+    "shortName": "GuapX",
+    "nativeCurrency": {
+      "symbol": "GuapX"
+    }
+  },
+  {
+    "chainId": 71117,
+    "name": "Wadzchain Testnet",
+    "shortName": "wadzchain-testnet",
+    "nativeCurrency": {
+      "symbol": "WCO"
+    }
+  },
+  {
+    "chainId": 71393,
+    "name": "Polyjuice Testnet",
+    "shortName": "ckb",
+    "nativeCurrency": {
+      "symbol": "CKB"
+    }
+  },
+  {
+    "chainId": 71401,
+    "name": "Godwoken Testnet v1",
+    "shortName": "gw-testnet-v1",
+    "nativeCurrency": {
+      "symbol": "pCKB"
+    }
+  },
+  {
+    "chainId": 71402,
+    "name": "Godwoken Mainnet",
+    "shortName": "gw-mainnet-v1",
+    "nativeCurrency": {
+      "symbol": "pCKB"
+    }
+  },
+  {
+    "chainId": 72080,
+    "name": "Nexera Testnet",
+    "shortName": "nxra-testnet",
+    "nativeCurrency": {
+      "symbol": "tNXRA"
+    }
+  },
+  {
+    "chainId": 72344,
+    "name": "Radius Test Network",
+    "shortName": "radius-network-testnet",
+    "nativeCurrency": {
+      "symbol": "RUSD"
+    }
+  },
+  {
+    "chainId": 72778,
+    "name": "CAGA crypto Ankara testnet",
+    "shortName": "caga",
+    "nativeCurrency": {
+      "symbol": "CAGA"
+    }
+  },
+  {
+    "chainId": 72888,
+    "name": "CAGA mainnet",
+    "shortName": "caga-mainnet",
+    "nativeCurrency": {
+      "symbol": "CAGA"
+    }
+  },
+  {
+    "chainId": 72992,
+    "name": "Grok Chain Mainnet",
+    "shortName": "GrokChain",
+    "nativeCurrency": {
+      "symbol": "GROC"
+    }
+  },
+  {
+    "chainId": 73114,
+    "name": "ICB Testnet",
+    "shortName": "ICBT",
+    "nativeCurrency": {
+      "symbol": "ICBT"
+    }
+  },
+  {
+    "chainId": 73115,
+    "name": "ICB Network",
+    "shortName": "ICBX",
+    "nativeCurrency": {
+      "symbol": "ICBX"
+    }
+  },
+  {
+    "chainId": 73285,
+    "name": "Nebula",
+    "shortName": "nebula",
+    "nativeCurrency": {
+      "symbol": "NEBX"
+    }
+  },
+  {
+    "chainId": 73790,
+    "name": "NV-CHAIN",
+    "shortName": "nvc",
+    "nativeCurrency": {
+      "symbol": "NVC"
+    }
+  },
+  {
+    "chainId": 73799,
+    "name": "Energy Web Volta Testnet",
+    "shortName": "vt",
+    "nativeCurrency": {
+      "symbol": "VT"
+    }
+  },
+  {
+    "chainId": 73927,
+    "name": "Mixin Virtual Machine",
+    "shortName": "mvm",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 75000,
+    "name": "ResinCoin Mainnet",
+    "shortName": "resin",
+    "nativeCurrency": {
+      "symbol": "RESIN"
+    }
+  },
+  {
+    "chainId": 75338,
+    "name": "AppLayer Testnet",
+    "shortName": "applayer-testnet",
+    "nativeCurrency": {
+      "symbol": "APPL"
+    }
+  },
+  {
+    "chainId": 75512,
+    "name": "GEEK Verse Mainnet",
+    "shortName": "GEEK",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 75513,
+    "name": "GEEK Verse Testnet",
+    "shortName": "GEEK_Test",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 76672,
+    "name": "CarrChain Testnet",
+    "shortName": "CarrChain-Testnet",
+    "nativeCurrency": {
+      "symbol": "CARR"
+    }
+  },
+  {
+    "chainId": 77001,
+    "name": "BORAchain mainnet",
+    "shortName": "BORAchain",
+    "nativeCurrency": {
+      "symbol": "BORA"
+    }
+  },
+  {
+    "chainId": 77238,
+    "name": "Foundry Chain Testnet",
+    "shortName": "fnc",
+    "nativeCurrency": {
+      "symbol": "tFNC"
+    }
+  },
+  {
+    "chainId": 77612,
+    "name": "Vention Smart Chain Mainnet",
+    "shortName": "vscm",
+    "nativeCurrency": {
+      "symbol": "VNT"
+    }
+  },
+  {
+    "chainId": 77652,
+    "name": "CarrChain Testnet (Deprecated)",
+    "shortName": "Carrchain-Testnet-Deprecated",
+    "nativeCurrency": {
+      "symbol": "CARR"
+    }
+  },
+  {
+    "chainId": 77677,
+    "name": "Cycle Network Mainnet Sailboat",
+    "shortName": "cycles",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 77777,
+    "name": "Toronet Mainnet",
+    "shortName": "Toronet",
+    "nativeCurrency": {
+      "symbol": "TOROE"
+    }
+  },
+  {
+    "chainId": 77778,
+    "name": "StreetDog Chain",
+    "shortName": "sdc",
+    "nativeCurrency": {
+      "symbol": "SD"
+    }
+  },
+  {
+    "chainId": 78110,
+    "name": "Firenze test network",
+    "shortName": "firenze",
+    "nativeCurrency": {
+      "symbol": "FIN"
+    }
+  },
+  {
+    "chainId": 78281,
+    "name": "Dragonfly Mainnet (Hexapod)",
+    "shortName": "dfly",
+    "nativeCurrency": {
+      "symbol": "DFLY"
+    }
+  },
+  {
+    "chainId": 78430,
+    "name": "Amplify Subnet",
+    "shortName": "amplify",
+    "nativeCurrency": {
+      "symbol": "AMP"
+    }
+  },
+  {
+    "chainId": 78431,
+    "name": "Bulletin Subnet",
+    "shortName": "bulletin",
+    "nativeCurrency": {
+      "symbol": "BLT"
+    }
+  },
+  {
+    "chainId": 78432,
+    "name": "Conduit Subnet",
+    "shortName": "conduit",
+    "nativeCurrency": {
+      "symbol": "CON"
+    }
+  },
+  {
+    "chainId": 78600,
+    "name": "Vanguard",
+    "shortName": "vanguard",
+    "nativeCurrency": {
+      "symbol": "VANRY"
+    }
+  },
+  {
+    "chainId": 78651,
+    "name": "Nillion Network Sepolia Testnet",
+    "shortName": "nilsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 79879,
+    "name": "Gold Smart Chain Testnet",
+    "shortName": "STANDt",
+    "nativeCurrency": {
+      "symbol": "STAND"
+    }
+  },
+  {
+    "chainId": 80001,
+    "name": "Mumbai",
+    "shortName": "maticmum",
+    "nativeCurrency": {
+      "symbol": "MATIC"
+    }
+  },
+  {
+    "chainId": 80002,
+    "name": "Amoy",
+    "shortName": "polygonamoy",
+    "nativeCurrency": {
+      "symbol": "POL"
+    }
+  },
+  {
+    "chainId": 80008,
+    "name": "Polynomial Sepolia",
+    "shortName": "polynomialSepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 80069,
+    "name": "Berachain Bepolia",
+    "shortName": "berachain-bepolia",
+    "nativeCurrency": {
+      "symbol": "BERA"
+    }
+  },
+  {
+    "chainId": 80084,
+    "name": "Berachain bArtio",
+    "shortName": "berachainbArtio",
+    "nativeCurrency": {
+      "symbol": "BERA"
+    }
+  },
+  {
+    "chainId": 80085,
+    "name": "Berachain Artio",
+    "shortName": "berachainArtio",
+    "nativeCurrency": {
+      "symbol": "BERA"
+    }
+  },
+  {
+    "chainId": 80094,
+    "name": "Berachain",
+    "shortName": "berachain",
+    "nativeCurrency": {
+      "symbol": "BERA"
+    }
+  },
+  {
+    "chainId": 80096,
+    "name": "Hizoco mainnet",
+    "shortName": "hzc",
+    "nativeCurrency": {
+      "symbol": "HZC"
+    }
+  },
+  {
+    "chainId": 80451,
+    "name": "Geo Genesis",
+    "shortName": "geo",
+    "nativeCurrency": {
+      "symbol": "GRT"
+    }
+  },
+  {
+    "chainId": 80808,
+    "name": "HyperX",
+    "shortName": "hpx",
+    "nativeCurrency": {
+      "symbol": "HPX"
+    }
+  },
+  {
+    "chainId": 80931,
+    "name": "Forta Chain",
+    "shortName": "forta",
+    "nativeCurrency": {
+      "symbol": "FORT"
+    }
+  },
+  {
+    "chainId": 81041,
+    "name": "Nordek Mainnet",
+    "shortName": "nordek",
+    "nativeCurrency": {
+      "symbol": "NRK"
+    }
+  },
+  {
+    "chainId": 81224,
+    "name": "Codex",
+    "shortName": "codex",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 81341,
+    "name": "Amana Testnet",
+    "shortName": "amanatest",
+    "nativeCurrency": {
+      "symbol": "MEER-T"
+    }
+  },
+  {
+    "chainId": 81342,
+    "name": "Amana Mixnet",
+    "shortName": "amanamix",
+    "nativeCurrency": {
+      "symbol": "MEER-M"
+    }
+  },
+  {
+    "chainId": 81343,
+    "name": "Amana Privnet",
+    "shortName": "amanapriv",
+    "nativeCurrency": {
+      "symbol": "MEER-P"
+    }
+  },
+  {
+    "chainId": 81351,
+    "name": "Flana Testnet",
+    "shortName": "flanatest",
+    "nativeCurrency": {
+      "symbol": "MEER-T"
+    }
+  },
+  {
+    "chainId": 81352,
+    "name": "Flana Mixnet",
+    "shortName": "flanamix",
+    "nativeCurrency": {
+      "symbol": "MEER-M"
+    }
+  },
+  {
+    "chainId": 81353,
+    "name": "Flana Privnet",
+    "shortName": "flanapriv",
+    "nativeCurrency": {
+      "symbol": "MEER-P"
+    }
+  },
+  {
+    "chainId": 81361,
+    "name": "Mizana Testnet",
+    "shortName": "mizanatest",
+    "nativeCurrency": {
+      "symbol": "MEER-T"
+    }
+  },
+  {
+    "chainId": 81362,
+    "name": "Mizana Mixnet",
+    "shortName": "mizanamix",
+    "nativeCurrency": {
+      "symbol": "MEER-M"
+    }
+  },
+  {
+    "chainId": 81363,
+    "name": "Mizana Privnet",
+    "shortName": "mizanapriv",
+    "nativeCurrency": {
+      "symbol": "MEER-P"
+    }
+  },
+  {
+    "chainId": 81457,
+    "name": "Blast",
+    "shortName": "blastmainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 81720,
+    "name": "Quantum Chain Mainnet",
+    "shortName": "qnet",
+    "nativeCurrency": {
+      "symbol": "QNET"
+    }
+  },
+  {
+    "chainId": 82459,
+    "name": "Smart Layer Network Testnet",
+    "shortName": "tSLN",
+    "nativeCurrency": {
+      "symbol": "SU"
+    }
+  },
+  {
+    "chainId": 82614,
+    "name": "VEMP Horizon",
+    "shortName": "vemp-horizon",
+    "nativeCurrency": {
+      "symbol": "VEMP"
+    }
+  },
+  {
+    "chainId": 82716,
+    "name": "Pylun Testnet",
+    "shortName": "pylun",
+    "nativeCurrency": {
+      "symbol": "PYLUN"
+    }
+  },
+  {
+    "chainId": 83144,
+    "name": "Xprotocol Testnet",
+    "shortName": "xprotocoltestnet",
+    "nativeCurrency": {
+      "symbol": "KICK"
+    }
+  },
+  {
+    "chainId": 83278,
+    "name": "Esa",
+    "shortName": "Esa",
+    "nativeCurrency": {
+      "symbol": "Esa"
+    }
+  },
+  {
+    "chainId": 83592,
+    "name": "Katron AI Mainnet",
+    "shortName": "ktn",
+    "nativeCurrency": {
+      "symbol": "KTN"
+    }
+  },
+  {
+    "chainId": 83868,
+    "name": "Xprotocol Sepolia",
+    "shortName": "xprotocolsepolia",
+    "nativeCurrency": {
+      "symbol": "KICK"
+    }
+  },
+  {
+    "chainId": 83872,
+    "name": "ZEDXION",
+    "shortName": "ZEDX",
+    "nativeCurrency": {
+      "symbol": "ZEDX"
+    }
+  },
+  {
+    "chainId": 84531,
+    "name": "Base Goerli Testnet",
+    "shortName": "basegor",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 84532,
+    "name": "Base Sepolia Testnet",
+    "shortName": "basesep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 84841,
+    "name": "O Chain",
+    "shortName": "O",
+    "nativeCurrency": {
+      "symbol": "O"
+    }
+  },
+  {
+    "chainId": 84886,
+    "name": "Aerie Network",
+    "shortName": "Aerie",
+    "nativeCurrency": {
+      "symbol": "AER"
+    }
+  },
+  {
+    "chainId": 85321,
+    "name": "GDPR Testnet",
+    "shortName": "gdpr-testnet",
+    "nativeCurrency": {
+      "symbol": "GDPR"
+    }
+  },
+  {
+    "chainId": 85449,
+    "name": "CYBERTRUST",
+    "shortName": "Cyber",
+    "nativeCurrency": {
+      "symbol": "CYBER"
+    }
+  },
+  {
+    "chainId": 86606,
+    "name": "CpChain Testnet",
+    "shortName": "cpchain-testnet",
+    "nativeCurrency": {
+      "symbol": "CP"
+    }
+  },
+  {
+    "chainId": 86608,
+    "name": "CpChain Mainnet",
+    "shortName": "cpchain",
+    "nativeCurrency": {
+      "symbol": "CP"
+    }
+  },
+  {
+    "chainId": 88002,
+    "name": "Nautilus Proteus Testnet",
+    "shortName": "NAUTTest",
+    "nativeCurrency": {
+      "symbol": "tZBC"
+    }
+  },
+  {
+    "chainId": 88559,
+    "name": "InoAi",
+    "shortName": "INO",
+    "nativeCurrency": {
+      "symbol": "INO"
+    }
+  },
+  {
+    "chainId": 88688,
+    "name": "Cycle Network Mainnet Frigate",
+    "shortName": "cyclef",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 88788,
+    "name": "PropTech Mainnet",
+    "shortName": "ptek",
+    "nativeCurrency": {
+      "symbol": "PTEK"
+    }
+  },
+  {
+    "chainId": 88800,
+    "name": "ZKasino Mainnet",
+    "shortName": "ZKasino",
+    "nativeCurrency": {
+      "symbol": "ZKAS"
+    }
+  },
+  {
+    "chainId": 88811,
+    "name": "Unit Zero Mainnet",
+    "shortName": "unit0-mainnet",
+    "nativeCurrency": {
+      "symbol": "UNIT0"
+    }
+  },
+  {
+    "chainId": 88817,
+    "name": "Unit Zero Testnet",
+    "shortName": "unit0-testnet",
+    "nativeCurrency": {
+      "symbol": "UNIT0"
+    }
+  },
+  {
+    "chainId": 88819,
+    "name": "Unit Zero Stagenet",
+    "shortName": "unit0-stagenet",
+    "nativeCurrency": {
+      "symbol": "UNIT0"
+    }
+  },
+  {
+    "chainId": 88866,
+    "name": "Matr1x Testnet",
+    "shortName": "Matr1x-Testnet",
+    "nativeCurrency": {
+      "symbol": "MAX"
+    }
+  },
+  {
+    "chainId": 88880,
+    "name": "Chiliz Scoville Testnet",
+    "shortName": "chz",
+    "nativeCurrency": {
+      "symbol": "CHZ"
+    }
+  },
+  {
+    "chainId": 88882,
+    "name": "Chiliz Spicy Testnet",
+    "shortName": "chzspicy",
+    "nativeCurrency": {
+      "symbol": "CHZ"
+    }
+  },
+  {
+    "chainId": 88888,
+    "name": "Chiliz Chain Mainnet",
+    "shortName": "chzmainnet",
+    "nativeCurrency": {
+      "symbol": "CHZ"
+    }
+  },
+  {
+    "chainId": 88899,
+    "name": "Unite",
+    "shortName": "unite",
+    "nativeCurrency": {
+      "symbol": "UNITE"
+    }
+  },
+  {
+    "chainId": 89001,
+    "name": "JAMIROQU.AI",
+    "shortName": "insan",
+    "nativeCurrency": {
+      "symbol": "INSAN"
+    }
+  },
+  {
+    "chainId": 90001,
+    "name": "Pundi AIFX Omnilayer Testnet",
+    "shortName": "dhobyghaut",
+    "nativeCurrency": {
+      "symbol": "PUNDAI"
+    }
+  },
+  {
+    "chainId": 90002,
+    "name": "UBIT SMARTCHAIN MAINNET",
+    "shortName": "UBITSCAN",
+    "nativeCurrency": {
+      "symbol": "USC"
+    }
+  },
+  {
+    "chainId": 90210,
+    "name": "Beverly Hills",
+    "shortName": "bvhl",
+    "nativeCurrency": {
+      "symbol": "BVE"
+    }
+  },
+  {
+    "chainId": 90354,
+    "name": "Camp Testnet",
+    "shortName": "camp",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 91002,
+    "name": "Nautilus Trition Chain",
+    "shortName": "NAUT",
+    "nativeCurrency": {
+      "symbol": "tZBC"
+    }
+  },
+  {
+    "chainId": 91111,
+    "name": "Henez Chain Mainnet",
+    "shortName": "henez",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 91120,
+    "name": "MetaDAP Enterprise Mainnet",
+    "shortName": "MetaDAP",
+    "nativeCurrency": {
+      "symbol": "DAP"
+    }
+  },
+  {
+    "chainId": 91342,
+    "name": "GIWA Sepolia Testnet",
+    "shortName": "giwasepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 91715,
+    "name": "Combo Testnet",
+    "shortName": "combo-testnet",
+    "nativeCurrency": {
+      "symbol": "tcBNB"
+    }
+  },
+  {
+    "chainId": 92001,
+    "name": "Lambda Testnet",
+    "shortName": "lambda-testnet",
+    "nativeCurrency": {
+      "symbol": "LAMB"
+    }
+  },
+  {
+    "chainId": 92278,
+    "name": "Miracle Chain",
+    "shortName": "MIRACLE",
+    "nativeCurrency": {
+      "symbol": "MPT"
+    }
+  },
+  {
+    "chainId": 93572,
+    "name": "LiquidLayer Testnet",
+    "shortName": "tLILA",
+    "nativeCurrency": {
+      "symbol": "LILA"
+    }
+  },
+  {
+    "chainId": 93747,
+    "name": "StratoVM Testnet",
+    "shortName": "stratovm",
+    "nativeCurrency": {
+      "symbol": "SVM"
+    }
+  },
+  {
+    "chainId": 94524,
+    "name": "XCHAIN",
+    "shortName": "xc",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 95432,
+    "name": "SRICHAIN",
+    "shortName": "sriscan",
+    "nativeCurrency": {
+      "symbol": "SRIX"
+    }
+  },
+  {
+    "chainId": 96368,
+    "name": "Lux Testnet",
+    "shortName": "tlux",
+    "nativeCurrency": {
+      "symbol": "tLUX"
+    }
+  },
+  {
+    "chainId": 96369,
+    "name": "Lux Mainnet",
+    "shortName": "lux",
+    "nativeCurrency": {
+      "symbol": "LUX"
+    }
+  },
+  {
+    "chainId": 96370,
+    "name": "Lumoz Chain Mainnet",
+    "shortName": "Lumoz-Chain-Mainnet",
+    "nativeCurrency": {
+      "symbol": "MOZ"
+    }
+  },
+  {
+    "chainId": 96371,
+    "name": "Wonder Testnet",
+    "shortName": "wndr",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 96970,
+    "name": "Mantis Testnet (Hexapod)",
+    "shortName": "mantis",
+    "nativeCurrency": {
+      "symbol": "MANTIS"
+    }
+  },
+  {
+    "chainId": 97053,
+    "name": "Tetron Testnet Smart Chain",
+    "shortName": "TetronTestnet",
+    "nativeCurrency": {
+      "symbol": "TSC"
+    }
+  },
+  {
+    "chainId": 97055,
+    "name": "Tetron Smart Chain",
+    "shortName": "Tetron",
+    "nativeCurrency": {
+      "symbol": "TSC"
+    }
+  },
+  {
+    "chainId": 97288,
+    "name": "Boba BNB Mainnet Old",
+    "shortName": "BobaBnbOld",
+    "nativeCurrency": {
+      "symbol": "BOBA"
+    }
+  },
+  {
+    "chainId": 97435,
+    "name": "SlingShot Testnet",
+    "shortName": "sling",
+    "nativeCurrency": {
+      "symbol": "SLINGT"
+    }
+  },
+  {
+    "chainId": 97453,
+    "name": "Sidra Chain",
+    "shortName": "sidra",
+    "nativeCurrency": {
+      "symbol": "SDA"
+    }
+  },
+  {
+    "chainId": 97476,
+    "name": "Doma Testnet",
+    "shortName": "doma-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 97477,
+    "name": "Doma",
+    "shortName": "doma",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 97531,
+    "name": "Green Chain Testnet",
+    "shortName": "greenchain",
+    "nativeCurrency": {
+      "symbol": "GREEN"
+    }
+  },
+  {
+    "chainId": 97741,
+    "name": "Pepe Unchained V2",
+    "shortName": "pepuv2",
+    "nativeCurrency": {
+      "symbol": "PEPU"
+    }
+  },
+  {
+    "chainId": 97766,
+    "name": "MetaBenz CHAIN",
+    "shortName": "metabenzscan",
+    "nativeCurrency": {
+      "symbol": "MBC"
+    }
+  },
+  {
+    "chainId": 97970,
+    "name": "OptimusZ7 Testnet",
+    "shortName": "OZ7t",
+    "nativeCurrency": {
+      "symbol": "OZ7"
+    }
+  },
+  {
+    "chainId": 98864,
+    "name": "Plume Devnet (Legacy)",
+    "shortName": "plume-devnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 98865,
+    "name": "Plume (Legacy)",
+    "shortName": "plume",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 98866,
+    "name": "Plume Mainnet",
+    "shortName": "plume-mainnet",
+    "nativeCurrency": {
+      "symbol": "PLUME"
+    }
+  },
+  {
+    "chainId": 98867,
+    "name": "Plume Testnet",
+    "shortName": "plume-testnet",
+    "nativeCurrency": {
+      "symbol": "PLUME"
+    }
+  },
+  {
+    "chainId": 98875,
+    "name": "Nillion Network",
+    "shortName": "nil",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 98881,
+    "name": "Ebi Chain",
+    "shortName": "ebi",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 98964,
+    "name": "Pay1 Network",
+    "shortName": "pay1",
+    "nativeCurrency": {
+      "symbol": "Pay1"
+    }
+  },
+  {
+    "chainId": 98985,
+    "name": "Superposition Testnet",
+    "shortName": "superposition-testnet",
+    "nativeCurrency": {
+      "symbol": "SPN"
+    }
+  },
+  {
+    "chainId": 99099,
+    "name": "eLiberty Testnet",
+    "shortName": "ELt",
+    "nativeCurrency": {
+      "symbol": "$EL"
+    }
+  },
+  {
+    "chainId": 99110,
+    "name": "Dorsen Chain",
+    "shortName": "dorsen-test",
+    "nativeCurrency": {
+      "symbol": "DC"
+    }
+  },
+  {
+    "chainId": 99119,
+    "name": "Dorsen Testnet",
+    "shortName": "dorsen-main",
+    "nativeCurrency": {
+      "symbol": "tDC"
+    }
+  },
+  {
+    "chainId": 99876,
+    "name": "Edge Matrix Chain Testnet",
+    "shortName": "EMCTestnet",
+    "nativeCurrency": {
+      "symbol": "EMC"
+    }
+  },
+  {
+    "chainId": 99879,
+    "name": "Edge Matrix Chain Sepolia",
+    "shortName": "EMCSepolia",
+    "nativeCurrency": {
+      "symbol": "EMC"
+    }
+  },
+  {
+    "chainId": 99998,
+    "name": "UB Smart Chain(testnet)",
+    "shortName": "usctest",
+    "nativeCurrency": {
+      "symbol": "UBC"
+    }
+  },
+  {
+    "chainId": 99999,
+    "name": "UB Smart Chain",
+    "shortName": "usc",
+    "nativeCurrency": {
+      "symbol": "UBC"
+    }
+  },
+  {
+    "chainId": 100000,
+    "name": "QuarkChain Mainnet Root",
+    "shortName": "qkc-r",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100001,
+    "name": "QuarkChain Mainnet Shard 0",
+    "shortName": "qkc-s0",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100002,
+    "name": "QuarkChain Mainnet Shard 1",
+    "shortName": "qkc-s1",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100003,
+    "name": "QuarkChain Mainnet Shard 2",
+    "shortName": "qkc-s2",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100004,
+    "name": "QuarkChain Mainnet Shard 3",
+    "shortName": "qkc-s3",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100005,
+    "name": "QuarkChain Mainnet Shard 4",
+    "shortName": "qkc-s4",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100006,
+    "name": "QuarkChain Mainnet Shard 5",
+    "shortName": "qkc-s5",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100007,
+    "name": "QuarkChain Mainnet Shard 6",
+    "shortName": "qkc-s6",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100008,
+    "name": "QuarkChain Mainnet Shard 7",
+    "shortName": "qkc-s7",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100009,
+    "name": "VeChain",
+    "shortName": "vechain",
+    "nativeCurrency": {
+      "symbol": "VET"
+    }
+  },
+  {
+    "chainId": 100010,
+    "name": "VeChain Testnet",
+    "shortName": "vechain-testnet",
+    "nativeCurrency": {
+      "symbol": "VET"
+    }
+  },
+  {
+    "chainId": 100011,
+    "name": "QuarkChain L2 Mainnet",
+    "shortName": "qkc-l2",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 100021,
+    "name": "Sova",
+    "shortName": "sova",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 100100,
+    "name": "Deprecated CHI",
+    "shortName": "chi1",
+    "nativeCurrency": {
+      "symbol": "xDAI"
+    }
+  },
+  {
+    "chainId": 100501,
+    "name": "DeInfra Mainnet",
+    "shortName": "deinfra-mainnet",
+    "nativeCurrency": {
+      "symbol": "SK"
+    }
+  },
+  {
+    "chainId": 100610,
+    "name": "Monsoon ",
+    "shortName": "monsoon",
+    "nativeCurrency": {
+      "symbol": "RDP"
+    }
+  },
+  {
+    "chainId": 100611,
+    "name": "Monsoon Alpha",
+    "shortName": "monsoon-alpha",
+    "nativeCurrency": {
+      "symbol": "RDL"
+    }
+  },
+  {
+    "chainId": 101003,
+    "name": "Socotra JUNE-Chain",
+    "shortName": "Socotra-JUNE",
+    "nativeCurrency": {
+      "symbol": "JUNE"
+    }
+  },
+  {
+    "chainId": 101010,
+    "name": "Global Trust Network",
+    "shortName": "stabilityprotocol",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 101088,
+    "name": "Xitcoin",
+    "shortName": "Xitcoin",
+    "nativeCurrency": {
+      "symbol": "$XTC"
+    }
+  },
+  {
+    "chainId": 102030,
+    "name": "Creditcoin",
+    "shortName": "ctc",
+    "nativeCurrency": {
+      "symbol": "CTC"
+    }
+  },
+  {
+    "chainId": 102031,
+    "name": "Creditcoin Testnet",
+    "shortName": "ctctest",
+    "nativeCurrency": {
+      "symbol": "tCTC"
+    }
+  },
+  {
+    "chainId": 102032,
+    "name": "Creditcoin Devnet",
+    "shortName": "ctcdev",
+    "nativeCurrency": {
+      "symbol": "devCTC"
+    }
+  },
+  {
+    "chainId": 103090,
+    "name": "Crystaleum",
+    "shortName": "CRFI",
+    "nativeCurrency": {
+      "symbol": "◈"
+    }
+  },
+  {
+    "chainId": 103454,
+    "name": "Masa Testnet",
+    "shortName": "masatest",
+    "nativeCurrency": {
+      "symbol": "MASA"
+    }
+  },
+  {
+    "chainId": 104566,
+    "name": "KaspaClassic Mainnet",
+    "shortName": "cas",
+    "nativeCurrency": {
+      "symbol": "CAS"
+    }
+  },
+  {
+    "chainId": 105105,
+    "name": "Xertra Mainnet",
+    "shortName": "xertra",
+    "nativeCurrency": {
+      "symbol": "STRAX"
+    }
+  },
+  {
+    "chainId": 105363,
+    "name": "Lumoz Chain Testnet",
+    "shortName": "Lumoz-Chain-Testnet",
+    "nativeCurrency": {
+      "symbol": "MOZ"
+    }
+  },
+  {
+    "chainId": 108801,
+    "name": "BROChain Mainnet",
+    "shortName": "bro",
+    "nativeCurrency": {
+      "symbol": "BRO"
+    }
+  },
+  {
+    "chainId": 110000,
+    "name": "QuarkChain Devnet Root",
+    "shortName": "qkc-d-r",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110001,
+    "name": "QuarkChain Devnet Shard 0",
+    "shortName": "qkc-d-s0",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110002,
+    "name": "QuarkChain Devnet Shard 1",
+    "shortName": "qkc-d-s1",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110003,
+    "name": "QuarkChain Devnet Shard 2",
+    "shortName": "qkc-d-s2",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110004,
+    "name": "QuarkChain Devnet Shard 3",
+    "shortName": "qkc-d-s3",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110005,
+    "name": "QuarkChain Devnet Shard 4",
+    "shortName": "qkc-d-s4",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110006,
+    "name": "QuarkChain Devnet Shard 5",
+    "shortName": "qkc-d-s5",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110007,
+    "name": "QuarkChain Devnet Shard 6",
+    "shortName": "qkc-d-s6",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110008,
+    "name": "QuarkChain Devnet Shard 7",
+    "shortName": "qkc-d-s7",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110011,
+    "name": "QuarkChain L2 Testnet",
+    "shortName": "qkc-l2-t",
+    "nativeCurrency": {
+      "symbol": "QKC"
+    }
+  },
+  {
+    "chainId": 110110,
+    "name": "Mars Credit",
+    "shortName": "mars",
+    "nativeCurrency": {
+      "symbol": "MARS"
+    }
+  },
+  {
+    "chainId": 111000,
+    "name": "Siberium Test Network",
+    "shortName": "testsbr",
+    "nativeCurrency": {
+      "symbol": "SIBR"
+    }
+  },
+  {
+    "chainId": 111111,
+    "name": "Siberium Network",
+    "shortName": "sbr",
+    "nativeCurrency": {
+      "symbol": "SIBR"
+    }
+  },
+  {
+    "chainId": 111188,
+    "name": "re.al",
+    "shortName": "re-al",
+    "nativeCurrency": {
+      "symbol": "reETH"
+    }
+  },
+  {
+    "chainId": 111451,
+    "name": "eGold Chain Testnet",
+    "shortName": "egoldchaint",
+    "nativeCurrency": {
+      "symbol": "XAU"
+    }
+  },
+  {
+    "chainId": 112358,
+    "name": "Metachain One Mainnet",
+    "shortName": "metao",
+    "nativeCurrency": {
+      "symbol": "METAO"
+    }
+  },
+  {
+    "chainId": 119139,
+    "name": "MetaDAP Enterprise Testnet",
+    "shortName": "MetaDAP-T",
+    "nativeCurrency": {
+      "symbol": "DAP"
+    }
+  },
+  {
+    "chainId": 120893,
+    "name": "Sova Sepolia Testnet",
+    "shortName": "sovasep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 121212,
+    "name": "Rome Devnet Esquiline",
+    "shortName": "rome-devnet-esquiline",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 121213,
+    "name": "Rome Devnet Subura",
+    "shortName": "rome-devnet-subura",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 121214,
+    "name": "Rome Testnet Martius",
+    "shortName": "rome-testnet-martius",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 121215,
+    "name": "Rome Testnet Caelian",
+    "shortName": "rome-testnet-caelian",
+    "nativeCurrency": {
+      "symbol": "RSOL"
+    }
+  },
+  {
+    "chainId": 121224,
+    "name": "Fushuma",
+    "shortName": "fushuma",
+    "nativeCurrency": {
+      "symbol": "FUMA"
+    }
+  },
+  {
+    "chainId": 121525,
+    "name": "Ethernova Mainnet",
+    "shortName": "ethnova",
+    "nativeCurrency": {
+      "symbol": "NOVA"
+    }
+  },
+  {
+    "chainId": 123321,
+    "name": "Gemchain",
+    "shortName": "gemchain",
+    "nativeCurrency": {
+      "symbol": "GEM"
+    }
+  },
+  {
+    "chainId": 123456,
+    "name": "ADIL Devnet",
+    "shortName": "dadil",
+    "nativeCurrency": {
+      "symbol": "ADIL"
+    }
+  },
+  {
+    "chainId": 124832,
+    "name": "Mitosis Testnet",
+    "shortName": "mitosis-testnet",
+    "nativeCurrency": {
+      "symbol": "MITO"
+    }
+  },
+  {
+    "chainId": 127823,
+    "name": "Etherlink Shadownet Testnet",
+    "shortName": "etlst",
+    "nativeCurrency": {
+      "symbol": "XTZ"
+    }
+  },
+  {
+    "chainId": 128123,
+    "name": "Etherlink Ghostnet Testnet",
+    "shortName": "etlt",
+    "nativeCurrency": {
+      "symbol": "XTZ"
+    }
+  },
+  {
+    "chainId": 129399,
+    "name": "Tatara Testnet",
+    "shortName": "Tatara",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 131313,
+    "name": "Odyssey Chain (Testnet)",
+    "shortName": "DIONE",
+    "nativeCurrency": {
+      "symbol": "DIONE"
+    }
+  },
+  {
+    "chainId": 131419,
+    "name": "ETND Chain Mainnets",
+    "shortName": "ETND",
+    "nativeCurrency": {
+      "symbol": "ETND"
+    }
+  },
+  {
+    "chainId": 132902,
+    "name": "Form Testnet",
+    "shortName": "formtestnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 141319,
+    "name": "MagApe Testnet",
+    "shortName": "mag",
+    "nativeCurrency": {
+      "symbol": "MAG"
+    }
+  },
+  {
+    "chainId": 141491,
+    "name": "Bitharvest Chain Testnet",
+    "shortName": "BitharvestTestnet",
+    "nativeCurrency": {
+      "symbol": "BTH"
+    }
+  },
+  {
+    "chainId": 142857,
+    "name": "ICPlaza Mainnet",
+    "shortName": "ICPlaza",
+    "nativeCurrency": {
+      "symbol": "ict"
+    }
+  },
+  {
+    "chainId": 153153,
+    "name": "Odyssey Chain Mainnet",
+    "shortName": "Odyssey",
+    "nativeCurrency": {
+      "symbol": "DIONE"
+    }
+  },
+  {
+    "chainId": 153871,
+    "name": "Orqus Testnet",
+    "shortName": "orqus-testnet",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 158245,
+    "name": "CryptoX",
+    "shortName": "cryptox",
+    "nativeCurrency": {
+      "symbol": "XCOIN"
+    }
+  },
+  {
+    "chainId": 158345,
+    "name": "XCOIN",
+    "shortName": "xcoin",
+    "nativeCurrency": {
+      "symbol": "XCOIN"
+    }
+  },
+  {
+    "chainId": 161201,
+    "name": "OpenLedger Testnet",
+    "shortName": "openledgertest",
+    "nativeCurrency": {
+      "symbol": "OPN"
+    }
+  },
+  {
+    "chainId": 161212,
+    "name": "PlayFi Mainnet",
+    "shortName": "playfi",
+    "nativeCurrency": {
+      "symbol": "PLAY"
+    }
+  },
+  {
+    "chainId": 161803,
+    "name": "Eventum Mainnet",
+    "shortName": "Eventum",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 165279,
+    "name": "Eclat Mainnet",
+    "shortName": "ECLAT",
+    "nativeCurrency": {
+      "symbol": "ECLAT"
+    }
+  },
+  {
+    "chainId": 167000,
+    "name": "Taiko",
+    "shortName": "tko-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167004,
+    "name": "Taiko (Alpha-2 Testnet)",
+    "shortName": "taiko-a2",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167005,
+    "name": "Taiko Grimsvotn L2",
+    "shortName": "taiko-l2",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167006,
+    "name": "Taiko Eldfell L3",
+    "shortName": "taiko-l3",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167007,
+    "name": "Taiko Jolnir L2",
+    "shortName": "tko-jolnir",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167008,
+    "name": "Taiko Katla L2",
+    "shortName": "tko-katla",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167009,
+    "name": "Taiko Hekla (deprecated)",
+    "shortName": "tko-hekla",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 167013,
+    "name": "Taiko Hoodi",
+    "shortName": "tko-hoodi",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 168168,
+    "name": "Zchains",
+    "shortName": "zchains",
+    "nativeCurrency": {
+      "symbol": "ZCD"
+    }
+  },
+  {
+    "chainId": 168169,
+    "name": "MUD Chain",
+    "shortName": "MUD",
+    "nativeCurrency": {
+      "symbol": "MUD"
+    }
+  },
+  {
+    "chainId": 171000,
+    "name": "Fair Testnet",
+    "shortName": "fairt",
+    "nativeCurrency": {
+      "symbol": "FAIR"
+    }
+  },
+  {
+    "chainId": 171717,
+    "name": "Wadzchain Mainnet",
+    "shortName": "wadzchain-mainnet",
+    "nativeCurrency": {
+      "symbol": "WCO"
+    }
+  },
+  {
+    "chainId": 175177,
+    "name": "Chronicle - Lit Protocol Testnet",
+    "shortName": "lpc",
+    "nativeCurrency": {
+      "symbol": "tstLIT"
+    }
+  },
+  {
+    "chainId": 175188,
+    "name": "Chronicle Yellowstone - Lit Protocol Testnet",
+    "shortName": "lpy",
+    "nativeCurrency": {
+      "symbol": "tstLPX"
+    }
+  },
+  {
+    "chainId": 175190,
+    "name": "Chronicle Loa - Lit Protocol Testnet",
+    "shortName": "lpl",
+    "nativeCurrency": {
+      "symbol": "tLit"
+    }
+  },
+  {
+    "chainId": 175200,
+    "name": "Lit Chain Mainnet",
+    "shortName": "lit",
+    "nativeCurrency": {
+      "symbol": "LITKEY"
+    }
+  },
+  {
+    "chainId": 177155,
+    "name": "mfenx",
+    "shortName": "mfenx",
+    "nativeCurrency": {
+      "symbol": "JULIAN"
+    }
+  },
+  {
+    "chainId": 179170,
+    "name": "Transparency Solution",
+    "shortName": "clts",
+    "nativeCurrency": {
+      "symbol": "CLT"
+    }
+  },
+  {
+    "chainId": 181228,
+    "name": "HPP Sepolia Testnet",
+    "shortName": "hpp-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 188710,
+    "name": "Bitica Chain Mainnet",
+    "shortName": "bdcc",
+    "nativeCurrency": {
+      "symbol": "BDCC"
+    }
+  },
+  {
+    "chainId": 188881,
+    "name": "Condor Test Network",
+    "shortName": "condor",
+    "nativeCurrency": {
+      "symbol": "CONDOR"
+    }
+  },
+  {
+    "chainId": 190415,
+    "name": "HPP Mainnet",
+    "shortName": "hpp-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 191919,
+    "name": "Altblockscan Mainnet",
+    "shortName": "altb",
+    "nativeCurrency": {
+      "symbol": "ALTB"
+    }
+  },
+  {
+    "chainId": 192940,
+    "name": "Mind Network Testnet",
+    "shortName": "fhet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 193939,
+    "name": "R0AR Chain",
+    "shortName": "R0AR-Chain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 198989,
+    "name": "Lydia Coin Testnet",
+    "shortName": "lydia-testnet",
+    "nativeCurrency": {
+      "symbol": "BSW"
+    }
+  },
+  {
+    "chainId": 199991,
+    "name": "MAZZE Testnet",
+    "shortName": "MAZZE",
+    "nativeCurrency": {
+      "symbol": "MAZZE"
+    }
+  },
+  {
+    "chainId": 200000,
+    "name": "xFair.AI Testnet",
+    "shortName": "fait",
+    "nativeCurrency": {
+      "symbol": "FAI"
+    }
+  },
+  {
+    "chainId": 200024,
+    "name": "NitroGraph Testnet",
+    "shortName": "nitro-testnet",
+    "nativeCurrency": {
+      "symbol": "NOS"
+    }
+  },
+  {
+    "chainId": 200101,
+    "name": "Milkomeda C1 Testnet",
+    "shortName": "milkTAda",
+    "nativeCurrency": {
+      "symbol": "mTAda"
+    }
+  },
+  {
+    "chainId": 200200,
+    "name": "Zoo Mainnet",
+    "shortName": "zoo",
+    "nativeCurrency": {
+      "symbol": "ZOO"
+    }
+  },
+  {
+    "chainId": 200202,
+    "name": "Milkomeda A1 Testnet",
+    "shortName": "milkTAlgo",
+    "nativeCurrency": {
+      "symbol": "mTAlgo"
+    }
+  },
+  {
+    "chainId": 200625,
+    "name": "Akroma",
+    "shortName": "aka",
+    "nativeCurrency": {
+      "symbol": "AKA"
+    }
+  },
+  {
+    "chainId": 200810,
+    "name": "Bitlayer Testnet",
+    "shortName": "btrt",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 200901,
+    "name": "Bitlayer Mainnet",
+    "shortName": "btr",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 201018,
+    "name": "Alaya Mainnet",
+    "shortName": "alaya",
+    "nativeCurrency": {
+      "symbol": "atp"
+    }
+  },
+  {
+    "chainId": 201030,
+    "name": "Alaya Dev Testnet",
+    "shortName": "alayadev",
+    "nativeCurrency": {
+      "symbol": "atp"
+    }
+  },
+  {
+    "chainId": 201804,
+    "name": "Mythical Chain",
+    "shortName": "myth",
+    "nativeCurrency": {
+      "symbol": "MYTH"
+    }
+  },
+  {
+    "chainId": 202020,
+    "name": "Decimal Smart Chain Testnet",
+    "shortName": "tDSC",
+    "nativeCurrency": {
+      "symbol": "tDEL"
+    }
+  },
+  {
+    "chainId": 202105,
+    "name": "DuckChain Testnet",
+    "shortName": "Duck-Chain-Testnet",
+    "nativeCurrency": {
+      "symbol": "TON"
+    }
+  },
+  {
+    "chainId": 202202,
+    "name": "Bethel Sydney",
+    "shortName": "bethel-sydney",
+    "nativeCurrency": {
+      "symbol": "BECX"
+    }
+  },
+  {
+    "chainId": 202209,
+    "name": "Alterscope",
+    "shortName": "Alterscope",
+    "nativeCurrency": {
+      "symbol": "RISK"
+    }
+  },
+  {
+    "chainId": 202212,
+    "name": "X1 Devnet",
+    "shortName": "x1-devnet",
+    "nativeCurrency": {
+      "symbol": "XN"
+    }
+  },
+  {
+    "chainId": 202401,
+    "name": "YMTECH-BESU Testnet",
+    "shortName": "YMTECH-BESU",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 202424,
+    "name": "Blockfit",
+    "shortName": "Blockfit",
+    "nativeCurrency": {
+      "symbol": "BFIT"
+    }
+  },
+  {
+    "chainId": 202599,
+    "name": "JuChain Testnet",
+    "shortName": "ju-test",
+    "nativeCurrency": {
+      "symbol": "JU"
+    }
+  },
+  {
+    "chainId": 202601,
+    "name": "Ronin Saigon Testnet",
+    "shortName": "ronin-saigon",
+    "nativeCurrency": {
+      "symbol": "RON"
+    }
+  },
+  {
+    "chainId": 202624,
+    "name": "Jellie",
+    "shortName": "twl-jellie",
+    "nativeCurrency": {
+      "symbol": "TWL"
+    }
+  },
+  {
+    "chainId": 204005,
+    "name": "X1 Network",
+    "shortName": "x1-testnet",
+    "nativeCurrency": {
+      "symbol": "XN"
+    }
+  },
+  {
+    "chainId": 205205,
+    "name": "Auroria Testnet",
+    "shortName": "auroria",
+    "nativeCurrency": {
+      "symbol": "tSTRAX"
+    }
+  },
+  {
+    "chainId": 210000,
+    "name": "JuChain Mainnet",
+    "shortName": "ju",
+    "nativeCurrency": {
+      "symbol": "JU"
+    }
+  },
+  {
+    "chainId": 210049,
+    "name": "GitAGI Atlas Testnet",
+    "shortName": "atlas",
+    "nativeCurrency": {
+      "symbol": "tGAGI"
+    }
+  },
+  {
+    "chainId": 210209,
+    "name": "Sorian",
+    "shortName": "sorian",
+    "nativeCurrency": {
+      "symbol": "SOR"
+    }
+  },
+  {
+    "chainId": 210210,
+    "name": "Sorian Testnet",
+    "shortName": "sorianTestnet",
+    "nativeCurrency": {
+      "symbol": "tSOR"
+    }
+  },
+  {
+    "chainId": 210425,
+    "name": "PlatON Mainnet",
+    "shortName": "platon",
+    "nativeCurrency": {
+      "symbol": "lat"
+    }
+  },
+  {
+    "chainId": 212013,
+    "name": "Heima",
+    "shortName": "heima",
+    "nativeCurrency": {
+      "symbol": "HEI"
+    }
+  },
+  {
+    "chainId": 220315,
+    "name": "Mas Mainnet",
+    "shortName": "mas",
+    "nativeCurrency": {
+      "symbol": "MAS"
+    }
+  },
+  {
+    "chainId": 221230,
+    "name": "Reapchain Mainnet",
+    "shortName": "reap",
+    "nativeCurrency": {
+      "symbol": "REAP"
+    }
+  },
+  {
+    "chainId": 221231,
+    "name": "Reapchain Testnet",
+    "shortName": "reap-testnet",
+    "nativeCurrency": {
+      "symbol": "tREAP"
+    }
+  },
+  {
+    "chainId": 222222,
+    "name": "Hydration",
+    "shortName": "hdx",
+    "nativeCurrency": {
+      "symbol": "WETH"
+    }
+  },
+  {
+    "chainId": 222555,
+    "name": "DeepL Mainnet",
+    "shortName": "deepl",
+    "nativeCurrency": {
+      "symbol": "DEEPL"
+    }
+  },
+  {
+    "chainId": 222666,
+    "name": "DeepL Testnet",
+    "shortName": "tdeepl",
+    "nativeCurrency": {
+      "symbol": "DEEPL"
+    }
+  },
+  {
+    "chainId": 223344,
+    "name": "B20 Testnet",
+    "shortName": "B20",
+    "nativeCurrency": {
+      "symbol": "TBOC"
+    }
+  },
+  {
+    "chainId": 224168,
+    "name": "Taf ECO Chain Mainnet",
+    "shortName": "TAFECO",
+    "nativeCurrency": {
+      "symbol": "TAFECO"
+    }
+  },
+  {
+    "chainId": 224400,
+    "name": "CONET Mainnet",
+    "shortName": "conet-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 224422,
+    "name": "CONET Sebolia Testnet",
+    "shortName": "conet-sebolia",
+    "nativeCurrency": {
+      "symbol": "CONET"
+    }
+  },
+  {
+    "chainId": 224433,
+    "name": "CONET Cancun",
+    "shortName": "conet-cancun",
+    "nativeCurrency": {
+      "symbol": "CONET"
+    }
+  },
+  {
+    "chainId": 229772,
+    "name": "Abyss Protocol",
+    "shortName": "abyss",
+    "nativeCurrency": {
+      "symbol": "aETH"
+    }
+  },
+  {
+    "chainId": 230315,
+    "name": "HashKey Chain Testnet(discard)",
+    "shortName": "hsktest",
+    "nativeCurrency": {
+      "symbol": "tHSK"
+    }
+  },
+  {
+    "chainId": 234666,
+    "name": "Haymo Testnet",
+    "shortName": "hym",
+    "nativeCurrency": {
+      "symbol": "HYM"
+    }
+  },
+  {
+    "chainId": 235711,
+    "name": "Universe Testnet",
+    "shortName": "unitestnet",
+    "nativeCurrency": {
+      "symbol": "UNI"
+    }
+  },
+  {
+    "chainId": 240240,
+    "name": "Studio Testnet",
+    "shortName": "sto",
+    "nativeCurrency": {
+      "symbol": "STO"
+    }
+  },
+  {
+    "chainId": 240241,
+    "name": "Studio Blockchain Mainnet",
+    "shortName": "stom",
+    "nativeCurrency": {
+      "symbol": "STO"
+    }
+  },
+  {
+    "chainId": 240515,
+    "name": "Orange Chain Testnet",
+    "shortName": "Orange-Chain-Testnet",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 241120,
+    "name": "Anomaly Andromeda Testnet",
+    "shortName": "anomaly-andromeda-testnet",
+    "nativeCurrency": {
+      "symbol": "tNOM"
+    }
+  },
+  {
+    "chainId": 246529,
+    "name": "ARTIS sigma1",
+    "shortName": "ats",
+    "nativeCurrency": {
+      "symbol": "ATS"
+    }
+  },
+  {
+    "chainId": 246785,
+    "name": "ARTIS Testnet tau1",
+    "shortName": "atstau",
+    "nativeCurrency": {
+      "symbol": "tATS"
+    }
+  },
+  {
+    "chainId": 247253,
+    "name": "Saakuru Testnet",
+    "shortName": "saakuru-testnet",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 250210,
+    "name": "PlasticHero",
+    "shortName": "pth",
+    "nativeCurrency": {
+      "symbol": "PTH"
+    }
+  },
+  {
+    "chainId": 250611,
+    "name": "StreamChain",
+    "shortName": "stc",
+    "nativeCurrency": {
+      "symbol": "STC"
+    }
+  },
+  {
+    "chainId": 252525,
+    "name": "CELESTIUM Network Testnet",
+    "shortName": "tclt",
+    "nativeCurrency": {
+      "symbol": "tCLT"
+    }
+  },
+  {
+    "chainId": 256256,
+    "name": "CMP-Mainnet",
+    "shortName": "cmp-mainnet",
+    "nativeCurrency": {
+      "symbol": "CMP"
+    }
+  },
+  {
+    "chainId": 258432,
+    "name": "Althea L1 Mainnet",
+    "shortName": "ALTHEA",
+    "nativeCurrency": {
+      "symbol": "ALTHEA"
+    }
+  },
+  {
+    "chainId": 262371,
+    "name": "Eclat Testnet",
+    "shortName": "tECLAT",
+    "nativeCurrency": {
+      "symbol": "ECLAT"
+    }
+  },
+  {
+    "chainId": 266256,
+    "name": "Gear Zero Network Testnet",
+    "shortName": "gz-testnet",
+    "nativeCurrency": {
+      "symbol": "GZN"
+    }
+  },
+  {
+    "chainId": 271271,
+    "name": "EgonCoin Testnet",
+    "shortName": "EGONt",
+    "nativeCurrency": {
+      "symbol": "EGON"
+    }
+  },
+  {
+    "chainId": 271828,
+    "name": "Datachain Rope",
+    "shortName": "datachain",
+    "nativeCurrency": {
+      "symbol": "FAT"
+    }
+  },
+  {
+    "chainId": 272247,
+    "name": "Nxy Area 51",
+    "shortName": "nxytest",
+    "nativeCurrency": {
+      "symbol": "NXY"
+    }
+  },
+  {
+    "chainId": 272520,
+    "name": "Nxy Oasis",
+    "shortName": "nxy",
+    "nativeCurrency": {
+      "symbol": "NXY"
+    }
+  },
+  {
+    "chainId": 281121,
+    "name": "Social Smart Chain Mainnet",
+    "shortName": "SoChain",
+    "nativeCurrency": {
+      "symbol": "$OC"
+    }
+  },
+  {
+    "chainId": 281123,
+    "name": "Athene Parthenon",
+    "shortName": "athene-parthenon",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 282828,
+    "name": "Zillion Sepolia Testnet",
+    "shortName": "zillsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 292003,
+    "name": "Cipherem Testnet",
+    "shortName": "CIP",
+    "nativeCurrency": {
+      "symbol": "CIP"
+    }
+  },
+  {
+    "chainId": 309075,
+    "name": "One World Chain Mainnet",
+    "shortName": "OWCTm",
+    "nativeCurrency": {
+      "symbol": "OWCT"
+    }
+  },
+  {
+    "chainId": 313313,
+    "name": "Sahara AI Testnet",
+    "shortName": "saharatest",
+    "nativeCurrency": {
+      "symbol": "SAHARA"
+    }
+  },
+  {
+    "chainId": 314159,
+    "name": "Filecoin - Calibration testnet",
+    "shortName": "filecoin-calibration",
+    "nativeCurrency": {
+      "symbol": "tFIL"
+    }
+  },
+  {
+    "chainId": 322202,
+    "name": "Parex Mainnet",
+    "shortName": "parex",
+    "nativeCurrency": {
+      "symbol": "PRX"
+    }
+  },
+  {
+    "chainId": 323213,
+    "name": "Bloom Genesis Testnet",
+    "shortName": "BGBC-Testnet",
+    "nativeCurrency": {
+      "symbol": "BGBC"
+    }
+  },
+  {
+    "chainId": 323432,
+    "name": "World Mobile Chain Testnet",
+    "shortName": "WMCTEST",
+    "nativeCurrency": {
+      "symbol": "WOMOX"
+    }
+  },
+  {
+    "chainId": 325000,
+    "name": "Camp Network Testnet V2",
+    "shortName": "CampV2",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 327126,
+    "name": "WABA Chain Mainnet",
+    "shortName": "waba",
+    "nativeCurrency": {
+      "symbol": "WABA"
+    }
+  },
+  {
+    "chainId": 328527,
+    "name": "Nal Mainnet",
+    "shortName": "nal",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 330844,
+    "name": "TTcoin Smart Chain Mainnet",
+    "shortName": "tc",
+    "nativeCurrency": {
+      "symbol": "TC"
+    }
+  },
+  {
+    "chainId": 333313,
+    "name": "Bloom Genesis Mainnet",
+    "shortName": "BGBC",
+    "nativeCurrency": {
+      "symbol": "BGBC"
+    }
+  },
+  {
+    "chainId": 333331,
+    "name": "Aves Testnet",
+    "shortName": "avst",
+    "nativeCurrency": {
+      "symbol": "AVST"
+    }
+  },
+  {
+    "chainId": 333333,
+    "name": "Nativ3 Testnet",
+    "shortName": "N3-Test",
+    "nativeCurrency": {
+      "symbol": "USNT"
+    }
+  },
+  {
+    "chainId": 333666,
+    "name": "Oone Chain Testnet",
+    "shortName": "oonetest",
+    "nativeCurrency": {
+      "symbol": "tOONE"
+    }
+  },
+  {
+    "chainId": 333777,
+    "name": "Oone Chain Devnet",
+    "shortName": "oonedev",
+    "nativeCurrency": {
+      "symbol": "tOONE"
+    }
+  },
+  {
+    "chainId": 333888,
+    "name": "Polis Testnet",
+    "shortName": "sparta",
+    "nativeCurrency": {
+      "symbol": "tPOLIS"
+    }
+  },
+  {
+    "chainId": 333999,
+    "name": "Polis Mainnet",
+    "shortName": "olympus",
+    "nativeCurrency": {
+      "symbol": "POLIS"
+    }
+  },
+  {
+    "chainId": 335700,
+    "name": "Scenium",
+    "shortName": "scenium",
+    "nativeCurrency": {
+      "symbol": "SCEN"
+    }
+  },
+  {
+    "chainId": 336655,
+    "name": "UPchain Testnet",
+    "shortName": "UPchain-testnet",
+    "nativeCurrency": {
+      "symbol": "UBTC"
+    }
+  },
+  {
+    "chainId": 336666,
+    "name": "UPchain Mainnet",
+    "shortName": "UPchain-mainnet",
+    "nativeCurrency": {
+      "symbol": "UBTC"
+    }
+  },
+  {
+    "chainId": 355110,
+    "name": "Bitfinity Network Mainnet",
+    "shortName": "bitfinity-mainnet",
+    "nativeCurrency": {
+      "symbol": "BTF"
+    }
+  },
+  {
+    "chainId": 355113,
+    "name": "Bitfinity Network Testnet",
+    "shortName": "bitfinity-testnet",
+    "nativeCurrency": {
+      "symbol": "BTF"
+    }
+  },
+  {
+    "chainId": 360890,
+    "name": "LAVITA Mainnet",
+    "shortName": "lavita-mainnet",
+    "nativeCurrency": {
+      "symbol": "vTFUEL"
+    }
+  },
+  {
+    "chainId": 363636,
+    "name": "Digit Soul Smart Chain 2",
+    "shortName": "DS2",
+    "nativeCurrency": {
+      "symbol": "DGC"
+    }
+  },
+  {
+    "chainId": 369369,
+    "name": "Denergy Network",
+    "shortName": "den-mainnet",
+    "nativeCurrency": {
+      "symbol": "WATT"
+    }
+  },
+  {
+    "chainId": 373737,
+    "name": "HAPchain Testnet",
+    "shortName": "hap-testnet",
+    "nativeCurrency": {
+      "symbol": "HAP"
+    }
+  },
+  {
+    "chainId": 380929,
+    "name": "Silent Data Mainnet",
+    "shortName": "silent-data-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 381185,
+    "name": "Silent Data Testnet",
+    "shortName": "silent-data-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 381931,
+    "name": "Metal C-Chain",
+    "shortName": "metal",
+    "nativeCurrency": {
+      "symbol": "METAL"
+    }
+  },
+  {
+    "chainId": 381932,
+    "name": "Metal Tahoe C-Chain",
+    "shortName": "Tahoe",
+    "nativeCurrency": {
+      "symbol": "METAL"
+    }
+  },
+  {
+    "chainId": 383353,
+    "name": "CheeseChain",
+    "shortName": "CheeseChain",
+    "nativeCurrency": {
+      "symbol": "CHEESE"
+    }
+  },
+  {
+    "chainId": 404040,
+    "name": "Tipboxcoin Mainnet",
+    "shortName": "TPBXm",
+    "nativeCurrency": {
+      "symbol": "TPBX"
+    }
+  },
+  {
+    "chainId": 413413,
+    "name": "AIE Testnet",
+    "shortName": "aie",
+    "nativeCurrency": {
+      "symbol": "AIE"
+    }
+  },
+  {
+    "chainId": 420000,
+    "name": "Infinaeon",
+    "shortName": "Infinaeon",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 420042,
+    "name": "Vector Smart Chain",
+    "shortName": "vsg",
+    "nativeCurrency": {
+      "symbol": "VSG"
+    }
+  },
+  {
+    "chainId": 420420,
+    "name": "Kekchain",
+    "shortName": "KEK",
+    "nativeCurrency": {
+      "symbol": "KEK"
+    }
+  },
+  {
+    "chainId": 420666,
+    "name": "Kekchain (kektest)",
+    "shortName": "tKEK",
+    "nativeCurrency": {
+      "symbol": "tKEK"
+    }
+  },
+  {
+    "chainId": 420692,
+    "name": "Alterium L2 Testnet",
+    "shortName": "alterium",
+    "nativeCurrency": {
+      "symbol": "AltETH"
+    }
+  },
+  {
+    "chainId": 421611,
+    "name": "Arbitrum Rinkeby",
+    "shortName": "arb-rinkeby",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 421613,
+    "name": "Arbitrum Goerli",
+    "shortName": "arb-goerli",
+    "nativeCurrency": {
+      "symbol": "AGOR"
+    }
+  },
+  {
+    "chainId": 421614,
+    "name": "Arbitrum Sepolia",
+    "shortName": "arb-sep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 424242,
+    "name": "Fastex Chain testnet",
+    "shortName": "fastexTestnet",
+    "nativeCurrency": {
+      "symbol": "FTN"
+    }
+  },
+  {
+    "chainId": 431140,
+    "name": "Markr Go",
+    "shortName": "markr-go",
+    "nativeCurrency": {
+      "symbol": "AVAX"
+    }
+  },
+  {
+    "chainId": 432201,
+    "name": "Dexalot Subnet Testnet",
+    "shortName": "dexalot-testnet",
+    "nativeCurrency": {
+      "symbol": "ALOT"
+    }
+  },
+  {
+    "chainId": 432204,
+    "name": "Dexalot Subnet",
+    "shortName": "dexalot",
+    "nativeCurrency": {
+      "symbol": "ALOT"
+    }
+  },
+  {
+    "chainId": 440017,
+    "name": "Graphite Mainnet",
+    "shortName": "graphite",
+    "nativeCurrency": {
+      "symbol": "@G"
+    }
+  },
+  {
+    "chainId": 444444,
+    "name": "Syndr L3 Sepolia",
+    "shortName": "syndr",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 444900,
+    "name": "Weelink Testnet",
+    "shortName": "wlkt",
+    "nativeCurrency": {
+      "symbol": "tWLK"
+    }
+  },
+  {
+    "chainId": 471100,
+    "name": "Patex Sepolia Testnet",
+    "shortName": "psep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 473861,
+    "name": "Ultra Pro Mainnet",
+    "shortName": "ultrapro",
+    "nativeCurrency": {
+      "symbol": "UPRO"
+    }
+  },
+  {
+    "chainId": 474142,
+    "name": "OpenChain Mainnet",
+    "shortName": "oc",
+    "nativeCurrency": {
+      "symbol": "OPC"
+    }
+  },
+  {
+    "chainId": 484752,
+    "name": "World Chain Sepolia Testnet Deprecated",
+    "shortName": "wcsep-dep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 486487,
+    "name": "Gobbl Testnet",
+    "shortName": "gbl-testnet",
+    "nativeCurrency": {
+      "symbol": "GOBBL"
+    }
+  },
+  {
+    "chainId": 490000,
+    "name": "Autonomys Taurus Testnet",
+    "shortName": "ATN-deprecated",
+    "nativeCurrency": {
+      "symbol": "AI3"
+    }
+  },
+  {
+    "chainId": 490092,
+    "name": "PUMPFI CHAIN TESTNET",
+    "shortName": "pumpfi-testnet",
+    "nativeCurrency": {
+      "symbol": "PMPT"
+    }
+  },
+  {
+    "chainId": 504441,
+    "name": "Playdapp Network",
+    "shortName": "PDA",
+    "nativeCurrency": {
+      "symbol": "PDA"
+    }
+  },
+  {
+    "chainId": 511111,
+    "name": "Alpha Chain Testnet",
+    "shortName": "alpha-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 512512,
+    "name": "CMP-Testnet",
+    "shortName": "cmp",
+    "nativeCurrency": {
+      "symbol": "CMP"
+    }
+  },
+  {
+    "chainId": 513100,
+    "name": "EthereumFair",
+    "shortName": "ethf",
+    "nativeCurrency": {
+      "symbol": "ETHF"
+    }
+  },
+  {
+    "chainId": 526916,
+    "name": "DoCoin Community Chain",
+    "shortName": "DoCoin",
+    "nativeCurrency": {
+      "symbol": "DCT"
+    }
+  },
+  {
+    "chainId": 534351,
+    "name": "Scroll Sepolia Testnet",
+    "shortName": "scr-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 534352,
+    "name": "Scroll",
+    "shortName": "scr",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 534353,
+    "name": "Scroll Alpha Testnet",
+    "shortName": "scr-alpha",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 534354,
+    "name": "Scroll Pre-Alpha Testnet",
+    "shortName": "scr-prealpha",
+    "nativeCurrency": {
+      "symbol": "TSETH"
+    }
+  },
+  {
+    "chainId": 534849,
+    "name": "Shinarium Beta",
+    "shortName": "shi",
+    "nativeCurrency": {
+      "symbol": "SHI"
+    }
+  },
+  {
+    "chainId": 535037,
+    "name": "BeanEco SmartChain",
+    "shortName": "BESC",
+    "nativeCurrency": {
+      "symbol": "BESC"
+    }
+  },
+  {
+    "chainId": 541764,
+    "name": "OverProtocol Testnet",
+    "shortName": "overprotocol-testnet",
+    "nativeCurrency": {
+      "symbol": "OVER"
+    }
+  },
+  {
+    "chainId": 543210,
+    "name": "ZERO Network",
+    "shortName": "zero-network",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 552981,
+    "name": "One World Chain Testnet",
+    "shortName": "OWCTt",
+    "nativeCurrency": {
+      "symbol": "OWCT"
+    }
+  },
+  {
+    "chainId": 555555,
+    "name": "Pentagon Testnet",
+    "shortName": "pentagon-testnet",
+    "nativeCurrency": {
+      "symbol": "PEN"
+    }
+  },
+  {
+    "chainId": 555666,
+    "name": "Eclipse Testnet",
+    "shortName": "eclipset",
+    "nativeCurrency": {
+      "symbol": "ECLPS"
+    }
+  },
+  {
+    "chainId": 555777,
+    "name": "Xsolla ZK Sepolia Testnet",
+    "shortName": "xsollazk-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 555888,
+    "name": "DustBoy IoT",
+    "shortName": "DustBoy_IoT",
+    "nativeCurrency": {
+      "symbol": "DST"
+    }
+  },
+  {
+    "chainId": 560000,
+    "name": "Hetu Mainnet",
+    "shortName": "HETU",
+    "nativeCurrency": {
+      "symbol": "HETU"
+    }
+  },
+  {
+    "chainId": 560013,
+    "name": "Rogue Chain",
+    "shortName": "rogue",
+    "nativeCurrency": {
+      "symbol": "ROGUE"
+    }
+  },
+  {
+    "chainId": 560048,
+    "name": "Ethereum Hoodi",
+    "shortName": "hoe",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 621847,
+    "name": "DJT Testnet",
+    "shortName": "DJT",
+    "nativeCurrency": {
+      "symbol": "DJT"
+    }
+  },
+  {
+    "chainId": 622277,
+    "name": "Hypra Mainnet",
+    "shortName": "hyp",
+    "nativeCurrency": {
+      "symbol": "HYP"
+    }
+  },
+  {
+    "chainId": 622463,
+    "name": "Atlas",
+    "shortName": "atlas-testnet",
+    "nativeCurrency": {
+      "symbol": "TON"
+    }
+  },
+  {
+    "chainId": 631571,
+    "name": "Polter Testnet",
+    "shortName": "poltergeist",
+    "nativeCurrency": {
+      "symbol": "GHST"
+    }
+  },
+  {
+    "chainId": 641230,
+    "name": "Bear Network Chain Mainnet",
+    "shortName": "BRNKC",
+    "nativeCurrency": {
+      "symbol": "BRNKC"
+    }
+  },
+  {
+    "chainId": 651940,
+    "name": "ALL Mainnet",
+    "shortName": "ALL",
+    "nativeCurrency": {
+      "symbol": "ALL"
+    }
+  },
+  {
+    "chainId": 656476,
+    "name": "EDU Chain Testnet",
+    "shortName": "open-campus-codex",
+    "nativeCurrency": {
+      "symbol": "EDU"
+    }
+  },
+  {
+    "chainId": 660279,
+    "name": "Xai Mainnet",
+    "shortName": "xai",
+    "nativeCurrency": {
+      "symbol": "XAI"
+    }
+  },
+  {
+    "chainId": 666666,
+    "name": "Vision - Vpioneer Test Chain",
+    "shortName": "vpioneer",
+    "nativeCurrency": {
+      "symbol": "VS"
+    }
+  },
+  {
+    "chainId": 666888,
+    "name": "Hela Official Runtime Testnet",
+    "shortName": "hela-testnet",
+    "nativeCurrency": {
+      "symbol": "HLUSD"
+    }
+  },
+  {
+    "chainId": 668668,
+    "name": "Conwai Mainnet",
+    "shortName": "cnw",
+    "nativeCurrency": {
+      "symbol": "CNW"
+    }
+  },
+  {
+    "chainId": 685685,
+    "name": "Gensyn Testnet",
+    "shortName": "gensyn-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 685689,
+    "name": "Gensyn Mainnet",
+    "shortName": "gensyn-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 686868,
+    "name": "Won Network",
+    "shortName": "WonChain",
+    "nativeCurrency": {
+      "symbol": "WON"
+    }
+  },
+  {
+    "chainId": 695569,
+    "name": "Pyrope Testnet",
+    "shortName": "pyrope",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 696969,
+    "name": "Galadriel Devnet",
+    "shortName": "galadriel-devnet",
+    "nativeCurrency": {
+      "symbol": "GAL"
+    }
+  },
+  {
+    "chainId": 698369,
+    "name": "Primea Network Mainnet",
+    "shortName": "goldpn",
+    "nativeCurrency": {
+      "symbol": "GOLDPN"
+    }
+  },
+  {
+    "chainId": 706883,
+    "name": "Fidesinnova",
+    "shortName": "Fidesinnova",
+    "nativeCurrency": {
+      "symbol": "FDS"
+    }
+  },
+  {
+    "chainId": 710420,
+    "name": "Tiltyard Mainnet Subnet",
+    "shortName": "tiltyardmainnet",
+    "nativeCurrency": {
+      "symbol": "TILT"
+    }
+  },
+  {
+    "chainId": 713715,
+    "name": "Sei Devnet",
+    "shortName": "sei-devnet",
+    "nativeCurrency": {
+      "symbol": "SEI"
+    }
+  },
+  {
+    "chainId": 715131,
+    "name": "Zether Mainnet",
+    "shortName": "zth",
+    "nativeCurrency": {
+      "symbol": "ZTH"
+    }
+  },
+  {
+    "chainId": 721529,
+    "name": "ERAM Mainnet",
+    "shortName": "ERAM",
+    "nativeCurrency": {
+      "symbol": "ERAM"
+    }
+  },
+  {
+    "chainId": 723107,
+    "name": "TixChain Testnet",
+    "shortName": "tixchain",
+    "nativeCurrency": {
+      "symbol": "TIX"
+    }
+  },
+  {
+    "chainId": 723487,
+    "name": "Radius Network",
+    "shortName": "radius",
+    "nativeCurrency": {
+      "symbol": "RUSD"
+    }
+  },
+  {
+    "chainId": 737373,
+    "name": "bokuto",
+    "shortName": "bokuto",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 743111,
+    "name": "Hemi Sepolia",
+    "shortName": "hemi-sep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 747474,
+    "name": "katana",
+    "shortName": "katana",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 751230,
+    "name": "Bear Network Chain Testnet",
+    "shortName": "BRNKCTEST",
+    "nativeCurrency": {
+      "symbol": "tBRNKC"
+    }
+  },
+  {
+    "chainId": 752024,
+    "name": "Ternoa Testnet",
+    "shortName": "ternoa",
+    "nativeCurrency": {
+      "symbol": "CAPS"
+    }
+  },
+  {
+    "chainId": 752025,
+    "name": "Ternoa",
+    "shortName": "ternoa-mainnet",
+    "nativeCurrency": {
+      "symbol": "CAPS"
+    }
+  },
+  {
+    "chainId": 756689,
+    "name": "PAYSCAN CHAIN",
+    "shortName": "payscan",
+    "nativeCurrency": {
+      "symbol": "PYZ"
+    }
+  },
+  {
+    "chainId": 761412,
+    "name": "Miexs Smartchain",
+    "shortName": "Miexs",
+    "nativeCurrency": {
+      "symbol": "MIX"
+    }
+  },
+  {
+    "chainId": 763373,
+    "name": "Ink Sepolia",
+    "shortName": "inksepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 763374,
+    "name": "Surge deprecated Testnet",
+    "shortName": "surge-deprecated-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 763375,
+    "name": "Surge Testnet",
+    "shortName": "surge-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 764984,
+    "name": "Lamina1 Testnet",
+    "shortName": "lamina1test",
+    "nativeCurrency": {
+      "symbol": "L1T"
+    }
+  },
+  {
+    "chainId": 767368,
+    "name": "Lamina1 Identity Testnet",
+    "shortName": "lamina1idtest",
+    "nativeCurrency": {
+      "symbol": "L1IDT"
+    }
+  },
+  {
+    "chainId": 776877,
+    "name": "Modularium",
+    "shortName": "mdlrm",
+    "nativeCurrency": {
+      "symbol": "MDM"
+    }
+  },
+  {
+    "chainId": 777777,
+    "name": "Winr Protocol Mainnet",
+    "shortName": "winr",
+    "nativeCurrency": {
+      "symbol": "WINR"
+    }
+  },
+  {
+    "chainId": 777888,
+    "name": "Oone Chain Mainnet",
+    "shortName": "oone",
+    "nativeCurrency": {
+      "symbol": "OONE"
+    }
+  },
+  {
+    "chainId": 786786,
+    "name": "Zebro Smart Chain",
+    "shortName": "zebro",
+    "nativeCurrency": {
+      "symbol": "ZEBRO"
+    }
+  },
+  {
+    "chainId": 789789,
+    "name": "Emeraldz",
+    "shortName": "emed",
+    "nativeCurrency": {
+      "symbol": "EMED"
+    }
+  },
+  {
+    "chainId": 800001,
+    "name": "OctaSpace",
+    "shortName": "octa",
+    "nativeCurrency": {
+      "symbol": "OCTA"
+    }
+  },
+  {
+    "chainId": 806582,
+    "name": "Ethpar Testnet",
+    "shortName": "ethpar-tesnet",
+    "nativeCurrency": {
+      "symbol": "ETP"
+    }
+  },
+  {
+    "chainId": 808080,
+    "name": "BIZ Smart Chain Testnet",
+    "shortName": "bizt-testnet",
+    "nativeCurrency": {
+      "symbol": "tBIZT"
+    }
+  },
+  {
+    "chainId": 808813,
+    "name": "BOB Sepolia",
+    "shortName": "bob-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 810180,
+    "name": "zkLink Nova Mainnet",
+    "shortName": "zklink-nova",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 810181,
+    "name": "zkLink Nova Sepolia Testnet",
+    "shortName": "zklink-nova-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 810182,
+    "name": "zkLink Nova Goerli Testnet",
+    "shortName": "zklink-nova-goerli",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 812242,
+    "name": "Codex Testnet",
+    "shortName": "codex-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 812397,
+    "name": "SG Verse Mainnet",
+    "shortName": "SGV",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 820522,
+    "name": "TSC Testnet",
+    "shortName": "tTSC",
+    "nativeCurrency": {
+      "symbol": "tTAS"
+    }
+  },
+  {
+    "chainId": 827431,
+    "name": "CURVE Mainnet",
+    "shortName": "CURVEm",
+    "nativeCurrency": {
+      "symbol": "CURVE"
+    }
+  },
+  {
+    "chainId": 838838,
+    "name": "HyperCluster",
+    "shortName": "HYPEC",
+    "nativeCurrency": {
+      "symbol": "HYPEC"
+    }
+  },
+  {
+    "chainId": 839320,
+    "name": "PRM Testnet",
+    "shortName": "prmtest",
+    "nativeCurrency": {
+      "symbol": "PRM"
+    }
+  },
+  {
+    "chainId": 839999,
+    "name": "exSat Testnet",
+    "shortName": "txsat",
+    "nativeCurrency": {
+      "symbol": "BTC"
+    }
+  },
+  {
+    "chainId": 840000,
+    "name": "RUNEVM Testnet",
+    "shortName": "runevm-test",
+    "nativeCurrency": {
+      "symbol": "tBTC"
+    }
+  },
+  {
+    "chainId": 846000,
+    "name": "4GoodNetwork",
+    "shortName": "bloqs4good",
+    "nativeCurrency": {
+      "symbol": "APTA"
+    }
+  },
+  {
+    "chainId": 853211,
+    "name": "Testethiq",
+    "shortName": "testethiq",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 855456,
+    "name": "Dodao",
+    "shortName": "dodao",
+    "nativeCurrency": {
+      "symbol": "DODAO"
+    }
+  },
+  {
+    "chainId": 879151,
+    "name": "BlocX Mainnet",
+    "shortName": "blx",
+    "nativeCurrency": {
+      "symbol": "BLX"
+    }
+  },
+  {
+    "chainId": 888882,
+    "name": "REXX Mainnet",
+    "shortName": "REXX",
+    "nativeCurrency": {
+      "symbol": "REXX"
+    }
+  },
+  {
+    "chainId": 888888,
+    "name": "Vision - Mainnet",
+    "shortName": "vision",
+    "nativeCurrency": {
+      "symbol": "VS"
+    }
+  },
+  {
+    "chainId": 888991,
+    "name": "Unite Testnet",
+    "shortName": "unitetestnet",
+    "nativeCurrency": {
+      "symbol": "UNITE"
+    }
+  },
+  {
+    "chainId": 900000,
+    "name": "Posichain Mainnet Shard 0",
+    "shortName": "psc-s0",
+    "nativeCurrency": {
+      "symbol": "POSI"
+    }
+  },
+  {
+    "chainId": 910000,
+    "name": "Posichain Testnet Shard 0",
+    "shortName": "psc-t-s0",
+    "nativeCurrency": {
+      "symbol": "POSI"
+    }
+  },
+  {
+    "chainId": 911867,
+    "name": "Odyssey Testnet",
+    "shortName": "odyssey-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 912559,
+    "name": "Astria EVM Dusknet",
+    "shortName": "ria-dev",
+    "nativeCurrency": {
+      "symbol": "RIA"
+    }
+  },
+  {
+    "chainId": 918273,
+    "name": "Owshen Mainnet",
+    "shortName": "owshen-mainnet",
+    "nativeCurrency": {
+      "symbol": "DIVE"
+    }
+  },
+  {
+    "chainId": 920000,
+    "name": "Posichain Devnet Shard 0",
+    "shortName": "psc-d-s0",
+    "nativeCurrency": {
+      "symbol": "POSI"
+    }
+  },
+  {
+    "chainId": 920001,
+    "name": "Posichain Devnet Shard 1",
+    "shortName": "psc-d-s1",
+    "nativeCurrency": {
+      "symbol": "POSI"
+    }
+  },
+  {
+    "chainId": 923018,
+    "name": "FNCY Testnet",
+    "shortName": "tFNCY",
+    "nativeCurrency": {
+      "symbol": "FNCY"
+    }
+  },
+  {
+    "chainId": 955081,
+    "name": "Jono12 Subnet",
+    "shortName": "jono12",
+    "nativeCurrency": {
+      "symbol": "JONO"
+    }
+  },
+  {
+    "chainId": 955305,
+    "name": "Eluvio Content Fabric",
+    "shortName": "elv",
+    "nativeCurrency": {
+      "symbol": "ELV"
+    }
+  },
+  {
+    "chainId": 963369,
+    "name": "AVI Coin",
+    "shortName": "avi",
+    "nativeCurrency": {
+      "symbol": "AVI"
+    }
+  },
+  {
+    "chainId": 978657,
+    "name": "Treasure Ruby",
+    "shortName": "treasure-ruby",
+    "nativeCurrency": {
+      "symbol": "MAGIC"
+    }
+  },
+  {
+    "chainId": 978658,
+    "name": "Treasure Topaz",
+    "shortName": "treasure-topaz",
+    "nativeCurrency": {
+      "symbol": "MAGIC"
+    }
+  },
+  {
+    "chainId": 984122,
+    "name": "Forma",
+    "shortName": "forma",
+    "nativeCurrency": {
+      "symbol": "TIA"
+    }
+  },
+  {
+    "chainId": 984123,
+    "name": "Forma Sketchpad",
+    "shortName": "sketchpad",
+    "nativeCurrency": {
+      "symbol": "TIA"
+    }
+  },
+  {
+    "chainId": 988207,
+    "name": "Ecrox Chain Mainnet",
+    "shortName": "ecrox",
+    "nativeCurrency": {
+      "symbol": "ECROX"
+    }
+  },
+  {
+    "chainId": 998899,
+    "name": "Supernet Testnet",
+    "shortName": "supernetchain",
+    "nativeCurrency": {
+      "symbol": "CHAIN"
+    }
+  },
+  {
+    "chainId": 999999,
+    "name": "AmChain",
+    "shortName": "AMC",
+    "nativeCurrency": {
+      "symbol": "AMC"
+    }
+  },
+  {
+    "chainId": 1000001,
+    "name": "WebChain ETK",
+    "shortName": "wvm",
+    "nativeCurrency": {
+      "symbol": "ETK"
+    }
+  },
+  {
+    "chainId": 1001996,
+    "name": "Wirex Pay Testnet",
+    "shortName": "wirex-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1008686,
+    "name": "Naga Testnet",
+    "shortName": "Naga",
+    "nativeCurrency": {
+      "symbol": "Naga"
+    }
+  },
+  {
+    "chainId": 1100789,
+    "name": "Netmind Chain Testnet",
+    "shortName": "nmtTest",
+    "nativeCurrency": {
+      "symbol": "NMT"
+    }
+  },
+  {
+    "chainId": 1127469,
+    "name": "Tiltyard Subnet",
+    "shortName": "tiltyard",
+    "nativeCurrency": {
+      "symbol": "TILTG"
+    }
+  },
+  {
+    "chainId": 1212101,
+    "name": "1Money Network Testnet",
+    "shortName": "1money-testnet",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 1212111,
+    "name": "1Money Sidechain Testnet",
+    "shortName": "1money-sc-testnet",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 1234567,
+    "name": "Sharecle Mainnet",
+    "shortName": "shr",
+    "nativeCurrency": {
+      "symbol": "SHR"
+    }
+  },
+  {
+    "chainId": 1261120,
+    "name": "zKatana",
+    "shortName": "azktn",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1313114,
+    "name": "Etho Protocol",
+    "shortName": "etho",
+    "nativeCurrency": {
+      "symbol": "ETHO"
+    }
+  },
+  {
+    "chainId": 1313500,
+    "name": "Xerom",
+    "shortName": "xero",
+    "nativeCurrency": {
+      "symbol": "XERO"
+    }
+  },
+  {
+    "chainId": 1337702,
+    "name": "Kintsugi",
+    "shortName": "kintsugi",
+    "nativeCurrency": {
+      "symbol": "kiETH"
+    }
+  },
+  {
+    "chainId": 1337802,
+    "name": "Kiln",
+    "shortName": "kiln",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1337803,
+    "name": "Zhejiang",
+    "shortName": "zhejiang",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1398243,
+    "name": "Automata Testnet",
+    "shortName": "automatatest",
+    "nativeCurrency": {
+      "symbol": "ATA"
+    }
+  },
+  {
+    "chainId": 1398244,
+    "name": "Automata Orbit Testnet",
+    "shortName": "automataorbittestnet",
+    "nativeCurrency": {
+      "symbol": "ATA"
+    }
+  },
+  {
+    "chainId": 1440000,
+    "name": "XRPL EVM Sidechain",
+    "shortName": "xrplevm",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 1440002,
+    "name": "XRPL EVM Sidechain Devnet",
+    "shortName": "xrplevmdevnet",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 1449000,
+    "name": "XRPL EVM Sidechain Testnet",
+    "shortName": "xrplevmtestnet",
+    "nativeCurrency": {
+      "symbol": "XRP"
+    }
+  },
+  {
+    "chainId": 1501869,
+    "name": "Waterfall 9 Test Network",
+    "shortName": "water9",
+    "nativeCurrency": {
+      "symbol": "WATER"
+    }
+  },
+  {
+    "chainId": 1612127,
+    "name": "PlayFi Albireo Testnet",
+    "shortName": "alberio",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1637450,
+    "name": "Xterio Testnet",
+    "shortName": "xteriotest",
+    "nativeCurrency": {
+      "symbol": "tBNB"
+    }
+  },
+  {
+    "chainId": 1698369,
+    "name": "Primea Network Testnet",
+    "shortName": "test-goldpn",
+    "nativeCurrency": {
+      "symbol": "GOLDPN"
+    }
+  },
+  {
+    "chainId": 1731313,
+    "name": "Turkey Demo Dev",
+    "shortName": "TDD",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1998991,
+    "name": "Xphere Testnet",
+    "shortName": "xp-test",
+    "nativeCurrency": {
+      "symbol": "XPT"
+    }
+  },
+  {
+    "chainId": 2019775,
+    "name": "Jovay Sepolia Testnet",
+    "shortName": "jovay-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2021398,
+    "name": "DeBank Testnet",
+    "shortName": "dbk",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 2022091,
+    "name": "Alterscope Testnet",
+    "shortName": "AlterscopeTest",
+    "nativeCurrency": {
+      "symbol": "RISKT"
+    }
+  },
+  {
+    "chainId": 2099156,
+    "name": "Plian Mainnet Main",
+    "shortName": "plian-mainnet",
+    "nativeCurrency": {
+      "symbol": "PI"
+    }
+  },
+  {
+    "chainId": 2203181,
+    "name": "PlatON Dev Testnet Deprecated",
+    "shortName": "platondev",
+    "nativeCurrency": {
+      "symbol": "lat"
+    }
+  },
+  {
+    "chainId": 2206132,
+    "name": "PlatON Dev Testnet2",
+    "shortName": "platondev2",
+    "nativeCurrency": {
+      "symbol": "lat"
+    }
+  },
+  {
+    "chainId": 2222222,
+    "name": "Coinweb BNB shard",
+    "shortName": "cweb-bnb",
+    "nativeCurrency": {
+      "symbol": "CWEB"
+    }
+  },
+  {
+    "chainId": 2481632,
+    "name": "Recall Testnet",
+    "shortName": "trecall",
+    "nativeCurrency": {
+      "symbol": "RECALL"
+    }
+  },
+  {
+    "chainId": 2611555,
+    "name": "DPU Chain",
+    "shortName": "DPU",
+    "nativeCurrency": {
+      "symbol": "DGC"
+    }
+  },
+  {
+    "chainId": 2632500,
+    "name": "COTI",
+    "shortName": "coti",
+    "nativeCurrency": {
+      "symbol": "COTI"
+    }
+  },
+  {
+    "chainId": 2651420,
+    "name": "Horizen Testnet",
+    "shortName": "horizen-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2702128,
+    "name": "Xterio Chain (ETH)",
+    "shortName": "xterio",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3132023,
+    "name": "Sahara AI",
+    "shortName": "sahara",
+    "nativeCurrency": {
+      "symbol": "SAHARA"
+    }
+  },
+  {
+    "chainId": 3141592,
+    "name": "Filecoin - Butterfly testnet",
+    "shortName": "filecoin-butterfly",
+    "nativeCurrency": {
+      "symbol": "tFIL"
+    }
+  },
+  {
+    "chainId": 3397901,
+    "name": "Funki Sepolia Testnet",
+    "shortName": "funkisepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3441005,
+    "name": "Manta Pacific Testnet",
+    "shortName": "mantaTestnet",
+    "nativeCurrency": {
+      "symbol": "MANTA"
+    }
+  },
+  {
+    "chainId": 3441006,
+    "name": "Manta Pacific Sepolia Testnet",
+    "shortName": "mantaSepoliaTestnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4000003,
+    "name": "AltLayer Zero Gas Network",
+    "shortName": "alt-zerogas",
+    "nativeCurrency": {
+      "symbol": "ZERO"
+    }
+  },
+  {
+    "chainId": 4278608,
+    "name": "Arcadia Mainnet",
+    "shortName": "aip",
+    "nativeCurrency": {
+      "symbol": "AIP"
+    }
+  },
+  {
+    "chainId": 4281033,
+    "name": "Worlds Caldera",
+    "shortName": "worldscal",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4284265,
+    "name": "Zuux chain testnet",
+    "shortName": "zuuxchain",
+    "nativeCurrency": {
+      "symbol": "ZUUX"
+    }
+  },
+  {
+    "chainId": 4444444,
+    "name": "Altar Testnet",
+    "shortName": "altarTestnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 4457845,
+    "name": "ZERO Testnet (Sepolia)",
+    "shortName": "zero-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 5042002,
+    "name": "Arc Network Testnet",
+    "shortName": "arc-testnet",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 5112023,
+    "name": "NumBlock Chain",
+    "shortName": "NUMB",
+    "nativeCurrency": {
+      "symbol": "NUMB"
+    }
+  },
+  {
+    "chainId": 5167003,
+    "name": "MXC Wannsee zkEVM Testnet",
+    "shortName": "MXCdiscontinued",
+    "nativeCurrency": {
+      "symbol": "MXC"
+    }
+  },
+  {
+    "chainId": 5167004,
+    "name": "Moonchain Geneva Testnet",
+    "shortName": "MXC",
+    "nativeCurrency": {
+      "symbol": "MXC"
+    }
+  },
+  {
+    "chainId": 5201420,
+    "name": "Electroneum Testnet",
+    "shortName": "etn-testnet",
+    "nativeCurrency": {
+      "symbol": "ETN"
+    }
+  },
+  {
+    "chainId": 5318007,
+    "name": "Reactive Lasna",
+    "shortName": "lreact",
+    "nativeCurrency": {
+      "symbol": "lREACT"
+    }
+  },
+  {
+    "chainId": 5318008,
+    "name": "Reactive Kopli",
+    "shortName": "kreact",
+    "nativeCurrency": {
+      "symbol": "REACT"
+    }
+  },
+  {
+    "chainId": 5511555,
+    "name": "PointPay Testnet",
+    "shortName": "PPTEST",
+    "nativeCurrency": {
+      "symbol": "PXP"
+    }
+  },
+  {
+    "chainId": 5555555,
+    "name": "Imversed Mainnet",
+    "shortName": "imversed",
+    "nativeCurrency": {
+      "symbol": "IMV"
+    }
+  },
+  {
+    "chainId": 5555558,
+    "name": "Imversed Testnet",
+    "shortName": "imversed-testnet",
+    "nativeCurrency": {
+      "symbol": "IMV"
+    }
+  },
+  {
+    "chainId": 5734951,
+    "name": "Jovay Mainnet",
+    "shortName": "jovay",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6038361,
+    "name": "Astar zKyoto",
+    "shortName": "azkyt",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 6231991,
+    "name": "Block Chain LOL Berachain Testnet",
+    "shortName": "block-chain-lol-testnet",
+    "nativeCurrency": {
+      "symbol": "HARRY"
+    }
+  },
+  {
+    "chainId": 6666665,
+    "name": "Safe(AnWang) Mainnet",
+    "shortName": "SafeMainnet",
+    "nativeCurrency": {
+      "symbol": "SAFE"
+    }
+  },
+  {
+    "chainId": 6666666,
+    "name": "Safe(AnWang) Testnet",
+    "shortName": "SafeTestnet",
+    "nativeCurrency": {
+      "symbol": "SAFE"
+    }
+  },
+  {
+    "chainId": 6666689,
+    "name": "The Ting Blockchain Testnet Explorer",
+    "shortName": "ting-testnet",
+    "nativeCurrency": {
+      "symbol": "Ton"
+    }
+  },
+  {
+    "chainId": 6912115,
+    "name": "ENI Testnet (Deprecated)",
+    "shortName": "eni-test-deprecated",
+    "nativeCurrency": {
+      "symbol": "EGAS"
+    }
+  },
+  {
+    "chainId": 6985385,
+    "name": "Humanity Protocol",
+    "shortName": "hp",
+    "nativeCurrency": {
+      "symbol": "H"
+    }
+  },
+  {
+    "chainId": 7080969,
+    "name": "Humanity Protocol testnet",
+    "shortName": "thp",
+    "nativeCurrency": {
+      "symbol": "tHP"
+    }
+  },
+  {
+    "chainId": 7082400,
+    "name": "COTI Testnet",
+    "shortName": "coti-testnet",
+    "nativeCurrency": {
+      "symbol": "COTI"
+    }
+  },
+  {
+    "chainId": 7225878,
+    "name": "Saakuru Mainnet",
+    "shortName": "saakuru",
+    "nativeCurrency": {
+      "symbol": "OAS"
+    }
+  },
+  {
+    "chainId": 7355310,
+    "name": "OpenVessel",
+    "shortName": "vsl",
+    "nativeCurrency": {
+      "symbol": "VETH"
+    }
+  },
+  {
+    "chainId": 7668378,
+    "name": "QL1 Testnet",
+    "shortName": "tqom",
+    "nativeCurrency": {
+      "symbol": "QOM"
+    }
+  },
+  {
+    "chainId": 7762959,
+    "name": "Musicoin",
+    "shortName": "music",
+    "nativeCurrency": {
+      "symbol": "MUSIC"
+    }
+  },
+  {
+    "chainId": 7777777,
+    "name": "Zora",
+    "shortName": "zora",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7849306,
+    "name": "Ozean Poseidon Testnet",
+    "shortName": "ozean-poseidon",
+    "nativeCurrency": {
+      "symbol": "USDX"
+    }
+  },
+  {
+    "chainId": 8007736,
+    "name": "Plian Mainnet Subchain 1",
+    "shortName": "plian-mainnet-l2",
+    "nativeCurrency": {
+      "symbol": "PI"
+    }
+  },
+  {
+    "chainId": 8008135,
+    "name": "Fhenix Helium",
+    "shortName": "fhe-helium",
+    "nativeCurrency": {
+      "symbol": "tFHE"
+    }
+  },
+  {
+    "chainId": 8080808,
+    "name": "Hokum",
+    "shortName": "hokum",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8601152,
+    "name": "Waterfall 8 Test Network",
+    "shortName": "waterfall",
+    "nativeCurrency": {
+      "symbol": "WATER"
+    }
+  },
+  {
+    "chainId": 8794598,
+    "name": "HAPchain",
+    "shortName": "hap",
+    "nativeCurrency": {
+      "symbol": "HAP"
+    }
+  },
+  {
+    "chainId": 8888881,
+    "name": "Quarix Testnet",
+    "shortName": "quarix-testnet",
+    "nativeCurrency": {
+      "symbol": "QARE"
+    }
+  },
+  {
+    "chainId": 8888888,
+    "name": "Quarix",
+    "shortName": "quarix",
+    "nativeCurrency": {
+      "symbol": "QARE"
+    }
+  },
+  {
+    "chainId": 9322252,
+    "name": "XCAP",
+    "shortName": "xcap",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 9322253,
+    "name": "Milvine",
+    "shortName": "milv",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 9999999,
+    "name": "Fluence",
+    "shortName": "fluence",
+    "nativeCurrency": {
+      "symbol": "FLT"
+    }
+  },
+  {
+    "chainId": 10058111,
+    "name": "Spotlight",
+    "shortName": "spotlight",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 10058112,
+    "name": "Spotlight Sepolia Testnet",
+    "shortName": "spotlightsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 10067275,
+    "name": "Plian Testnet Subchain 1",
+    "shortName": "plian-testnet-l2",
+    "nativeCurrency": {
+      "symbol": "TPI"
+    }
+  },
+  {
+    "chainId": 10101010,
+    "name": "Soverun Mainnet",
+    "shortName": "SVRNm",
+    "nativeCurrency": {
+      "symbol": "SVRN"
+    }
+  },
+  {
+    "chainId": 10111945,
+    "name": "SATUCHAIN Mainnet",
+    "shortName": "satumainnet",
+    "nativeCurrency": {
+      "symbol": "STU"
+    }
+  },
+  {
+    "chainId": 10241024,
+    "name": "AlienX Mainnet",
+    "shortName": "AlienX",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 10241025,
+    "name": "ALIENX Hal Testnet",
+    "shortName": "ALIENXHal",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11111110,
+    "name": "ClawCoin Testnet",
+    "shortName": "cc-testnet",
+    "nativeCurrency": {
+      "symbol": "CC"
+    }
+  },
+  {
+    "chainId": 11111111,
+    "name": "ClawCoin",
+    "shortName": "cc",
+    "nativeCurrency": {
+      "symbol": "CC"
+    }
+  },
+  {
+    "chainId": 11142220,
+    "name": "Celo Sepolia Testnet",
+    "shortName": "celo-sep",
+    "nativeCurrency": {
+      "symbol": "CELO"
+    }
+  },
+  {
+    "chainId": 11145513,
+    "name": "Blessnet Sepolia",
+    "shortName": "bless-sepolia",
+    "nativeCurrency": {
+      "symbol": "BLESS"
+    }
+  },
+  {
+    "chainId": 11155111,
+    "name": "Ethereum Sepolia",
+    "shortName": "sep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11155420,
+    "name": "OP Sepolia Testnet",
+    "shortName": "opsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11155931,
+    "name": "RISE Testnet",
+    "shortName": "rise-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 11166111,
+    "name": "R0AR Testnet",
+    "shortName": "R0AR-Test-Chain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12020498,
+    "name": "Lummio Network",
+    "shortName": "lummio",
+    "nativeCurrency": {
+      "symbol": "LRPO"
+    }
+  },
+  {
+    "chainId": 12052024,
+    "name": "Memento Testnet (deprecated)",
+    "shortName": "memento-test",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 12082025,
+    "name": "ONFA Chain Mainnet",
+    "shortName": "onfachain",
+    "nativeCurrency": {
+      "symbol": "OFC"
+    }
+  },
+  {
+    "chainId": 12227331,
+    "name": "NeoX Testnet T3",
+    "shortName": "neox",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 12227332,
+    "name": "Neo X Testnet T4",
+    "shortName": "neox-t4",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 13068200,
+    "name": "COTI Devnet",
+    "shortName": "coti-devnet",
+    "nativeCurrency": {
+      "symbol": "COTI2"
+    }
+  },
+  {
+    "chainId": 13371337,
+    "name": "PepChain Churchill",
+    "shortName": "tpep",
+    "nativeCurrency": {
+      "symbol": "TPEP"
+    }
+  },
+  {
+    "chainId": 13863860,
+    "name": "Symbiosis",
+    "shortName": "symbiosis",
+    "nativeCurrency": {
+      "symbol": "SIS"
+    }
+  },
+  {
+    "chainId": 14288640,
+    "name": "Anduschain Mainnet",
+    "shortName": "anduschain-mainnet",
+    "nativeCurrency": {
+      "symbol": "DEB"
+    }
+  },
+  {
+    "chainId": 16658437,
+    "name": "Plian Testnet Main",
+    "shortName": "plian-testnet",
+    "nativeCurrency": {
+      "symbol": "TPI"
+    }
+  },
+  {
+    "chainId": 16969696,
+    "name": "Privix Chain Mainnet",
+    "shortName": "mpsc",
+    "nativeCurrency": {
+      "symbol": "PRIVIX"
+    }
+  },
+  {
+    "chainId": 17000920,
+    "name": "Lambda Chain Testnet",
+    "shortName": "tlambda",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 17081945,
+    "name": "SATUCHAIN Testnet",
+    "shortName": "satutestnet",
+    "nativeCurrency": {
+      "symbol": "tSTU"
+    }
+  },
+  {
+    "chainId": 18071918,
+    "name": "Mande Network Mainnet",
+    "shortName": "Mande",
+    "nativeCurrency": {
+      "symbol": "MAND"
+    }
+  },
+  {
+    "chainId": 18289463,
+    "name": "IOLite",
+    "shortName": "ilt",
+    "nativeCurrency": {
+      "symbol": "ILT"
+    }
+  },
+  {
+    "chainId": 19850818,
+    "name": "DeepBrainChain Testnet",
+    "shortName": "tDBC",
+    "nativeCurrency": {
+      "symbol": "tDBC"
+    }
+  },
+  {
+    "chainId": 19880818,
+    "name": "DeepBrainChain Mainnet",
+    "shortName": "DBC",
+    "nativeCurrency": {
+      "symbol": "DBC"
+    }
+  },
+  {
+    "chainId": 20180427,
+    "name": "Stability Testnet",
+    "shortName": "stabilitytestnet",
+    "nativeCurrency": {
+      "symbol": "FREE"
+    }
+  },
+  {
+    "chainId": 20180430,
+    "name": "SmartMesh Mainnet",
+    "shortName": "spectrum",
+    "nativeCurrency": {
+      "symbol": "SMT"
+    }
+  },
+  {
+    "chainId": 20181205,
+    "name": "quarkblockchain",
+    "shortName": "qki",
+    "nativeCurrency": {
+      "symbol": "QKI"
+    }
+  },
+  {
+    "chainId": 20201022,
+    "name": "Pego Network",
+    "shortName": "pg",
+    "nativeCurrency": {
+      "symbol": "PG"
+    }
+  },
+  {
+    "chainId": 20221001,
+    "name": "SoonChain Sepolia Devnet",
+    "shortName": "Soon-Devnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 20230825,
+    "name": "Vcity Testnet",
+    "shortName": "Vcitytestnet",
+    "nativeCurrency": {
+      "symbol": "VCT"
+    }
+  },
+  {
+    "chainId": 20240324,
+    "name": "DeBank Sepolia Testnet",
+    "shortName": "dbkse",
+    "nativeCurrency": {
+      "symbol": "USD"
+    }
+  },
+  {
+    "chainId": 20240603,
+    "name": "DBK Chain",
+    "shortName": "dbkchain",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 20241133,
+    "name": "Swan Proxima Testnet",
+    "shortName": "Proxima",
+    "nativeCurrency": {
+      "symbol": "sETH"
+    }
+  },
+  {
+    "chainId": 20250217,
+    "name": "Xphere Mainnet",
+    "shortName": "xp",
+    "nativeCurrency": {
+      "symbol": "XP"
+    }
+  },
+  {
+    "chainId": 20250407,
+    "name": "PlatON Dev Testnet",
+    "shortName": "platondev3",
+    "nativeCurrency": {
+      "symbol": "lat"
+    }
+  },
+  {
+    "chainId": 20250825,
+    "name": "Vcitychain Mainnet",
+    "shortName": "vcity",
+    "nativeCurrency": {
+      "symbol": "VCITY"
+    }
+  },
+  {
+    "chainId": 20256789,
+    "name": "ETP Mainnet",
+    "shortName": "ETP",
+    "nativeCurrency": {
+      "symbol": "ETP"
+    }
+  },
+  {
+    "chainId": 20260131,
+    "name": "Meta Assets Chain",
+    "shortName": "ma",
+    "nativeCurrency": {
+      "symbol": "MA"
+    }
+  },
+  {
+    "chainId": 20482050,
+    "name": "Hokum Testnet",
+    "shortName": "hokum-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 21000000,
+    "name": "Corn",
+    "shortName": "corn",
+    "nativeCurrency": {
+      "symbol": "BTCN"
+    }
+  },
+  {
+    "chainId": 21000001,
+    "name": "Corn Testnet",
+    "shortName": "corn-testnet",
+    "nativeCurrency": {
+      "symbol": "BTCN"
+    }
+  },
+  {
+    "chainId": 22052002,
+    "name": "Excelon Mainnet",
+    "shortName": "xlon",
+    "nativeCurrency": {
+      "symbol": "xlon"
+    }
+  },
+  {
+    "chainId": 24132016,
+    "name": "XMTP",
+    "shortName": "xmtp",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 24772477,
+    "name": "6Degree of Outreach - Testnet",
+    "shortName": "6dotest",
+    "nativeCurrency": {
+      "symbol": "6DO-T"
+    }
+  },
+  {
+    "chainId": 27082017,
+    "name": "Excoincial Chain Volta-Testnet",
+    "shortName": "exlvolta",
+    "nativeCurrency": {
+      "symbol": "TEXL"
+    }
+  },
+  {
+    "chainId": 27082022,
+    "name": "Excoincial Chain Mainnet",
+    "shortName": "exl",
+    "nativeCurrency": {
+      "symbol": "EXL"
+    }
+  },
+  {
+    "chainId": 28122024,
+    "name": "Ancient8 Testnet",
+    "shortName": "a8",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 28945486,
+    "name": "Auxilium Network Mainnet",
+    "shortName": "auxi",
+    "nativeCurrency": {
+      "symbol": "AUX"
+    }
+  },
+  {
+    "chainId": 29032022,
+    "name": "Flachain Mainnet",
+    "shortName": "fla",
+    "nativeCurrency": {
+      "symbol": "FLA"
+    }
+  },
+  {
+    "chainId": 31415926,
+    "name": "Filecoin - Local testnet",
+    "shortName": "filecoin-local",
+    "nativeCurrency": {
+      "symbol": "tFIL"
+    }
+  },
+  {
+    "chainId": 33626250,
+    "name": "Toliman Suave Testnet",
+    "shortName": "suave-toliman",
+    "nativeCurrency": {
+      "symbol": "TEEth"
+    }
+  },
+  {
+    "chainId": 33772211,
+    "name": "Xone Testnet",
+    "shortName": "tXOC",
+    "nativeCurrency": {
+      "symbol": "XOC"
+    }
+  },
+  {
+    "chainId": 34949059,
+    "name": "citronus-citro",
+    "shortName": "citronus-citro",
+    "nativeCurrency": {
+      "symbol": "CITRO"
+    }
+  },
+  {
+    "chainId": 35855456,
+    "name": "Joys Digital Mainnet",
+    "shortName": "JOYS",
+    "nativeCurrency": {
+      "symbol": "JOYS"
+    }
+  },
+  {
+    "chainId": 37084624,
+    "name": "SKALE Nebula Hub Testnet",
+    "shortName": "nebula-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 39916801,
+    "name": "Kingdom Chain",
+    "shortName": "kchain",
+    "nativeCurrency": {
+      "symbol": "KOZI"
+    }
+  },
+  {
+    "chainId": 43214913,
+    "name": "maistestsubnet",
+    "shortName": "mais",
+    "nativeCurrency": {
+      "symbol": "MAI"
+    }
+  },
+  {
+    "chainId": 50591822,
+    "name": "Stavanger Public Testnet",
+    "shortName": "stavanger",
+    "nativeCurrency": {
+      "symbol": "POL"
+    }
+  },
+  {
+    "chainId": 52027071,
+    "name": "Deviant Token Blockchain",
+    "shortName": "dtbc",
+    "nativeCurrency": {
+      "symbol": "DTBC"
+    }
+  },
+  {
+    "chainId": 52027080,
+    "name": "Deviant Token Blockchain Testnet",
+    "shortName": "tdtbc",
+    "nativeCurrency": {
+      "symbol": "tDTBC"
+    }
+  },
+  {
+    "chainId": 52164803,
+    "name": "Fluence Testnet",
+    "shortName": "fluence-testnet",
+    "nativeCurrency": {
+      "symbol": "tFLT"
+    }
+  },
+  {
+    "chainId": 61022448,
+    "name": "dKargo Warehouse Testnet",
+    "shortName": "dkargowarehouse",
+    "nativeCurrency": {
+      "symbol": "DKA"
+    }
+  },
+  {
+    "chainId": 61717561,
+    "name": "Aquachain",
+    "shortName": "aqua",
+    "nativeCurrency": {
+      "symbol": "AQUA"
+    }
+  },
+  {
+    "chainId": 65000000,
+    "name": "Autonity Mainnet",
+    "shortName": "aut",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65010000,
+    "name": "Autonity Bakerloo (Thames) Testnet",
+    "shortName": "bakerloo-0",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65010001,
+    "name": "Autonity Bakerloo (Barada) Testnet",
+    "shortName": "bakerloo-01",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65010002,
+    "name": "Autonity Bakerloo (Sumida) Testnet",
+    "shortName": "bakerloo-02",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65010003,
+    "name": "Autonity Bakerloo (Yamuna) Testnet",
+    "shortName": "bakerloo-03",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65100000,
+    "name": "Autonity Piccadilly (Thames) Testnet",
+    "shortName": "piccadilly-0",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65100001,
+    "name": "Autonity Piccadilly (Barada) Testnet",
+    "shortName": "piccadilly-01",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65100002,
+    "name": "Autonity Piccadilly (Sumida) Testnet",
+    "shortName": "piccadilly-02",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65100003,
+    "name": "Autonity Piccadilly (Yamuna) Testnet",
+    "shortName": "piccadilly-03",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 65100004,
+    "name": "Autonity Piccadilly (Tiber) Testnet",
+    "shortName": "piccadilly-04",
+    "nativeCurrency": {
+      "symbol": "ATN"
+    }
+  },
+  {
+    "chainId": 66666666,
+    "name": "Winr Protocol Testnet",
+    "shortName": "winrtestnet",
+    "nativeCurrency": {
+      "symbol": "WINR"
+    }
+  },
+  {
+    "chainId": 68840142,
+    "name": "Frame Testnet",
+    "shortName": "frametest",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 77787778,
+    "name": "0xHash Testnet",
+    "shortName": "HETH",
+    "nativeCurrency": {
+      "symbol": "HETH"
+    }
+  },
+  {
+    "chainId": 79479957,
+    "name": "SX Toronto Rollup",
+    "shortName": "SXR-Testnet",
+    "nativeCurrency": {
+      "symbol": "SX"
+    }
+  },
+  {
+    "chainId": 88558801,
+    "name": "Backstop Testnet",
+    "shortName": "backstop-testnet",
+    "nativeCurrency": {
+      "symbol": "ZBS"
+    }
+  },
+  {
+    "chainId": 88888888,
+    "name": "T.E.A.M Blockchain",
+    "shortName": "team",
+    "nativeCurrency": {
+      "symbol": "$TEAM"
+    }
+  },
+  {
+    "chainId": 89127398,
+    "name": "Krown Testnet",
+    "shortName": "krown-testnet",
+    "nativeCurrency": {
+      "symbol": "KROWN"
+    }
+  },
+  {
+    "chainId": 89346162,
+    "name": "Reya Cronos",
+    "shortName": "reya-cronos",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 91562037,
+    "name": "MST Testnet",
+    "shortName": "mst-testnet",
+    "nativeCurrency": {
+      "symbol": "tMSTC"
+    }
+  },
+  {
+    "chainId": 94204209,
+    "name": "Polygon Blackberry",
+    "shortName": "polygon-blackberry",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 96969696,
+    "name": " Privix Chain Testnet",
+    "shortName": "tpsc",
+    "nativeCurrency": {
+      "symbol": "PRIVIX"
+    }
+  },
+  {
+    "chainId": 97912060,
+    "name": "ChadChain",
+    "shortName": "chad",
+    "nativeCurrency": {
+      "symbol": "CHAD"
+    }
+  },
+  {
+    "chainId": 99415706,
+    "name": "Joys Digital TestNet",
+    "shortName": "TOYS",
+    "nativeCurrency": {
+      "symbol": "TOYS"
+    }
+  },
+  {
+    "chainId": 100000000,
+    "name": "Ethos",
+    "shortName": "ETHOS",
+    "nativeCurrency": {
+      "symbol": "ETHOS"
+    }
+  },
+  {
+    "chainId": 108160679,
+    "name": "Oraichain Mainnet",
+    "shortName": "Oraichain",
+    "nativeCurrency": {
+      "symbol": "ORAI"
+    }
+  },
+  {
+    "chainId": 111557560,
+    "name": "Cyber Testnet",
+    "shortName": "cysep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 123420111,
+    "name": "OP Celestia Raspberry",
+    "shortName": "opcelestia-raspberry",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 161221135,
+    "name": "Plume Testnet (Legacy)",
+    "shortName": "plume-testnet-legacy",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 168587773,
+    "name": "Blast Sepolia Testnet",
+    "shortName": "blastsepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 192837465,
+    "name": "Gather Mainnet Network",
+    "shortName": "GTH",
+    "nativeCurrency": {
+      "symbol": "GTH"
+    }
+  },
+  {
+    "chainId": 222000222,
+    "name": "Kanazawa",
+    "shortName": "kanazawa",
+    "nativeCurrency": {
+      "symbol": "gMELD"
+    }
+  },
+  {
+    "chainId": 241320161,
+    "name": "XMTP Sepolia",
+    "shortName": "xmtp-sepolia",
+    "nativeCurrency": {
+      "symbol": "USDC"
+    }
+  },
+  {
+    "chainId": 245022926,
+    "name": "Neon EVM Devnet",
+    "shortName": "neonevm-devnet",
+    "nativeCurrency": {
+      "symbol": "NEON"
+    }
+  },
+  {
+    "chainId": 245022929,
+    "name": "Neon EVM Devnet Rollup",
+    "shortName": "neonevm-devnet-rollup",
+    "nativeCurrency": {
+      "symbol": "NEON"
+    }
+  },
+  {
+    "chainId": 245022934,
+    "name": "Neon EVM Mainnet",
+    "shortName": "neonevm-mainnet",
+    "nativeCurrency": {
+      "symbol": "NEON"
+    }
+  },
+  {
+    "chainId": 245022940,
+    "name": "Neon EVM TestNet",
+    "shortName": "neonevm-testnet",
+    "nativeCurrency": {
+      "symbol": "NEON"
+    }
+  },
+  {
+    "chainId": 253368190,
+    "name": "Flame",
+    "shortName": "flame",
+    "nativeCurrency": {
+      "symbol": "TIA"
+    }
+  },
+  {
+    "chainId": 278611351,
+    "name": "Razor Skale Chain",
+    "shortName": "razor",
+    "nativeCurrency": {
+      "symbol": "SFUEL"
+    }
+  },
+  {
+    "chainId": 311752642,
+    "name": "OneLedger Mainnet",
+    "shortName": "oneledger",
+    "nativeCurrency": {
+      "symbol": "OLT"
+    }
+  },
+  {
+    "chainId": 324705682,
+    "name": "SKALE Base Sepolia",
+    "shortName": "skale-base-sepolia",
+    "nativeCurrency": {
+      "symbol": "CREDIT"
+    }
+  },
+  {
+    "chainId": 328527624,
+    "name": "Nal Sepolia Testnet",
+    "shortName": "nalsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 333000333,
+    "name": "Meld",
+    "shortName": "meld",
+    "nativeCurrency": {
+      "symbol": "gMELD"
+    }
+  },
+  {
+    "chainId": 344106930,
+    "name": "Deprecated SKALE Calypso Hub Testnet",
+    "shortName": "deprected-calypso-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 356256156,
+    "name": "Gather Testnet Network",
+    "shortName": "tGTH",
+    "nativeCurrency": {
+      "symbol": "GTH"
+    }
+  },
+  {
+    "chainId": 420420417,
+    "name": "Polkadot Testnet",
+    "shortName": "pas",
+    "nativeCurrency": {
+      "symbol": "PAS"
+    }
+  },
+  {
+    "chainId": 420420418,
+    "name": "Kusama",
+    "shortName": "ksm",
+    "nativeCurrency": {
+      "symbol": "KSM"
+    }
+  },
+  {
+    "chainId": 420420419,
+    "name": "Polkadot",
+    "shortName": "dot",
+    "nativeCurrency": {
+      "symbol": "DOT"
+    }
+  },
+  {
+    "chainId": 420420421,
+    "name": "Westend Asset Hub",
+    "shortName": "wst",
+    "nativeCurrency": {
+      "symbol": "WND"
+    }
+  },
+  {
+    "chainId": 420420422,
+    "name": "Paseo PassetHub",
+    "shortName": "pash",
+    "nativeCurrency": {
+      "symbol": "PAS"
+    }
+  },
+  {
+    "chainId": 476158412,
+    "name": "Deprecated SKALE Europa Hub Testnet",
+    "shortName": "deprecated-europa-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 476462898,
+    "name": "GPT Testnet",
+    "shortName": "Skopje",
+    "nativeCurrency": {
+      "symbol": "SkpGPT"
+    }
+  },
+  {
+    "chainId": 486217935,
+    "name": "Gather Devnet Network",
+    "shortName": "dGTH",
+    "nativeCurrency": {
+      "symbol": "GTH"
+    }
+  },
+  {
+    "chainId": 503129905,
+    "name": "Deprecated SKALE Nebula Hub Testnet",
+    "shortName": "deprecated-nebula-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 531050104,
+    "name": "Sophon Testnet",
+    "shortName": "sophon-testnet",
+    "nativeCurrency": {
+      "symbol": "SOPH"
+    }
+  },
+  {
+    "chainId": 661898459,
+    "name": "Smart Mainnet",
+    "shortName": "smart",
+    "nativeCurrency": {
+      "symbol": "SMART"
+    }
+  },
+  {
+    "chainId": 666666666,
+    "name": "Degen Chain",
+    "shortName": "degen-chain",
+    "nativeCurrency": {
+      "symbol": "DEGEN"
+    }
+  },
+  {
+    "chainId": 728126428,
+    "name": "Tron Mainnet",
+    "shortName": "tron",
+    "nativeCurrency": {
+      "symbol": "TRX"
+    }
+  },
+  {
+    "chainId": 737998412,
+    "name": "Tau Testnet",
+    "shortName": "tau-testnet",
+    "nativeCurrency": {
+      "symbol": "TAU"
+    }
+  },
+  {
+    "chainId": 888888888,
+    "name": "Ancient8",
+    "shortName": "ancient8",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 889910245,
+    "name": "PTCESCAN Testnet",
+    "shortName": "PTCE",
+    "nativeCurrency": {
+      "symbol": "PTCE"
+    }
+  },
+  {
+    "chainId": 889910246,
+    "name": "PTCESCAN Mainnet",
+    "shortName": "POLYTECH",
+    "nativeCurrency": {
+      "symbol": "PTCE"
+    }
+  },
+  {
+    "chainId": 974399131,
+    "name": "SKALE Calypso Hub Testnet",
+    "shortName": "calypso-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 994873017,
+    "name": "Lumia Mainnet",
+    "shortName": "lumia-mainnet",
+    "nativeCurrency": {
+      "symbol": "LUMIA"
+    }
+  },
+  {
+    "chainId": 999999999,
+    "name": "Zora Sepolia Testnet",
+    "shortName": "zsep",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1000000003,
+    "name": "DeInfra Devnet3",
+    "shortName": "deinfra-dev3",
+    "nativeCurrency": {
+      "symbol": "dSK"
+    }
+  },
+  {
+    "chainId": 1020352220,
+    "name": "SKALE Titan Hub Testnet",
+    "shortName": "titan-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1122334455,
+    "name": "IPOS Network",
+    "shortName": "ipos",
+    "nativeCurrency": {
+      "symbol": "IPOS"
+    }
+  },
+  {
+    "chainId": 1146703430,
+    "name": "CyberdeckNet",
+    "shortName": "cyb",
+    "nativeCurrency": {
+      "symbol": "CYB"
+    }
+  },
+  {
+    "chainId": 1187947933,
+    "name": "SKALE Base",
+    "shortName": "skale-base",
+    "nativeCurrency": {
+      "symbol": "CREDIT"
+    }
+  },
+  {
+    "chainId": 1213549903,
+    "name": "Mirasmanda",
+    "shortName": "mirasmanda",
+    "nativeCurrency": {
+      "symbol": "GAS"
+    }
+  },
+  {
+    "chainId": 1273227453,
+    "name": "HUMAN Protocol",
+    "shortName": "human-mainnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1278060416,
+    "name": "OFFICIAL VASYL",
+    "shortName": "Vasyl",
+    "nativeCurrency": {
+      "symbol": "VASYL"
+    }
+  },
+  {
+    "chainId": 1313161554,
+    "name": "Aurora Mainnet",
+    "shortName": "aurora",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1313161555,
+    "name": "Aurora Testnet",
+    "shortName": "aurora-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1313161556,
+    "name": "Aurora Betanet",
+    "shortName": "aurora-betanet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1313161560,
+    "name": "PowerGold",
+    "shortName": "powergold",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1313161567,
+    "name": "Turbo",
+    "shortName": "turbo",
+    "nativeCurrency": {
+      "symbol": "TURBO"
+    }
+  },
+  {
+    "chainId": 1313161573,
+    "name": "Tuxappcoin",
+    "shortName": "tuxa",
+    "nativeCurrency": {
+      "symbol": "TUXA"
+    }
+  },
+  {
+    "chainId": 1350216234,
+    "name": "SKALE Titan Hub",
+    "shortName": "titan-mainnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1351057110,
+    "name": "Chaos (SKALE Testnet)",
+    "shortName": "chaos-tenet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1380012617,
+    "name": "RARI Chain Mainnet",
+    "shortName": "rari-mainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1380996178,
+    "name": "RaptorChain",
+    "shortName": "rptr",
+    "nativeCurrency": {
+      "symbol": "RPTR"
+    }
+  },
+  {
+    "chainId": 1417429182,
+    "name": "Zephyr Testnet",
+    "shortName": "zephyr",
+    "nativeCurrency": {
+      "symbol": "Z"
+    }
+  },
+  {
+    "chainId": 1444673419,
+    "name": "SKALE Europa Hub Testnet",
+    "shortName": "europa-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1482601649,
+    "name": "SKALE Nebula Hub",
+    "shortName": "nebula-mainnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1511670449,
+    "name": "GPT Mainnet",
+    "shortName": "GPT",
+    "nativeCurrency": {
+      "symbol": "GPT"
+    }
+  },
+  {
+    "chainId": 1517929550,
+    "name": "Deprecated SKALE Titan Hub Testnet",
+    "shortName": "deprecated-titan-testnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1523903251,
+    "name": "Haust Network Testnet",
+    "shortName": "HaustTestnet",
+    "nativeCurrency": {
+      "symbol": "HAUST"
+    }
+  },
+  {
+    "chainId": 1564830818,
+    "name": "SKALE Calypso Hub",
+    "shortName": "calypso-mainnet",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 1570754601,
+    "name": "Haust Testnet",
+    "shortName": "hst-test",
+    "nativeCurrency": {
+      "symbol": "HAUST"
+    }
+  },
+  {
+    "chainId": 1660990954,
+    "name": "Status Network Sepolia",
+    "shortName": "sn-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1666600000,
+    "name": "Harmony Mainnet Shard 0",
+    "shortName": "hmy-s0",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666600001,
+    "name": "Harmony Mainnet Shard 1",
+    "shortName": "hmy-s1",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666600002,
+    "name": "Harmony Mainnet Shard 2",
+    "shortName": "hmy-s2",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666600003,
+    "name": "Harmony Mainnet Shard 3",
+    "shortName": "hmy-s3",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666700000,
+    "name": "Harmony Testnet Shard 0",
+    "shortName": "hmy-b-s0",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666700001,
+    "name": "Harmony Testnet Shard 1",
+    "shortName": "hmy-b-s1",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666900000,
+    "name": "Harmony Devnet Shard 0",
+    "shortName": "hmy-ps-s0",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1666900001,
+    "name": "Harmony Devnet Shard 1",
+    "shortName": "hmy-ps-s1",
+    "nativeCurrency": {
+      "symbol": "ONE"
+    }
+  },
+  {
+    "chainId": 1702448187,
+    "name": "WITNESS CHAIN",
+    "shortName": "Witness",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1722641160,
+    "name": "Silicon zkEVM Sepolia Testnet",
+    "shortName": "silicon-sepolia-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1802203764,
+    "name": "Kakarot Sepolia (Deprecated)",
+    "shortName": "kkrt-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1903648807,
+    "name": "Gemuchain Testnet",
+    "shortName": "Gemuchain",
+    "nativeCurrency": {
+      "symbol": "GEMU"
+    }
+  },
+  {
+    "chainId": 1918988905,
+    "name": "RARI Chain Testnet",
+    "shortName": "rari-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 1952959480,
+    "name": "Lumia Testnet",
+    "shortName": "lumiatestnet",
+    "nativeCurrency": {
+      "symbol": "LUMIA"
+    }
+  },
+  {
+    "chainId": 2021121117,
+    "name": "DataHopper",
+    "shortName": "hop",
+    "nativeCurrency": {
+      "symbol": "HOP"
+    }
+  },
+  {
+    "chainId": 2030232745,
+    "name": "Lumia Beam Testnet",
+    "shortName": "lumia-beam-testnet",
+    "nativeCurrency": {
+      "symbol": "LUMIA"
+    }
+  },
+  {
+    "chainId": 2046399126,
+    "name": "SKALE Europa Hub",
+    "shortName": "europa",
+    "nativeCurrency": {
+      "symbol": "sFUEL"
+    }
+  },
+  {
+    "chainId": 2478899481,
+    "name": "Accumulate Kermit",
+    "shortName": "Kermit",
+    "nativeCurrency": {
+      "symbol": "ACME"
+    }
+  },
+  {
+    "chainId": 2494104990,
+    "name": "Tron Shasta",
+    "shortName": "tron-shasta",
+    "nativeCurrency": {
+      "symbol": "TRX"
+    }
+  },
+  {
+    "chainId": 2863311531,
+    "name": "Ancient8 Testnet (deprecated)",
+    "shortName": "a8old",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 3125659152,
+    "name": "Pirl",
+    "shortName": "pirl",
+    "nativeCurrency": {
+      "symbol": "PIRL"
+    }
+  },
+  {
+    "chainId": 3416255149,
+    "name": "Ultima Mainnet",
+    "shortName": "ultima",
+    "nativeCurrency": {
+      "symbol": "ULTIMA"
+    }
+  },
+  {
+    "chainId": 3448148188,
+    "name": "Tron Nile",
+    "shortName": "tron-nile",
+    "nativeCurrency": {
+      "symbol": "TRX"
+    }
+  },
+  {
+    "chainId": 4216137055,
+    "name": "OneLedger Testnet Frankenstein",
+    "shortName": "frankenstein",
+    "nativeCurrency": {
+      "symbol": "OLT"
+    }
+  },
+  {
+    "chainId": 7078815900,
+    "name": "Mekong",
+    "shortName": "mekong",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 7088110746,
+    "name": "pectra-devnet-5",
+    "shortName": "pectra5",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 8691942025,
+    "name": "ONFA Chain",
+    "shortName": "onfa",
+    "nativeCurrency": {
+      "symbol": "OFC"
+    }
+  },
+  {
+    "chainId": 11297108099,
+    "name": "Palm Testnet",
+    "shortName": "tpalm",
+    "nativeCurrency": {
+      "symbol": "PALM"
+    }
+  },
+  {
+    "chainId": 11297108109,
+    "name": "Palm",
+    "shortName": "palm",
+    "nativeCurrency": {
+      "symbol": "PALM"
+    }
+  },
+  {
+    "chainId": 28872323069,
+    "name": "GitSwarm Test Network",
+    "shortName": "GS-ETH",
+    "nativeCurrency": {
+      "symbol": "GS-ETH"
+    }
+  },
+  {
+    "chainId": 37714555429,
+    "name": "Xai Testnet v2",
+    "shortName": "xaitestnet",
+    "nativeCurrency": {
+      "symbol": "sXAI"
+    }
+  },
+  {
+    "chainId": 44474237230,
+    "name": "Deriw Devnet",
+    "shortName": "deriw-dev",
+    "nativeCurrency": {
+      "symbol": "Der"
+    }
+  },
+  {
+    "chainId": 88153591557,
+    "name": "Arbitrum Blueberry",
+    "shortName": "arb-blueberry",
+    "nativeCurrency": {
+      "symbol": "CGT"
+    }
+  },
+  {
+    "chainId": 96737205180,
+    "name": "ALDChain Testnet",
+    "shortName": "ald",
+    "nativeCurrency": {
+      "symbol": "ALD"
+    }
+  },
+  {
+    "chainId": 107107114116,
+    "name": "Kakarot Sepolia Deprecated",
+    "shortName": "kkrt-sepolia-deprecated",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 111222333444,
+    "name": "Alphabet Mainnet",
+    "shortName": "alphabet",
+    "nativeCurrency": {
+      "symbol": "ALT"
+    }
+  },
+  {
+    "chainId": 111551119090,
+    "name": "Thanos Sepolia",
+    "shortName": "thanos-sepolia",
+    "nativeCurrency": {
+      "symbol": "TON"
+    }
+  },
+  {
+    "chainId": 123420000220,
+    "name": "Fluence Stage",
+    "shortName": "fluence-stage",
+    "nativeCurrency": {
+      "symbol": "tFLT"
+    }
+  },
+  {
+    "chainId": 123420000558,
+    "name": "PIN",
+    "shortName": "PIN",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 123420000586,
+    "name": "sivo-defi-testnet",
+    "shortName": "sivo-defi-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 123420000588,
+    "name": "volmex",
+    "shortName": "volmex",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 123420001114,
+    "name": "Basecamp",
+    "shortName": "Basecamp",
+    "nativeCurrency": {
+      "symbol": "CAMP"
+    }
+  },
+  {
+    "chainId": 197710212030,
+    "name": "Ntity Mainnet",
+    "shortName": "ntt",
+    "nativeCurrency": {
+      "symbol": "NTT"
+    }
+  },
+  {
+    "chainId": 197710212031,
+    "name": "Haradev Testnet",
+    "shortName": "haradev",
+    "nativeCurrency": {
+      "symbol": "NTTH"
+    }
+  },
+  {
+    "chainId": 202402181627,
+    "name": "GM Network Testnet",
+    "shortName": "gmnetwork-testnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 383414847825,
+    "name": "Zeniq",
+    "shortName": "zeniq",
+    "nativeCurrency": {
+      "symbol": "ZENIQ"
+    }
+  },
+  {
+    "chainId": 666301171999,
+    "name": "PDC Mainnet",
+    "shortName": "ipdc",
+    "nativeCurrency": {
+      "symbol": "PDC"
+    }
+  },
+  {
+    "chainId": 666301179999,
+    "name": "SmartPay Mobile Money",
+    "shortName": "SmartPay",
+    "nativeCurrency": {
+      "symbol": "SMM"
+    }
+  },
+  {
+    "chainId": 6022140761023,
+    "name": "Molereum Network",
+    "shortName": "mole",
+    "nativeCurrency": {
+      "symbol": "MOLE"
+    }
+  },
+  {
+    "chainId": 16604737732183,
+    "name": "Flame Testnet",
+    "shortName": "flame-testnet",
+    "nativeCurrency": {
+      "symbol": "TIA"
+    }
+  },
+  {
+    "chainId": 428962654539583,
+    "name": "Yominet",
+    "shortName": "yomi",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 868455272153094,
+    "name": "Godwoken Testnet (V1)",
+    "shortName": "gw-testnet-v1-deprecated",
+    "nativeCurrency": {
+      "symbol": "CKB"
+    }
+  },
+  {
+    "chainId": 920637907288165,
+    "name": "Kakarot Starknet Sepolia",
+    "shortName": "kkrt-starknet-sepolia",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2713017997578000,
+    "name": "DCHAIN Testnet",
+    "shortName": "dchaint",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  },
+  {
+    "chainId": 2716446429837000,
+    "name": "DCHAIN",
+    "shortName": "dchainmainnet",
+    "nativeCurrency": {
+      "symbol": "ETH"
+    }
+  }
+]

--- a/src/utils/chainMetadata.ts
+++ b/src/utils/chainMetadata.ts
@@ -1,0 +1,20 @@
+import chains from '../data/chains.json';
+
+type ChainEntry = {
+  chainId: number;
+  name: string;
+  shortName: string | null;
+  nativeCurrency: { symbol: string };
+};
+
+const chainMap = new Map<number, ChainEntry>(
+  (chains as ChainEntry[]).map(c => [c.chainId, c]),
+);
+
+export function getChainName(chainId: number): string {
+  return chainMap.get(chainId)?.name ?? `Chain ${chainId}`;
+}
+
+export function getNativeCurrencySymbol(chainId: number): string {
+  return chainMap.get(chainId)?.nativeCurrency.symbol ?? 'ETH';
+}

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -77,7 +77,7 @@ function bufToBigInt(b: Uint8Array): bigint {
   return BigInt('0x' + Buffer.from(b).toString('hex'));
 }
 
-function weiToEth(wei: bigint): string {
+function weiToNative(wei: bigint, symbol: string): string {
   if (wei === 0n) {
     return '0';
   }
@@ -87,7 +87,7 @@ function weiToEth(wei: bigint): string {
     return `${wei.toString()} wei`;
   }
 
-  return `${eth} ETH`;
+  return `${eth} ${symbol}`;
 }
 
 function weiToGwei(wei: bigint): string {
@@ -124,7 +124,7 @@ function assertList(value: RlpValue | undefined, field: string): RlpValue[] {
 }
 
 /** Parse a legacy (type 1) unsigned tx: RLP([nonce, gasPrice, gasLimit, to, value, data]) */
-function parseLegacy(bytes: Buffer): ParsedTx {
+function parseLegacy(bytes: Buffer, symbol: string): ParsedTx {
   const decoded = assertList(RLP.decode(bytes) as RlpValue, 'legacy payload');
   if (decoded.length < 6) {
     throw new Error(
@@ -139,7 +139,7 @@ function parseLegacy(bytes: Buffer): ParsedTx {
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
-    value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
+    value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
     data: dataHex,
     decodedCall: dataHex ? decodeCalldata(dataHex) ?? undefined : undefined,
     fees: {
@@ -152,7 +152,7 @@ function parseLegacy(bytes: Buffer): ParsedTx {
 
 /** Parse an EIP-1559 (type 4 / 0x02) unsigned tx:
  *  0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList]) */
-function parseEIP1559(bytes: Buffer): ParsedTx {
+function parseEIP1559(bytes: Buffer, symbol: string): ParsedTx {
   // Strip the 0x02 type prefix
   const rlpBytes = bytes[0] === 0x02 ? bytes.slice(1) : bytes;
   const decoded = assertList(
@@ -183,7 +183,7 @@ function parseEIP1559(bytes: Buffer): ParsedTx {
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
-    value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
+    value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
     data: dataHexEip1559,
     decodedCall: dataHexEip1559
       ? decodeCalldata(dataHexEip1559) ?? undefined
@@ -202,7 +202,7 @@ function parseEIP1559(bytes: Buffer): ParsedTx {
 }
 
 /** EIP-2930 (type 0x01): 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]) */
-function parseEIP2930(bytes: Buffer): ParsedTx {
+function parseEIP2930(bytes: Buffer, symbol: string): ParsedTx {
   const rlpBytes = bytes.slice(1);
   const decoded = assertList(
     RLP.decode(rlpBytes) as RlpValue,
@@ -222,7 +222,7 @@ function parseEIP2930(bytes: Buffer): ParsedTx {
   return {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
-    value: weiToEth(bufToBigInt(assertBytes(value, 'value'))),
+    value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
     data: dataHexEip2930,
     decodedCall: dataHexEip2930
       ? decodeCalldata(dataHexEip2930) ?? undefined
@@ -243,12 +243,14 @@ function parseEIP2930(bytes: Buffer): ParsedTx {
 export function parseTx(
   signDataHex: string,
   dataType: number,
+  nativeCurrencySymbol: string = 'ETH',
 ): ParsedTx | null {
   try {
     const bytes = Buffer.from(signDataHex, 'hex');
-    if (dataType === 1 && bytes[0] === 0x01) return parseEIP2930(bytes);
-    if (dataType === 1) return parseLegacy(bytes);
-    if (dataType === 4) return parseEIP1559(bytes);
+    if (dataType === 1 && bytes[0] === 0x01)
+      return parseEIP2930(bytes, nativeCurrencySymbol);
+    if (dataType === 1) return parseLegacy(bytes, nativeCurrencySymbol);
+    if (dataType === 4) return parseEIP1559(bytes, nativeCurrencySymbol);
     return null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-chains.js` (and `npm run generate:chains` / `npm run generate`) that fetches the chainid.network registry and writes a trimmed snapshot to `src/data/chains.json` (2593 chains, no runtime network call)
- Replaces the hardcoded 16-entry `CHAIN_NAMES` map in `EthSignRequestDetail` with `src/utils/chainMetadata.ts`  - `getChainName` and `getNativeCurrencySymbol`
- Transaction review header now shows the chain name ("Ethereum Mainnet", "Base", …) instead of raw chain ID; unknown IDs fall back to "Chain N"
- Native value display uses the correct currency symbol per chain ("0.05 BNB" on chain 56, "0.05 POL" on chain 137) instead of hardcoded "ETH"; `parseTx` accepts an optional `nativeCurrencySymbol` param (default `"ETH"`) so all existing tests pass unchanged
