### PR TITLE
feat: replace ML Kit QR scanner with internal ZXing/CameraX module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: Lint
         run: npm run lint
+
+      - name: Kotlin lint
+        working-directory: android
+        run: ./gradlew ktlintCheck
 
       - name: Run tests with coverage
         run: npm test -- --watchAll=false --coverage --coverageReporters=lcov --coverageReporters=text-summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Replace ML Kit barcode scanner with ZXing; offline flavor no longer declares INTERNET or storage permissions
+
 ## [1.3.0] - 2026-04-30
 
 ### Added

--- a/__tests__/QRScannerScreen.test.tsx
+++ b/__tests__/QRScannerScreen.test.tsx
@@ -27,7 +27,7 @@ jest.mock('react-native-paper', () => {
 // Capture the Camera's onReadCode so tests can trigger scan events.
 let capturedOnReadCode: ((event: any) => void) | null = null;
 
-jest.mock('react-native-camera-kit', () => ({
+jest.mock('../src/components/Camera', () => ({
   Camera: (props: any) => {
     capturedOnReadCode = props.onReadCode;
     return null;

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -168,4 +169,14 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    // ZXing barcode scanner — Apache 2.0, zero network dependencies
+    implementation("com.google.zxing:core:3.5.3")
+
+    // CameraX (previously transitive via react-native-camera-kit, now declared explicitly)
+    def camerax_version = "1.4.1"
+    implementation("androidx.camera:camera-core:${camerax_version}")
+    implementation("androidx.camera:camera-camera2:${camerax_version}")
+    implementation("androidx.camera:camera-lifecycle:${camerax_version}")
+    implementation("androidx.camera:camera-view:${camerax_version}")
 }

--- a/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
+++ b/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
@@ -2,14 +2,10 @@ package tech.gapsign
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.Promise
 
 class BuildConfigModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
+    override fun getName() = "BuildConfig"
 
-  override fun getName() = "BuildConfig"
-
-  override fun getConstants(): Map<String, Any> =
-    mapOf("INTERNET_ENABLED" to BuildConfig.INTERNET_ENABLED)
+    override fun getConstants(): Map<String, Any> = mapOf("INTERNET_ENABLED" to BuildConfig.INTERNET_ENABLED)
 }

--- a/android/app/src/main/java/tech/gapsign/BuildConfigPackage.kt
+++ b/android/app/src/main/java/tech/gapsign/BuildConfigPackage.kt
@@ -6,9 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
 class BuildConfigPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
-    listOf(BuildConfigModule(reactContext))
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = listOf(BuildConfigModule(reactContext))
 
-  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
-    emptyList()
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
 }

--- a/android/app/src/main/java/tech/gapsign/CameraPackage.kt
+++ b/android/app/src/main/java/tech/gapsign/CameraPackage.kt
@@ -1,0 +1,12 @@
+package tech.gapsign
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class CameraPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = emptyList()
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = listOf(CameraViewManager())
+}

--- a/android/app/src/main/java/tech/gapsign/CameraView.kt
+++ b/android/app/src/main/java/tech/gapsign/CameraView.kt
@@ -1,0 +1,140 @@
+package tech.gapsign
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.NotFoundException
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.common.HybridBinarizer
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class CameraView
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+    ) : FrameLayout(context, attrs) {
+        private val previewView =
+            PreviewView(context).apply {
+                implementationMode = PreviewView.ImplementationMode.PERFORMANCE
+            }
+        private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+        private val reader = MultiFormatReader()
+
+        init {
+            addView(previewView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+            reader.setHints(
+                mapOf(
+                    DecodeHintType.POSSIBLE_FORMATS to listOf(com.google.zxing.BarcodeFormat.QR_CODE),
+                    DecodeHintType.TRY_HARDER to true,
+                ),
+            )
+        }
+
+        // React Native sets dimensions on this ViewGroup via its own layout pass but doesn't
+        // re-measure children. Force a re-layout so PreviewView gets non-zero dimensions.
+        override fun requestLayout() {
+            super.requestLayout()
+            post {
+                measure(
+                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+                )
+                layout(left, top, right, bottom)
+            }
+        }
+
+        override fun onAttachedToWindow() {
+            super.onAttachedToWindow()
+            startCamera()
+        }
+
+        private fun startCamera() {
+            val reactContext = context as? ReactContext ?: return
+            val lifecycleOwner = reactContext.currentActivity as? LifecycleOwner ?: return
+
+            val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+            cameraProviderFuture.addListener(
+                {
+                    val cameraProvider = cameraProviderFuture.get()
+
+                    val preview =
+                        Preview.Builder().build().also {
+                            it.setSurfaceProvider(previewView.surfaceProvider)
+                        }
+
+                    val imageAnalysis =
+                        ImageAnalysis.Builder()
+                            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                            .build()
+                            .also { it.setAnalyzer(executor, ::analyzeImage) }
+
+                    try {
+                        cameraProvider.unbindAll()
+                        cameraProvider.bindToLifecycle(
+                            lifecycleOwner,
+                            CameraSelector.DEFAULT_BACK_CAMERA,
+                            preview,
+                            imageAnalysis,
+                        )
+                    } catch (_: Exception) {
+                    }
+                },
+                ContextCompat.getMainExecutor(context),
+            )
+        }
+
+        private fun analyzeImage(imageProxy: ImageProxy) {
+            try {
+                val buffer = imageProxy.planes[0].buffer
+                val data = ByteArray(buffer.remaining())
+                buffer.get(data)
+
+                val source =
+                    PlanarYUVLuminanceSource(
+                        data,
+                        imageProxy.width,
+                        imageProxy.height,
+                        0,
+                        0,
+                        imageProxy.width,
+                        imageProxy.height,
+                        false,
+                    )
+
+                val result = reader.decodeWithState(BinaryBitmap(HybridBinarizer(source)))
+                dispatchCodeEvent(result.text)
+            } catch (_: NotFoundException) {
+                // no QR in frame — expected
+            } finally {
+                reader.reset()
+                imageProxy.close()
+            }
+        }
+
+        private fun dispatchCodeEvent(value: String) {
+            val reactContext = context as? ReactContext ?: return
+            val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+            val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+            dispatcher?.dispatchEvent(ReadCodeEvent(surfaceId, id, value))
+        }
+
+        override fun onDetachedFromWindow() {
+            super.onDetachedFromWindow()
+            executor.shutdown()
+        }
+    }

--- a/android/app/src/main/java/tech/gapsign/CameraViewManager.kt
+++ b/android/app/src/main/java/tech/gapsign/CameraViewManager.kt
@@ -1,0 +1,15 @@
+package tech.gapsign
+
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+
+class CameraViewManager : SimpleViewManager<CameraView>() {
+    override fun getName() = "CameraView"
+
+    override fun createViewInstance(context: ThemedReactContext) = CameraView(context)
+
+    override fun getExportedCustomDirectEventTypeConstants() =
+        mapOf(
+            ReadCodeEvent.EVENT_NAME to mapOf("registrationName" to "onReadCode"),
+        )
+}

--- a/android/app/src/main/java/tech/gapsign/MainActivity.kt
+++ b/android/app/src/main/java/tech/gapsign/MainActivity.kt
@@ -6,17 +6,15 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnable
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 class MainActivity : ReactActivity() {
+    /**
+     * Returns the name of the main component registered from JavaScript. This is used to schedule
+     * rendering of the component.
+     */
+    override fun getMainComponentName(): String = "GapSign"
 
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun getMainComponentName(): String = "GapSign"
-
-  /**
-   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
-   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
-   */
-  override fun createReactActivityDelegate(): ReactActivityDelegate =
-      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+    /**
+     * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+     * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+     */
+    override fun createReactActivityDelegate(): ReactActivityDelegate = DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 }

--- a/android/app/src/main/java/tech/gapsign/MainApplication.kt
+++ b/android/app/src/main/java/tech/gapsign/MainApplication.kt
@@ -8,19 +8,19 @@ import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 
 class MainApplication : Application(), ReactApplication {
+    override val reactHost: ReactHost by lazy {
+        getDefaultReactHost(
+            context = applicationContext,
+            packageList =
+                PackageList(this).packages.apply {
+                    add(BuildConfigPackage())
+                    add(CameraPackage())
+                },
+        )
+    }
 
-  override val reactHost: ReactHost by lazy {
-    getDefaultReactHost(
-      context = applicationContext,
-      packageList =
-        PackageList(this).packages.apply {
-          add(BuildConfigPackage())
-        },
-    )
-  }
-
-  override fun onCreate() {
-    super.onCreate()
-    loadReactNative(this)
-  }
+    override fun onCreate() {
+        super.onCreate()
+        loadReactNative(this)
+    }
 }

--- a/android/app/src/main/java/tech/gapsign/ReadCodeEvent.kt
+++ b/android/app/src/main/java/tech/gapsign/ReadCodeEvent.kt
@@ -1,0 +1,21 @@
+package tech.gapsign
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.events.Event
+
+class ReadCodeEvent(
+    surfaceId: Int,
+    viewId: Int,
+    private val codeValue: String,
+) : Event<ReadCodeEvent>(surfaceId, viewId) {
+    override fun getEventName() = EVENT_NAME
+
+    override fun getEventData() =
+        Arguments.createMap().apply {
+            putString("codeStringValue", codeValue)
+        }
+
+    companion object {
+        const val EVENT_NAME = "topReadCode"
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,11 +10,13 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jlleitschuh.gradle:ktlint-gradle:12.1.2")
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "react": "^19.2.0",
         "react-native": "^0.83.1",
         "react-native-animated-ur-qr": "^0.1.5",
-        "react-native-camera-kit": "^17.0.1",
         "react-native-encrypted-storage": "^4.0.3",
         "react-native-get-random-values": "^2.0.0",
         "react-native-keycard": "^1.0.3",
@@ -12828,19 +12827,6 @@
       },
       "bin": {
         "react-native-asset": "esm/mod.js"
-      }
-    },
-    "node_modules/react-native-camera-kit": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-camera-kit/-/react-native-camera-kit-17.0.1.tgz",
-      "integrity": "sha512-DcXfyiNl1yXytDgCxbpny1BbhXnUUpQdzI144v9KhkgSLJo/m7ELC6uuMimQAH6h1ccRW29fQ5KY8BGboHEmww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-crypto": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react": "^19.2.0",
     "react-native": "^0.83.1",
     "react-native-animated-ur-qr": "^0.1.5",
-    "react-native-camera-kit": "^17.0.1",
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-get-random-values": "^2.0.0",
     "react-native-keycard": "^1.0.3",

--- a/src/components/Camera/index.tsx
+++ b/src/components/Camera/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { requireNativeComponent } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export interface ReadCodeEvent {
+  nativeEvent: { codeStringValue: string };
+}
+
+interface NativeCameraProps {
+  style?: StyleProp<ViewStyle>;
+  onReadCode?: (event: ReadCodeEvent) => void;
+}
+
+const NativeCamera = requireNativeComponent<NativeCameraProps>('CameraView');
+
+interface CameraProps {
+  style?: StyleProp<ViewStyle>;
+  onReadCode?: (event: ReadCodeEvent) => void;
+}
+
+export function Camera({ style, onReadCode }: CameraProps) {
+  return <NativeCamera style={style} onReadCode={onReadCode} />;
+}

--- a/src/screens/QRScannerScreen.tsx
+++ b/src/screens/QRScannerScreen.tsx
@@ -12,15 +12,16 @@ import {
   PermissionsAndroid,
   Platform,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Text, Button, ActivityIndicator, Icon } from 'react-native-paper';
-import { Camera } from 'react-native-camera-kit';
-import type { OnReadCodeData } from 'react-native-camera-kit/src/CameraProps';
 import { URDecoder } from '@ngraveio/bc-ur';
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
-import theme from '../theme';
-import { handleUR } from '../utils/ur';
+import { Text, Button, ActivityIndicator, Icon } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 import type { QRScannerScreenProps } from '../navigation/types';
+import theme from '../theme';
+
+import { Camera, type ReadCodeEvent } from '../components/Camera';
+import { handleUR } from '../utils/ur';
 
 export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
   const insets = useSafeAreaInsets();
@@ -57,7 +58,7 @@ export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
   );
 
   const onCodeScanned = useCallback(
-    (event: OnReadCodeData) => {
+    (event: ReadCodeEvent) => {
       if (scannedRef.current) {
         return;
       }
@@ -139,12 +140,7 @@ export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
   return (
     <View style={styles.fullscreen}>
       {isFocused && (
-        <Camera
-          style={StyleSheet.absoluteFill}
-          scanBarcode
-          onReadCode={onCodeScanned}
-          showFrame={false}
-        />
+        <Camera style={StyleSheet.absoluteFill} onReadCode={onCodeScanned} />
       )}
 
       <View style={styles.viewfinderContainer}>


### PR DESCRIPTION
## Summary

- `react-native-camera-kit` pulled in ML Kit -> Firebase telemetry (`com.google.android.datatransport`) -> `INTERNET` and storage permissions in the offline flavor, breaking the air-gap guarantee
- Replaced with a thin internal native module (`CameraView`) backed by ZXing (Apache 2.0) + CameraX — zero Google/Firebase dependencies, no network permissions
- JS surface is platform-neutral (`Camera` component, `CameraView` registered name) so an iOS AVFoundation implementation (#136) slots in without touching JS
- Added ktlint via ktlint-gradle and a `ktlint` CI job; fixed all existing Kotlin formatting violations
