### PR TITLE
feat: self-hosted F-Droid repository at fdroid.gapsign.tech

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_tag: ${{ steps.ver.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -128,3 +130,87 @@ jobs:
             android/app/build/outputs/apk/full/release/app-*-release.apk
             android/app/build/outputs/apk/offline/release/app-*-release.apk
             android/app/build/outputs/apk/release/SHA256SUMS.txt
+
+  fdroid:
+    name: Publish F-Droid Repository
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install fdroidserver
+        run: pip install fdroidserver
+
+      - name: Restore keystore
+        run: echo "${{ secrets.FDROID_KEYSTORE_B64 }}" | base64 -d > fdroid/keystore.p12
+
+      - name: Restore APKs from all previous releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+        run: |
+          mkdir -p fdroid/repo
+          gh release list --limit 100 --json tagName --jq '.[].tagName' \
+            | grep -v "^${RELEASE_TAG}$" \
+            | while read tag; do
+                gh release download "$tag" \
+                  --pattern "app-offline-*-release.apk" \
+                  --pattern "app-full-*-release.apk" \
+                  --dir fdroid/repo/ \
+                  --clobber 2>/dev/null || true
+              done
+
+      - name: Download current release APKs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+        run: |
+          mkdir -p new-apks/
+          gh release download "$RELEASE_TAG" \
+            --pattern "app-offline-*-release.apk" \
+            --pattern "app-full-*-release.apk" \
+            --dir new-apks/
+          count=$(find new-apks -maxdepth 1 -name "*.apk" | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "No APKs downloaded for $RELEASE_TAG — check release asset names."
+            exit 1
+          fi
+          cp new-apks/*.apk fdroid/repo/
+
+      - name: Copy repo icon
+        run: cp fastlane/metadata/android/en-US/images/icon.png fdroid/icon.png
+
+      - name: Run fdroid update
+        working-directory: fdroid
+        run: fdroid update --verbose
+        env:
+          FDROID_KEYSTORE_PASS: ${{ secrets.FDROID_KEYSTORE_PASS }}
+          FDROID_KEY_PASS: ${{ secrets.FDROID_KEY_PASS }}
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p pages
+          cp -r fdroid/repo pages/repo
+          cp -r fdroid/archive pages/archive 2>/dev/null || true
+          echo "fdroid.gapsign.tech" > pages/CNAME
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f fdroid/keystore.p12
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages/
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,13 @@ yarn-error.log
 # testing
 /coverage
 
+# F-Droid
+fdroid/keystore.p12
+fdroid/repo/
+fdroid/archive/
+fdroid/tmp/
+fdroid/icon.png
+
 # Yarn
 .yarn/*
 !.yarn/patches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Read Keycard names during NFC sessions and add a Keycard menu action to set or clear the on-card name
+- Self-hosted F-Droid repository at fdroid.gapsign.tech; published automatically on each tagged release via GitHub Actions
 
 ## [1.2.0] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Download the latest APK from [Releases](../../releases) and sideload it onto you
   <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/mmlado/GapSign">
     <img src="assets/badges/badge_obtainium.png" alt="Get it on Obtainium" height="70" />
   </a>
+  <a href="https://fdroid.gapsign.tech/repo?fingerprint=24EB891A8A617F8BF20892CB0CF9267709BA94056E64242AD9EDF638C2FED3D2">
+    <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="70" />
+  </a>
 </p>
 
 For most users, install the universal APK. ABI-specific split APKs are also attached to releases for smaller downloads on known device architectures.
@@ -92,7 +95,19 @@ For most users, install the universal APK. ABI-specific split APKs are also atta
 3. Use GitHub Releases as the update source.
 4. Select the universal APK from the latest release.
 
-> The APK is built automatically by GitHub Actions on every version tag. A self-hosted F-Droid repository is planned.
+### Install via F-Droid
+
+**Repository URL:**
+```
+https://fdroid.gapsign.tech/repo/
+```
+
+**Fingerprint:**
+```
+24EB891A8A617F8BF20892CB0CF9267709BA94056E64242AD9EDF638C2FED3D2
+```
+
+> The APK is built automatically by GitHub Actions on every version tag.
 
 ## Building from source
 

--- a/fdroid/config.yml
+++ b/fdroid/config.yml
@@ -1,0 +1,13 @@
+repo_name: "GapSign"
+repo_description: "Official GapSign release repository"
+repo_url: "https://fdroid.gapsign.tech/repo"
+repo_icon: icon.png
+repo_keyalias: repokey
+
+keystore: ./keystore.p12
+keystorepass: {env: FDROID_KEYSTORE_PASS}
+keypass: {env: FDROID_KEY_PASS}
+keydname: "CN=gapsign.tech, O=GapSign, C=RS"
+
+archive_older: 3
+allow_disabled_algorithms: false

--- a/fdroid/metadata/tech.gapsign.offline.yml
+++ b/fdroid/metadata/tech.gapsign.offline.yml
@@ -1,0 +1,16 @@
+Categories:
+  - Money
+  - Security
+
+License: MIT
+
+SourceCode: https://github.com/mmlado/GapSign
+IssueTracker: https://github.com/mmlado/GapSign/issues
+
+Summary: Air-gapped Ethereum and Bitcoin signing with a Keycard NFC smart card.
+Description: |
+  GapSign Offline is an air-gapped Android companion app for Status Keycard
+  NFC smart cards. Signs Ethereum and Bitcoin requests without exposing
+  private keys to a networked device. No INTERNET permission. Communication
+  with watch-only wallets happens through animated QR codes (Blockchain Commons
+  UR format); communication with the Keycard happens over NFC.

--- a/fdroid/metadata/tech.gapsign.yml
+++ b/fdroid/metadata/tech.gapsign.yml
@@ -1,0 +1,22 @@
+Categories:
+  - Money
+  - Security
+
+License: MIT
+
+SourceCode: https://github.com/mmlado/GapSign
+IssueTracker: https://github.com/mmlado/GapSign/issues
+
+Summary: Air-gapped Ethereum and Bitcoin signing with a Keycard NFC smart card.
+Description: |
+  GapSign is an air-gapped Android companion app for Status Keycard NFC smart
+  cards. Signs Ethereum and Bitcoin requests without exposing private keys to a
+  networked device. Communication with watch-only wallets happens through
+  animated QR codes (Blockchain Commons UR format); communication with the
+  Keycard happens over NFC.
+
+  This flavor declares the INTERNET permission but makes no network connections
+  in the current release. The permission is reserved for future opt-in security
+  features (such as certificate transparency checks). All signing and key
+  operations are identical to GapSign Offline. If you require a build with no
+  INTERNET permission declared, use GapSign Offline (tech.gapsign.offline).


### PR DESCRIPTION
## Summary

- Adds `fdroid/config.yml` — repo signing config using `{env:}` syntax for credentials, safe to commit
- Adds `fdroid/metadata/tech.gapsign.yml` and `tech.gapsign.offline.yml` — app metadata for both flavors
- Adds `fdroid` job to `android-release.yml` — restores APK history from GitHub Release assets, runs `fdroid update`, deploys signed index to GitHub Pages at `fdroid.gapsign.tech`
- F-Droid badge added to README alongside GitHub and Obtainium badges