### PR TITLE
feat: read and set Keycard name via NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Read Keycard names during NFC sessions and add a Keycard menu action to set or clear the on-card name
+
 ## [1.2.0] - 2026-04-29
 
 ### Added

--- a/__tests__/KeycardMenuScreen.test.tsx
+++ b/__tests__/KeycardMenuScreen.test.tsx
@@ -41,16 +41,18 @@ describe('KeycardMenuScreen', () => {
     renderScreen();
     expect(screen.getByText('Initialize')).toBeTruthy();
     expect(screen.getByText('Keypair')).toBeTruthy();
+    expect(screen.getByText('Set card name')).toBeTruthy();
     expect(screen.getByText('Secrets')).toBeTruthy();
     expect(screen.getByText('Factory reset')).toBeTruthy();
   });
 
-  it('shows the NFC indicator only for Initialize', () => {
+  it('shows the NFC indicator only for direct NFC actions', () => {
     renderScreen();
     expect(screen.getByTestId('menu-nfc-indicator-0')).toBeTruthy();
     expect(screen.queryByTestId('menu-nfc-indicator-1')).toBeNull();
     expect(screen.queryByTestId('menu-nfc-indicator-2')).toBeNull();
     expect(screen.queryByTestId('menu-nfc-indicator-3')).toBeNull();
+    expect(screen.queryByTestId('menu-nfc-indicator-4')).toBeNull();
   });
 
   it('renders the NFC indicator with the primary accent color', () => {
@@ -65,6 +67,7 @@ describe('KeycardMenuScreen', () => {
     for (const [label, destination] of [
       ['Initialize', 'InitCard'],
       ['Keypair', 'KeyPairMenu'],
+      ['Set card name', 'SetCardName'],
       ['Secrets', 'SecretsMenu'],
       ['Factory reset', 'FactoryReset'],
     ] as const) {

--- a/__tests__/NFCBottomSheet.test.tsx
+++ b/__tests__/NFCBottomSheet.test.tsx
@@ -61,6 +61,16 @@ describe('NFCBottomSheet', () => {
       renderSheet(makeNfc('nfc', { status: 'Waiting for card…' }));
       expect(screen.getByText('Waiting for card…')).toBeTruthy();
     });
+
+    it('shows the card name after it is read', () => {
+      renderSheet(makeNfc('nfc', { cardName: 'Main card' }));
+      expect(screen.getByText('Main card')).toBeTruthy();
+    });
+
+    it('shows unnamed placeholder for a blank card name', () => {
+      renderSheet(makeNfc('nfc', { cardName: '' }));
+      expect(screen.getByText('Unnamed card')).toBeTruthy();
+    });
   });
 
   describe('Cancel button — phase nfc (scanning)', () => {

--- a/__tests__/SetCardNameScreen.test.tsx
+++ b/__tests__/SetCardNameScreen.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+
+import SetCardNameScreen from '../src/screens/SetCardNameScreen';
+
+const mockStart = jest.fn();
+const mockCancel = jest.fn();
+let mockPhase = 'idle';
+let keyboardDidShow: ((event: any) => void) | null = null;
+let keyboardDidHide: (() => void) | null = null;
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return { MD3DarkTheme: { colors: {} }, Text };
+});
+
+jest.mock('../src/assets/icons', () => {
+  const { View } = require('react-native');
+  const Icon = (props: any) => <View {...props} />;
+  return {
+    Icons: {
+      nfcActivate: Icon,
+    },
+  };
+});
+
+jest.spyOn(Keyboard, 'addListener').mockImplementation((event, callback) => {
+  if (event === 'keyboardDidShow' || event === 'keyboardWillShow') {
+    keyboardDidShow = callback as (event: any) => void;
+  }
+  if (event === 'keyboardDidHide' || event === 'keyboardWillHide') {
+    keyboardDidHide = callback as () => void;
+  }
+  return { remove: jest.fn() } as any;
+});
+
+jest.mock('../src/components/NFCBottomSheet', () => {
+  const { Pressable, Text } = require('react-native');
+  return function MockNFCBottomSheet({ nfc, onCancel }: any) {
+    return (
+      <>
+        <Text>NFC phase: {nfc.phase}</Text>
+        <Pressable onPress={onCancel}>
+          <Text>Cancel NFC</Text>
+        </Pressable>
+      </>
+    );
+  };
+});
+
+jest.mock('../src/hooks/keycard/useSetCardName', () => ({
+  useSetCardName: () => ({
+    phase: mockPhase,
+    status: '',
+    start: mockStart,
+    cancel: mockCancel,
+  }),
+}));
+
+const navigation = {
+  goBack: jest.fn(),
+  reset: jest.fn(),
+  setOptions: jest.fn(),
+} as any;
+const route = { key: 'SetCardName', name: 'SetCardName' } as any;
+
+function renderScreen() {
+  return render(<SetCardNameScreen navigation={navigation} route={route} />);
+}
+
+describe('SetCardNameScreen', () => {
+  beforeEach(() => {
+    mockPhase = 'idle';
+    mockStart.mockReset();
+    mockCancel.mockReset();
+    navigation.goBack.mockClear();
+    navigation.reset.mockClear();
+    navigation.setOptions.mockClear();
+    keyboardDidShow = null;
+    keyboardDidHide = null;
+  });
+
+  it('submits the entered card name', () => {
+    renderScreen();
+    fireEvent.changeText(screen.getByPlaceholderText('Unnamed card'), 'Vault');
+    fireEvent.press(screen.getByText('Save card name'));
+    expect(mockStart).toHaveBeenCalledWith('Vault');
+  });
+
+  it('shows validation errors from the start handler', () => {
+    mockStart.mockImplementationOnce(() => {
+      throw new Error('Card name must be 20 bytes or fewer.');
+    });
+    renderScreen();
+    fireEvent.changeText(screen.getByPlaceholderText('Unnamed card'), 'Vault');
+    fireEvent.press(screen.getByText('Save card name'));
+    expect(
+      screen.getByText('Card name must be 20 bytes or fewer.'),
+    ).toBeTruthy();
+  });
+
+  it('cancels the NFC flow and goes back', () => {
+    mockPhase = 'nfc';
+    renderScreen();
+    fireEvent.press(screen.getByText('Cancel NFC'));
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an empty name to clear the card name', () => {
+    renderScreen();
+    fireEvent.press(screen.getByText('Save card name'));
+    expect(mockStart).toHaveBeenCalledWith('');
+  });
+
+  it('focuses the name field on open', () => {
+    renderScreen();
+    expect(screen.getByPlaceholderText('Unnamed card').props.autoFocus).toBe(
+      true,
+    );
+  });
+
+  it('navigates to dashboard when the NFC operation completes', () => {
+    mockPhase = 'done';
+    renderScreen();
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Dashboard', params: { toast: 'Card name updated' } }],
+    });
+  });
+
+  it('moves the bottom action above the keyboard', () => {
+    const { toJSON } = renderScreen();
+    fireEvent.changeText(screen.getByPlaceholderText('Unnamed card'), 'Vault');
+
+    act(() => {
+      keyboardDidShow?.({ endCoordinates: { height: 280 } });
+    });
+
+    expect(JSON.stringify(toJSON())).toContain('"paddingBottom":288');
+
+    act(() => {
+      keyboardDidHide?.();
+    });
+
+    expect(JSON.stringify(toJSON())).toContain('"paddingBottom":16');
+  });
+});

--- a/__tests__/keycardName.test.ts
+++ b/__tests__/keycardName.test.ts
@@ -1,0 +1,110 @@
+/* eslint-disable no-bitwise */
+
+import {
+  displayKeycardName,
+  encodeKeycardName,
+  mergeKeycardNameMetadata,
+  parseKeycardName,
+  validateKeycardName,
+} from '../src/utils/keycardName';
+
+describe('keycardName', () => {
+  it('encodes and parses shell-compatible length-prefixed names', () => {
+    const encoded = encodeKeycardName('Main card');
+    expect(Array.from(encoded)).toEqual([
+      0x20 | 9,
+      0x4d,
+      0x61,
+      0x69,
+      0x6e,
+      0x20,
+      0x63,
+      0x61,
+      0x72,
+      0x64,
+    ]);
+    expect(parseKeycardName(encoded)).toBe('Main card');
+  });
+
+  it('encodes an empty name as a clear operation', () => {
+    const encoded = encodeKeycardName('');
+    expect(Array.from(encoded)).toEqual([0x20]);
+    expect(parseKeycardName(encoded)).toBe('');
+  });
+
+  it('parses missing metadata as an empty name', () => {
+    expect(parseKeycardName()).toBe('');
+    expect(parseKeycardName(null)).toBe('');
+    expect(parseKeycardName(new Uint8Array())).toBe('');
+  });
+
+  it('ignores metadata that does not start with a name field', () => {
+    expect(parseKeycardName(new Uint8Array([0x40, 0x01]))).toBe('');
+  });
+
+  it('throws on corrupt metadata where name length exceeds data', () => {
+    const corrupt = new Uint8Array([0x20 | 10, 0x41]);
+    expect(() => mergeKeycardNameMetadata('New', corrupt)).toThrow(
+      'Corrupt card metadata',
+    );
+  });
+
+  it('preserves existing metadata after the card name field', () => {
+    const current = new Uint8Array([
+      0x20 | 3,
+      0x6f,
+      0x6c,
+      0x64,
+      0x40,
+      0x02,
+      0xaa,
+      0xbb,
+    ]);
+    expect(Array.from(mergeKeycardNameMetadata('New', current))).toEqual([
+      0x20 | 3,
+      0x4e,
+      0x65,
+      0x77,
+      0x40,
+      0x02,
+      0xaa,
+      0xbb,
+    ]);
+  });
+
+  it('uses only the encoded name when there is no existing name metadata', () => {
+    expect(Array.from(mergeKeycardNameMetadata('New'))).toEqual([
+      0x20 | 3,
+      0x4e,
+      0x65,
+      0x77,
+    ]);
+    expect(
+      Array.from(mergeKeycardNameMetadata('New', new Uint8Array([0x40]))),
+    ).toEqual([0x20 | 3, 0x4e, 0x65, 0x77]);
+  });
+
+  it('rejects names longer than the Keycard field limit', () => {
+    expect(() => encodeKeycardName('x'.repeat(21))).toThrow(
+      'Card name must be 20 bytes or fewer.',
+    );
+  });
+
+  it('validateKeycardName passes for valid names', () => {
+    expect(() => validateKeycardName('My card')).not.toThrow();
+    expect(() => validateKeycardName('')).not.toThrow();
+    expect(() => validateKeycardName('x'.repeat(20))).not.toThrow();
+  });
+
+  it('validateKeycardName rejects names over the byte limit', () => {
+    expect(() => validateKeycardName('x'.repeat(21))).toThrow(
+      'Card name must be 20 bytes or fewer.',
+    );
+  });
+
+  it('displays a placeholder for blank card names', () => {
+    expect(displayKeycardName('Main card')).toBe('Main card');
+    expect(displayKeycardName('')).toBe('Unnamed card');
+    expect(displayKeycardName(null)).toBe('Unnamed card');
+  });
+});

--- a/__tests__/pairingStorage.test.ts
+++ b/__tests__/pairingStorage.test.ts
@@ -1,7 +1,7 @@
 import {
+  deletePairing,
   loadPairing,
   savePairing,
-  deletePairing,
 } from '../src/storage/pairingStorage';
 
 // ---------------------------------------------------------------------------
@@ -92,10 +92,11 @@ describe('pairingStorage', () => {
   });
 
   describe('deletePairing', () => {
-    it('removes the entry under the correct key', async () => {
+    it('removes the pairing entry under the correct key', async () => {
       mockRemoveItem.mockResolvedValue(undefined);
       await deletePairing('abc123');
       expect(mockRemoveItem).toHaveBeenCalledWith('pairing_abc123');
+      expect(mockRemoveItem).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-bitwise */
+
 import { act, renderHook } from '@testing-library/react-native';
 import { useKeycardOperation } from '../src/hooks/keycard/useKeycardOperation';
 import type { UseKeycardOperation } from '../src/hooks/keycard/useKeycardOperation';
@@ -88,6 +90,7 @@ describe('useKeycardOperation', () => {
       const { result } = renderHook(() => useKeycardOperation<string>());
       expect(result.current.phase).toBe('idle');
       expect(result.current.status).toBe('');
+      expect(result.current.cardName).toBeNull();
       expect(result.current.result).toBeNull();
     });
   });
@@ -239,6 +242,10 @@ describe('useKeycardOperation', () => {
       getPairing: jest.fn().mockReturnValue({ pairingIndex: 0 }),
       setPairing: jest.fn(),
       autoOpenSecureChannel: jest.fn().mockResolvedValue(undefined),
+      getData: jest.fn().mockResolvedValue({
+        sw: 0x9000,
+        data: new Uint8Array([0x20 | 9, ...Buffer.from('Main card')]),
+      }),
       verifyPIN: jest.fn().mockResolvedValue({
         sw: 0x9000,
         checkAuthOK: jest.fn(),
@@ -270,6 +277,35 @@ describe('useKeycardOperation', () => {
       });
       await triggerCardConnect(result.current);
       expect(mockCheckGenuine).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads the card name after select for the active NFC session', async () => {
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.cardName).toBe('Main card');
+    });
+
+    it('enters error phase when reading the card name fails', async () => {
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        getData: jest.fn().mockResolvedValue({ sw: 0x6f00 }),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe('GET DATA failed: 0x6F00');
     });
 
     it('phase becomes genuine_warning when check fails', async () => {

--- a/__tests__/useSetCardName.test.ts
+++ b/__tests__/useSetCardName.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable no-bitwise */
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useSetCardName } from '../src/hooks/keycard/useSetCardName';
+
+type OperationFn = (cmdSet: any, helpers: any) => Promise<void>;
+
+let capturedOperation: OperationFn | null = null;
+let capturedOptions: { requiresPin?: boolean } | null = null;
+
+const mockExecute = jest.fn(
+  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+  },
+);
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOperation: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    result: null,
+    execute: mockExecute,
+    cancel: jest.fn(),
+    reset: jest.fn(),
+    submitPin: jest.fn(),
+  }),
+}));
+
+describe('useSetCardName', () => {
+  beforeEach(() => {
+    mockExecute.mockClear();
+    capturedOperation = null;
+    capturedOptions = null;
+  });
+
+  it('writes the encoded card name with PIN verification', async () => {
+    const { result } = renderHook(() => useSetCardName());
+    await act(async () => {
+      result.current.start('Vault');
+    });
+
+    expect(capturedOptions).toEqual({ requiresPin: true });
+
+    const storeData = jest.fn().mockResolvedValue({ sw: 0x9000 });
+    const getData = jest.fn().mockResolvedValue({
+      sw: 0x9000,
+      data: new Uint8Array([0x20 | 3, 0x6f, 0x6c, 0x64, 0x40, 0xaa]),
+    });
+    const setStatus = jest.fn();
+    await capturedOperation!(
+      {
+        applicationInfo: { instanceUID: new Uint8Array([0xaa, 0xbb]) },
+        getData,
+        storeData,
+      },
+      { setStatus },
+    );
+
+    expect(setStatus).toHaveBeenCalledWith('Writing card name...');
+    expect(storeData).toHaveBeenCalledWith(
+      new Uint8Array([0x20 | 5, 0x56, 0x61, 0x75, 0x6c, 0x74, 0x40, 0xaa]),
+      0x00,
+    );
+  });
+
+  it('throws when reading current metadata fails', async () => {
+    const { result } = renderHook(() => useSetCardName());
+    await act(async () => {
+      result.current.start('Vault');
+    });
+
+    await expect(
+      capturedOperation!(
+        {
+          getData: jest.fn().mockResolvedValue({ sw: 0x6f00 }),
+          storeData: jest.fn(),
+        },
+        { setStatus: jest.fn() },
+      ),
+    ).rejects.toThrow('GET DATA failed: 0x6F00');
+  });
+
+  it('throws when writing card metadata fails', async () => {
+    const { result } = renderHook(() => useSetCardName());
+    await act(async () => {
+      result.current.start('Vault');
+    });
+
+    await expect(
+      capturedOperation!(
+        {
+          getData: jest.fn().mockResolvedValue({
+            sw: 0x9000,
+            data: new Uint8Array([0x20]),
+          }),
+          storeData: jest.fn().mockResolvedValue({ sw: 0x6985 }),
+        },
+        { setStatus: jest.fn() },
+      ),
+    ).rejects.toThrow('STORE DATA failed: 0x6985');
+  });
+
+  it('throws before NFC when the name is too long', () => {
+    const { result } = renderHook(() => useSetCardName());
+    expect(() => result.current.start('x'.repeat(21))).toThrow(
+      'Card name must be 20 bytes or fewer.',
+    );
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NFCBottomSheet/NFCSheet.tsx
+++ b/src/components/NFCBottomSheet/NFCSheet.tsx
@@ -4,11 +4,13 @@ import { Text } from 'react-native-paper';
 
 import theme from '../../theme';
 import { Icons } from '../../assets/icons';
+import { displayKeycardName } from '../../utils/keycardName';
 import type { NFCVariant } from './index';
 
 type Props = {
   variant: NFCVariant;
   status: string;
+  cardName?: string | null;
   onCancel: () => void;
 };
 
@@ -57,7 +59,12 @@ function PulseRing({ delay, size }: { delay: number; size: number }) {
   );
 }
 
-export default function NFCSheet({ variant, status, onCancel }: Props) {
+export default function NFCSheet({
+  variant,
+  status,
+  cardName,
+  onCancel,
+}: Props) {
   const NfcIcon =
     variant === 'success'
       ? Icons.nfc.success
@@ -79,7 +86,9 @@ export default function NFCSheet({ variant, status, onCancel }: Props) {
       </View>
 
       <Text variant="titleLarge" style={styles.title}>
-        Tap your Keycard
+        {cardName === undefined || cardName === null
+          ? 'Tap your Keycard'
+          : displayKeycardName(cardName)}
       </Text>
       <Text variant="bodyMedium" style={styles.status}>
         {status}

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -12,6 +12,7 @@ export type NFCVariant = 'scanning' | 'success' | 'error' | 'genuine_warning';
 export type NFCOperation = {
   phase: string;
   status: string;
+  cardName?: string | null;
   pinError?: string | null;
   submitPin?: (pin: string) => void;
   proceedWithNonGenuine?: () => void;
@@ -25,7 +26,14 @@ type Props = {
 };
 
 export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
-  const { phase, status, pinError, submitPin, proceedWithNonGenuine } = nfc;
+  const {
+    phase,
+    status,
+    cardName,
+    pinError,
+    submitPin,
+    proceedWithNonGenuine,
+  } = nfc;
   const insets = useSafeAreaInsets();
   const slideAnim = useRef(new Animated.Value(400)).current;
 
@@ -97,7 +105,12 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
               ]}
             >
               <View style={styles.handle} />
-              <NFCSheet variant={variant} status={status} onCancel={onCancel} />
+              <NFCSheet
+                variant={variant}
+                status={status}
+                cardName={cardName}
+                onCancel={onCancel}
+              />
             </Animated.View>
           </View>
         )}

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -7,6 +7,7 @@ import { Commandset } from 'keycard-sdk/dist/commandset';
 import { PAIRING_PASSWORD } from '../../constants/keycard';
 import { loadPairing, savePairing } from '../../storage/pairingStorage';
 import { checkGenuine } from '../../utils/genuineCheck';
+import { displayKeycardName, parseKeycardName } from '../../utils/keycardName';
 import useNFCSession from './useNFCSession';
 
 function toHex(arr: Uint8Array): string {
@@ -35,6 +36,7 @@ export interface ExecuteOptions {
 export interface UseKeycardOperation<T> {
   phase: Phase;
   status: string;
+  cardName: string | null;
   result: T | null;
   pinError: string | null;
   execute: (op: KeycardOperationFn<T>, options?: ExecuteOptions) => void;
@@ -49,6 +51,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const [result, setResult] = useState<T | null>(null);
   const [waitingForPin, setWaitingForPin] = useState(false);
   const [pinError, setPinError] = useState<string | null>(null);
+  const [cardName, setCardName] = useState<string | null>(null);
   const [showGenuineWarning, setShowGenuineWarning] = useState(false);
 
   const pinRef = useRef('');
@@ -135,6 +138,16 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
           }, hasMasterKey: ${appInfo.hasMasterKey()}`,
       );
 
+      const dataResp = await cmdSet.getData(0x00);
+      if (dataResp.sw !== 0x9000) {
+        throw new Error(
+          `GET DATA failed: 0x${dataResp.sw.toString(16).toUpperCase()}`,
+        );
+      }
+      const name = parseKeycardName(dataResp.data);
+      setCardName(name);
+      setStatus(`Connected to ${displayKeycardName(name)}`);
+
       const existingPairing = await loadPairing(uid);
       if (!existingPairing && !approvedNonGenuineUidsRef.current.has(uid)) {
         setStatus('Verifying card...');
@@ -213,6 +226,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     resetNFC();
     setWaitingForPin(false);
     setPinError(null);
+    setCardName(null);
     setShowGenuineWarning(false);
     pendingUidRef.current = null;
     pinRef.current = '';
@@ -224,6 +238,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     resetNFC();
     setWaitingForPin(false);
     setPinError(null);
+    setCardName(null);
     setShowGenuineWarning(false);
     pendingUidRef.current = null;
     pinRef.current = '';
@@ -235,6 +250,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   return {
     phase,
     status,
+    cardName,
     result,
     pinError,
     execute,

--- a/src/hooks/keycard/useSetCardName.ts
+++ b/src/hooks/keycard/useSetCardName.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+import {
+  mergeKeycardNameMetadata,
+  validateKeycardName,
+} from '../../utils/keycardName';
+import { useKeycardOperation } from './useKeycardOperation';
+
+export function useSetCardName() {
+  const keycard = useKeycardOperation<void>();
+
+  const start = useCallback(
+    (name: string) => {
+      validateKeycardName(name);
+      keycard.execute(
+        async (cmdSet, { setStatus }) => {
+          const dataResp = await cmdSet.getData(0x00);
+          if (dataResp.sw !== 0x9000) {
+            throw new Error(
+              `GET DATA failed: 0x${dataResp.sw.toString(16).toUpperCase()}`,
+            );
+          }
+
+          setStatus('Writing card name...');
+          const metadata = mergeKeycardNameMetadata(name, dataResp.data);
+          const resp = await cmdSet.storeData(metadata, 0x00);
+          if (resp.sw !== 0x9000) {
+            throw new Error(
+              `STORE DATA failed: 0x${resp.sw.toString(16).toUpperCase()}`,
+            );
+          }
+        },
+        { requiresPin: true },
+      );
+    },
+    [keycard],
+  );
+
+  return { ...keycard, start };
+}

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -16,6 +16,7 @@ import KeycardMenuScreen from '../screens/KeycardMenuScreen';
 import KeycardScreen from '../screens/KeycardScreen';
 import QRResultScreen from '../screens/QRResultScreen';
 import QRScannerScreen from '../screens/QRScannerScreen';
+import SetCardNameScreen from '../screens/SetCardNameScreen';
 import TransactionDetailScreen from '../screens/TransactionDetailScreen';
 
 // Address screens
@@ -65,6 +66,11 @@ export const routes: Route[] = [
   {
     name: 'InitCard',
     component: InitCardScreen,
+    options: defaultHeaderOptions,
+  },
+  {
+    name: 'SetCardName',
+    component: SetCardNameScreen,
     options: defaultHeaderOptions,
   },
   {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -39,6 +39,7 @@ export type SecretType = 'pin' | 'puk' | 'pairing';
 export type RootStackParamList = {
   Dashboard: { toast?: string } | undefined;
   KeycardMenu: undefined;
+  SetCardName: undefined;
   InitCard: undefined;
   SecretsMenu: undefined;
   ChangeSecret: { secretType: SecretType };
@@ -84,6 +85,11 @@ export type InitCardScreenProps = NativeStackScreenProps<
 export type KeycardMenuScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'KeycardMenu'
+>;
+
+export type SetCardNameScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'SetCardName'
 >;
 
 export type QRScannerScreenProps = NativeStackScreenProps<

--- a/src/screens/KeycardMenuScreen.tsx
+++ b/src/screens/KeycardMenuScreen.tsx
@@ -23,6 +23,10 @@ export default function KeycardMenuScreen({
       onPress: () => navigation.navigate('KeyPairMenu'),
     },
     {
+      label: 'Set card name',
+      onPress: () => navigation.navigate('SetCardName'),
+    },
+    {
       label: 'Secrets',
       onPress: () => navigation.navigate('SecretsMenu'),
     },

--- a/src/screens/SetCardNameScreen.tsx
+++ b/src/screens/SetCardNameScreen.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { Keyboard, Platform, StyleSheet, TextInput, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { SetCardNameScreenProps } from '../navigation/types';
+import theme from '../theme';
+
+import { Icons } from '../assets/icons';
+import NFCBottomSheet from '../components/NFCBottomSheet';
+import PrimaryButton from '../components/PrimaryButton';
+import { useSetCardName } from '../hooks/keycard/useSetCardName';
+import { MAX_KEYCARD_NAME_LENGTH } from '../utils/keycardName';
+
+export default function SetCardNameScreen({
+  navigation,
+}: SetCardNameScreenProps) {
+  const insets = useSafeAreaInsets();
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const keycard = useSetCardName();
+  const { phase, start, cancel } = keycard;
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'Set card name' });
+  }, [navigation]);
+
+  useEffect(() => {
+    const show = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
+      e => setKeyboardHeight(e.endCoordinates.height),
+    );
+    const hide = Keyboard.addListener(
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      () => setKeyboardHeight(0),
+    );
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 'done') {
+      return;
+    }
+
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'Dashboard', params: { toast: 'Card name updated' } }],
+    });
+  }, [phase, navigation]);
+
+  const handleSubmit = useCallback(() => {
+    try {
+      setError(null);
+      start(name);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, [name, start]);
+
+  const handleCancel = useCallback(() => {
+    cancel();
+    navigation.goBack();
+  }, [cancel, navigation]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          paddingBottom:
+            keyboardHeight > 0 ? keyboardHeight + 8 : insets.bottom + 16,
+        },
+      ]}
+    >
+      {phase === 'idle' && (
+        <View style={styles.content}>
+          <View style={styles.body}>
+            <Text style={styles.description}>
+              Set a short label stored on the Keycard. Leave it empty to clear
+              the current name.
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={name}
+              onChangeText={value => {
+                setName(value);
+                setError(null);
+              }}
+              maxLength={MAX_KEYCARD_NAME_LENGTH}
+              autoFocus
+              autoCapitalize="words"
+              autoCorrect={false}
+              placeholder="Unnamed card"
+              placeholderTextColor={theme.colors.onSurfaceDisabled}
+            />
+            <Text style={[styles.error, !error && styles.errorHidden]}>
+              {error ?? ''}
+            </Text>
+          </View>
+
+          <View style={styles.footer}>
+            <PrimaryButton
+              label="Save card name"
+              onPress={handleSubmit}
+              icon={Icons.nfcActivate}
+            />
+          </View>
+        </View>
+      )}
+
+      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 8,
+  },
+  body: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  description: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  input: {
+    backgroundColor: theme.colors.surfaceVariant,
+    borderBottomWidth: 3,
+    borderBottomColor: theme.colors.onSurface,
+    borderTopLeftRadius: 4,
+    borderTopRightRadius: 4,
+    color: theme.colors.onSurface,
+    fontSize: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  error: {
+    color: theme.colors.errorDark,
+    fontSize: 12,
+    height: 20,
+    lineHeight: 16,
+    paddingTop: 4,
+  },
+  errorHidden: {
+    opacity: 0,
+  },
+  footer: {
+    paddingBottom: 16,
+  },
+});

--- a/src/utils/keycardName.ts
+++ b/src/utils/keycardName.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-bitwise */
+
+const KEYCARD_NAME_TAG = 1 << 5;
+export const MAX_KEYCARD_NAME_LENGTH = 20;
+
+function bytesToString(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('utf8');
+}
+
+function stringToBytes(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, 'utf8'));
+}
+
+export function parseKeycardName(data?: Uint8Array | null): string {
+  if (!data || data.length === 0) {
+    return '';
+  }
+
+  if (data[0] >> 5 !== 1) {
+    return '';
+  }
+
+  const length = data[0] & 0x1f;
+  if (length === 0) {
+    return '';
+  }
+
+  return bytesToString(data.slice(1, 1 + length));
+}
+
+export function validateKeycardName(name: string): void {
+  const bytes = stringToBytes(name.trim());
+  if (bytes.length > MAX_KEYCARD_NAME_LENGTH) {
+    throw new Error(
+      `Card name must be ${MAX_KEYCARD_NAME_LENGTH} bytes or fewer.`,
+    );
+  }
+}
+
+export function encodeKeycardName(name: string): Uint8Array {
+  const trimmed = name.trim();
+  const nameBytes = stringToBytes(trimmed);
+  if (nameBytes.length > MAX_KEYCARD_NAME_LENGTH) {
+    throw new Error(
+      `Card name must be ${MAX_KEYCARD_NAME_LENGTH} bytes or fewer.`,
+    );
+  }
+
+  return new Uint8Array([KEYCARD_NAME_TAG | nameBytes.length, ...nameBytes]);
+}
+
+export function mergeKeycardNameMetadata(
+  name: string,
+  current?: Uint8Array | null,
+): Uint8Array {
+  const encodedName = encodeKeycardName(name);
+  if (!current || current.length === 0 || current[0] >> 5 !== 1) {
+    return encodedName;
+  }
+
+  const currentNameLength = current[0] & 0x1f;
+  const metadataOffset = 1 + currentNameLength;
+  if (metadataOffset > current.length) {
+    throw new Error('Corrupt card metadata: name length exceeds data length.');
+  }
+
+  return new Uint8Array([...encodedName, ...current.slice(metadataOffset)]);
+}
+
+export function displayKeycardName(name?: string | null): string {
+  return name && name.length > 0 ? name : 'Unnamed card';
+}


### PR DESCRIPTION
## Summary

- Adds `SetCardNameScreen` — text input + NFC flow to write a label to the Keycard's data store
- Adds `useSetCardName` hook: validates input before NFC opens, reads existing metadata, merges new name, writes back with `STORE DATA`
- Adds `keycardName.ts` utilities: `parseKeycardName`, `encodeKeycardName`, `validateKeycardName`, `mergeKeycardNameMetadata`, `displayKeycardName` — all compatible with keycard-shell's encoding format
- Card name is read and displayed in the NFC modal on every tap via `useKeycardOperation`
- "Set card name" entry added to `KeycardMenuScreen`

## Test plan

- [x] Build and install debug offline flavor
- [x] Open Keycard menu → Set card name
- [x] Enter a name, tap card, verify toast "Card name updated"
- [x] Re-enter NFC flow on any screen, verify card name appears in the NFC modal
- [x] Set an empty name, verify it clears the displayed name
- [x] Jest suite passes: `npx jest --no-coverage`
