### PR TITLE
feat: add special review renderers for Permit SafeTx and Universal Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Add special review renderers for EIP-712 Permit, PermitSingle, SafeTx, and Uniswap Universal Router calls
 - Bundle offline token logo assets for the no-INTERNET Android flavor while keeping remote token logos for network-enabled builds
 
 ## [1.4.0] - 2026-05-02

--- a/__tests__/DecodedCallSection.test.tsx
+++ b/__tests__/DecodedCallSection.test.tsx
@@ -188,6 +188,68 @@ describe('DecodedCallSection', () => {
     });
   });
 
+  describe('universal-router-execute', () => {
+    it('lists Universal Router subcommands with decoded parameters', () => {
+      const call: DecodedCall = {
+        kind: 'universal-router-execute',
+        deadline: '1712345678',
+        commands: [
+          {
+            index: 0,
+            command: '0x08',
+            name: 'V2 Swap Exact In',
+            allowRevert: false,
+            args: [
+              { name: 'recipient', type: 'address', value: ADDR_A },
+              { name: 'amountIn', type: 'uint256', value: '1000000' },
+            ],
+          },
+          {
+            index: 1,
+            command: '0x05',
+            name: 'Transfer',
+            allowRevert: true,
+            args: [{ name: 'value', type: 'uint256', value: '500' }],
+          },
+        ],
+      };
+      render(<DecodedCallSection call={call} />);
+
+      expect(screen.getByText('Uniswap Universal Router')).toBeTruthy();
+      expect(screen.getByText('Deadline: 1712345678')).toBeTruthy();
+      expect(screen.getByText('Command 1: V2 Swap Exact In')).toBeTruthy();
+      expect(screen.getByText(`recipient (address): ${ADDR_A}`)).toBeTruthy();
+      expect(screen.getByText('amountIn (uint256): 1000000')).toBeTruthy();
+      expect(
+        screen.getByText('Command 2: Transfer (allow revert)'),
+      ).toBeTruthy();
+      expect(screen.getByText('value (uint256): 500')).toBeTruthy();
+    });
+
+    it('shows Universal Router decode errors without dropping raw input', () => {
+      const call: DecodedCall = {
+        kind: 'universal-router-execute',
+        commands: [
+          {
+            index: 0,
+            command: '0x08',
+            name: 'V2 Swap Exact In',
+            allowRevert: false,
+            args: [],
+            error: 'Could not decode command input',
+            rawInput: '0xdeadbeef',
+          },
+        ],
+      };
+      render(<DecodedCallSection call={call} />);
+
+      expect(
+        screen.getByText('Decode: Could not decode command input'),
+      ).toBeTruthy();
+      expect(screen.getByText('Input: 0xdeadbeef')).toBeTruthy();
+    });
+  });
+
   describe('with token metadata (chainId + known contract)', () => {
     it('shows symbol and formatted amount for a known ERC-20 transfer', () => {
       const call: DecodedCall = {

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -84,6 +84,10 @@ function renderDetail(request: EthSignRequest) {
   return render(<EthSignRequestDetail request={request} />);
 }
 
+function typedDataHex(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('hex');
+}
+
 // ---------------------------------------------------------------------------
 // Chain name display
 // ---------------------------------------------------------------------------
@@ -290,5 +294,151 @@ describe('EthSignRequestDetail — amount row visibility', () => {
       chainId: 1,
     });
     expect(screen.getByText('0.001 ETH')).toBeTruthy();
+  });
+});
+
+describe('EthSignRequestDetail — EIP-712 special renderers', () => {
+  it('shows Permit allowance, spender, and deadline with token formatting', () => {
+    renderDetail({
+      signData: typedDataHex({
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          Permit: [
+            { name: 'owner', type: 'address' },
+            { name: 'spender', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ],
+        },
+        primaryType: 'Permit',
+        domain: {
+          name: 'USD Coin',
+          version: '2',
+          chainId: 1,
+          verifyingContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        },
+        message: {
+          owner: '0x2222222222222222222222222222222222222222',
+          spender: '0x1111111111111111111111111111111111111111',
+          value: '1000000',
+          nonce: '7',
+          deadline: '1712345678',
+        },
+      }),
+      dataType: 2,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+
+    expect(screen.getByText('EIP-712 Permit')).toBeTruthy();
+    expect(
+      screen.getByText('0x1111111111111111111111111111111111111111'),
+    ).toBeTruthy();
+    expect(screen.getByText('1 USDC')).toBeTruthy();
+    expect(screen.getByText('1712345678')).toBeTruthy();
+    expect(screen.queryByText('Message Fields')).toBeNull();
+  });
+
+  it('flags unlimited PermitSingle approvals', () => {
+    renderDetail({
+      signData: typedDataHex({
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          PermitSingle: [
+            { name: 'details', type: 'PermitDetails' },
+            { name: 'spender', type: 'address' },
+            { name: 'sigDeadline', type: 'uint256' },
+          ],
+          PermitDetails: [
+            { name: 'token', type: 'address' },
+            { name: 'amount', type: 'uint160' },
+            { name: 'expiration', type: 'uint48' },
+            { name: 'nonce', type: 'uint48' },
+          ],
+        },
+        primaryType: 'PermitSingle',
+        domain: {
+          name: 'Permit2',
+          chainId: 1,
+          verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+        },
+        message: {
+          details: {
+            token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            amount: (2n ** 160n - 1n).toString(),
+            expiration: '1712345000',
+            nonce: '1',
+          },
+          spender: '0x1111111111111111111111111111111111111111',
+          sigDeadline: '1712345678',
+        },
+      }),
+      dataType: 2,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+
+    expect(screen.getByText('Unlimited USDC')).toBeTruthy();
+    expect(screen.getByText(/Unlimited permit/)).toBeTruthy();
+  });
+
+  it('decodes SafeTx inner calldata through the selector database', () => {
+    renderDetail({
+      signData: typedDataHex({
+        types: {
+          EIP712Domain: [
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          SafeTx: [
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'data', type: 'bytes' },
+            { name: 'operation', type: 'uint8' },
+            { name: 'safeTxGas', type: 'uint256' },
+            { name: 'baseGas', type: 'uint256' },
+            { name: 'gasPrice', type: 'uint256' },
+            { name: 'gasToken', type: 'address' },
+            { name: 'refundReceiver', type: 'address' },
+            { name: 'nonce', type: 'uint256' },
+          ],
+        },
+        primaryType: 'SafeTx',
+        domain: {
+          chainId: 1,
+          verifyingContract: '0x3333333333333333333333333333333333333333',
+        },
+        message: {
+          to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          value: '0',
+          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240',
+          operation: 0,
+          safeTxGas: '100000',
+          baseGas: '21000',
+          gasPrice: '0',
+          gasToken: '0x0000000000000000000000000000000000000000',
+          refundReceiver: '0x0000000000000000000000000000000000000000',
+          nonce: '12',
+        },
+      }),
+      dataType: 2,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+
+    expect(screen.getByText('Safe Transaction')).toBeTruthy();
+    expect(screen.getByText('ERC-20 Transfer')).toBeTruthy();
+    expect(screen.getByText('1 USDC')).toBeTruthy();
+    expect(screen.queryByText(/a9059cbb/)).toBeNull();
   });
 });

--- a/__tests__/eip712.test.ts
+++ b/__tests__/eip712.test.ts
@@ -116,6 +116,163 @@ describe('parseEip712Summary', () => {
       verified: 'true',
     });
   });
+
+  it('detects EIP-2612 Permit typed data', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Permit: [
+          { name: 'owner', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Permit',
+      domain: {
+        name: 'USD Coin',
+        version: '2',
+        chainId: 1,
+        verifyingContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      },
+      message: {
+        owner: '0x2222222222222222222222222222222222222222',
+        spender: '0x1111111111111111111111111111111111111111',
+        value: '1000000',
+        nonce: '7',
+        deadline: '1712345678',
+      },
+    };
+    const signDataHex = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+
+    expect(parseEip712Summary(signDataHex)?.special).toEqual({
+      kind: 'permit',
+      tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      chainId: 1,
+      spender: '0x1111111111111111111111111111111111111111',
+      amount: 1000000n,
+      deadline: '1712345678',
+      unlimited: false,
+    });
+  });
+
+  it('detects PermitSingle typed data and flags max uint160 as unlimited', () => {
+    const maxUint160 = (2n ** 160n - 1n).toString();
+    const payload = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        PermitSingle: [
+          { name: 'details', type: 'PermitDetails' },
+          { name: 'spender', type: 'address' },
+          { name: 'sigDeadline', type: 'uint256' },
+        ],
+        PermitDetails: [
+          { name: 'token', type: 'address' },
+          { name: 'amount', type: 'uint160' },
+          { name: 'expiration', type: 'uint48' },
+          { name: 'nonce', type: 'uint48' },
+        ],
+      },
+      primaryType: 'PermitSingle',
+      domain: {
+        name: 'Permit2',
+        chainId: 1,
+        verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+      },
+      message: {
+        details: {
+          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          amount: maxUint160,
+          expiration: '1712345000',
+          nonce: '1',
+        },
+        spender: '0x1111111111111111111111111111111111111111',
+        sigDeadline: '1712345678',
+      },
+    };
+    const signDataHex = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+
+    expect(parseEip712Summary(signDataHex)?.special).toEqual({
+      kind: 'permit-single',
+      tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      chainId: 1,
+      spender: '0x1111111111111111111111111111111111111111',
+      amount: 2n ** 160n - 1n,
+      deadline: '1712345678',
+      expiration: '1712345000',
+      unlimited: true,
+    });
+  });
+
+  it('detects SafeTx typed data and decodes embedded calldata', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        SafeTx: [
+          { name: 'to', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'data', type: 'bytes' },
+          { name: 'operation', type: 'uint8' },
+          { name: 'safeTxGas', type: 'uint256' },
+          { name: 'baseGas', type: 'uint256' },
+          { name: 'gasPrice', type: 'uint256' },
+          { name: 'gasToken', type: 'address' },
+          { name: 'refundReceiver', type: 'address' },
+          { name: 'nonce', type: 'uint256' },
+        ],
+      },
+      primaryType: 'SafeTx',
+      domain: {
+        chainId: 1,
+        verifyingContract: '0x3333333333333333333333333333333333333333',
+      },
+      message: {
+        to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        value: '0',
+        data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240',
+        operation: 0,
+        safeTxGas: '100000',
+        baseGas: '21000',
+        gasPrice: '0',
+        gasToken: '0x0000000000000000000000000000000000000000',
+        refundReceiver: '0x0000000000000000000000000000000000000000',
+        nonce: '12',
+      },
+    };
+    const signDataHex = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'hex',
+    );
+
+    expect(parseEip712Summary(signDataHex)?.special).toMatchObject({
+      kind: 'safe-tx',
+      safeAddress: '0x3333333333333333333333333333333333333333',
+      chainId: 1,
+      to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      operation: 'Call',
+      nonce: '12',
+      decodedCall: {
+        kind: 'erc20-transfer',
+        amount: 1000000n,
+      },
+    });
+  });
 });
 
 describe('parseEip712Prehashed', () => {

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -1,5 +1,10 @@
 import { RLP } from '@ethereumjs/rlp';
-import { encodeFunctionData, parseAbi } from 'viem';
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  parseAbi,
+  parseAbiParameters,
+} from 'viem';
 
 import { decodeCalldata, getTxLabel, parseTx } from '../src/utils/txParser';
 
@@ -413,6 +418,91 @@ describe('decodeCalldata', () => {
   it('returns null for empty calldata', () => {
     expect(decodeCalldata('0x')).toBeNull();
     expect(decodeCalldata('')).toBeNull();
+  });
+
+  it('decodes Uniswap Universal Router execute commands individually', () => {
+    const swapInput = encodeAbiParameters(
+      parseAbiParameters(
+        'address recipient, uint256 amountIn, uint256 amountOutMin, address[] path, bool payerIsUser',
+      ),
+      [
+        RECIPIENT,
+        1000000n,
+        990000n,
+        [
+          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          '0x6b175474e89094c44da98b954eedeac495271d0f',
+        ],
+        true,
+      ],
+    );
+    const transferInput = encodeAbiParameters(
+      parseAbiParameters('address token, address recipient, uint256 value'),
+      ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', RECIPIENT, 1000000n],
+    );
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x0805', [swapInput, transferInput], 1712345678n],
+    });
+
+    const result = decodeCalldata(data);
+    expect(result).toMatchObject({
+      kind: 'universal-router-execute',
+      deadline: '1712345678',
+      commands: [
+        {
+          index: 0,
+          command: '0x08',
+          name: 'V2 Swap Exact In',
+          allowRevert: false,
+          args: expect.arrayContaining([
+            { name: 'recipient', type: 'address', value: RECIPIENT },
+            { name: 'amountIn', type: 'uint256', value: '1000000' },
+            { name: 'amountOutMin', type: 'uint256', value: '990000' },
+            { name: 'payerIsUser', type: 'bool', value: 'true' },
+          ]),
+        },
+        {
+          index: 1,
+          command: '0x05',
+          name: 'Transfer',
+          allowRevert: false,
+          args: expect.arrayContaining([
+            {
+              name: 'token',
+              type: 'address',
+              value: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            },
+            { name: 'recipient', type: 'address', value: RECIPIENT },
+            { name: 'value', type: 'uint256', value: '1000000' },
+          ]),
+        },
+      ],
+    });
+  });
+
+  it('keeps malformed Universal Router command inputs visible', () => {
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x08', ['0xdeadbeef'], 1712345678n],
+    });
+
+    expect(decodeCalldata(data)).toMatchObject({
+      kind: 'universal-router-execute',
+      commands: [
+        {
+          name: 'V2 Swap Exact In',
+          error: 'Could not decode command input',
+          rawInput: '0xdeadbeef',
+        },
+      ],
+    });
   });
 
   it('parseTx includes decodedCall for ERC-20 transfer in legacy tx', () => {

--- a/src/components/DecodedCallSection.tsx
+++ b/src/components/DecodedCallSection.tsx
@@ -186,6 +186,52 @@ export default function DecodedCallSection({
     );
   }
 
+  if (call.kind === 'universal-router-execute') {
+    return (
+      <>
+        <View style={styles.sectionHeader}>
+          <Text variant="labelMedium" style={styles.sectionHeaderText}>
+            Uniswap Universal Router
+          </Text>
+        </View>
+        {call.deadline && (
+          <View style={styles.row}>
+            <InfoRow label="Deadline" value={call.deadline} />
+          </View>
+        )}
+        {call.error && (
+          <View style={styles.warningRow}>
+            <Icon source="alert" size={16} color={theme.colors.negative} />
+            <Text variant="labelSmall" style={styles.warningText}>
+              {call.error}
+            </Text>
+          </View>
+        )}
+        {call.commands.map(command => (
+          <View key={`${command.index}-${command.command}`} style={styles.row}>
+            <InfoRow
+              label={`Command ${command.index + 1}`}
+              value={`${command.name}${
+                command.allowRevert ? ' (allow revert)' : ''
+              }`}
+            />
+            {command.args.map(arg => (
+              <InfoRow
+                key={`${command.index}-${arg.name}`}
+                label={`${arg.name} (${arg.type})`}
+                value={arg.value}
+              />
+            ))}
+            {command.error && <InfoRow label="Decode" value={command.error} />}
+            {command.rawInput && (
+              <InfoRow label="Input" value={command.rawInput} />
+            )}
+          </View>
+        ))}
+      </>
+    );
+  }
+
   return (
     <View style={styles.row}>
       <InfoRow label="Contract call" value={call.selector} />

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -1,13 +1,160 @@
 import { StyleSheet, View } from 'react-native';
 import { Icon, Text } from 'react-native-paper';
 
-import type { EthSignRequest } from '../types';
 import theme from '../theme';
+import type { EthSignRequest } from '../types';
+
 import DecodedCallSection from './DecodedCallSection';
 import InfoRow from './InfoRow';
+
 import { getChainName, getNativeCurrencySymbol } from '../utils/chainMetadata';
-import { parseEip712Prehashed, parseEip712Summary } from '../utils/eip712';
+import {
+  type Eip712SpecialReview,
+  parseEip712Prehashed,
+  parseEip712Summary,
+} from '../utils/eip712';
+import { formatTokenAmount, lookupToken } from '../utils/tokenMetadata';
 import { getTxLabel, parseTx } from '../utils/txParser';
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <View style={styles.sectionHeader}>
+      <Text variant="labelMedium" style={styles.sectionHeaderText}>
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+function formatPermitAmount(
+  special:
+    | Extract<Eip712SpecialReview, { kind: 'permit' }>
+    | Extract<Eip712SpecialReview, { kind: 'permit-single' }>,
+  chainId: number | undefined,
+): string {
+  const token = lookupToken(chainId, special.tokenContract);
+  if (special.unlimited) {
+    return token ? `Unlimited ${token.symbol}` : 'Unlimited';
+  }
+  return token
+    ? formatTokenAmount(special.amount, token)
+    : special.amount.toString();
+}
+
+function PermitReviewSection({
+  special,
+  chainId,
+}: {
+  special:
+    | Extract<Eip712SpecialReview, { kind: 'permit' }>
+    | Extract<Eip712SpecialReview, { kind: 'permit-single' }>;
+  chainId: number | undefined;
+}) {
+  return (
+    <>
+      <SectionHeader title="EIP-712 Permit" />
+      {special.tokenContract && (
+        <View style={styles.row}>
+          <InfoRow label="Token contract" value={special.tokenContract} />
+        </View>
+      )}
+      <View style={styles.row}>
+        <InfoRow label="Spender" value={special.spender} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow
+          label="Allowance"
+          value={formatPermitAmount(special, chainId)}
+        />
+      </View>
+      {special.deadline && (
+        <View style={styles.row}>
+          <InfoRow label="Deadline" value={special.deadline} />
+        </View>
+      )}
+      {special.kind === 'permit-single' && special.expiration && (
+        <View style={styles.row}>
+          <InfoRow label="Expiration" value={special.expiration} />
+        </View>
+      )}
+      {special.unlimited && (
+        <View style={styles.warningRow}>
+          <Icon source="alert" size={16} color={theme.colors.negative} />
+          <Text variant="labelSmall" style={styles.warningText}>
+            Unlimited permit - spender can transfer all tokens of this type
+          </Text>
+        </View>
+      )}
+    </>
+  );
+}
+
+function SafeTxReviewSection({
+  special,
+  chainId,
+}: {
+  special: Extract<Eip712SpecialReview, { kind: 'safe-tx' }>;
+  chainId: number | undefined;
+}) {
+  return (
+    <>
+      <SectionHeader title="Safe Transaction" />
+      {special.safeAddress && (
+        <View style={styles.row}>
+          <InfoRow label="Safe" value={special.safeAddress} />
+        </View>
+      )}
+      <View style={styles.row}>
+        <InfoRow label="To" value={special.to} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow label="Value" value={special.value} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow label="Operation" value={special.operation} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow label="Nonce" value={special.nonce} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow label="Safe tx gas" value={special.safeTxGas} />
+        <InfoRow label="Base gas" value={special.baseGas} />
+        <InfoRow label="Gas price" value={special.gasPrice} />
+      </View>
+      <View style={styles.row}>
+        <InfoRow label="Gas token" value={special.gasToken} />
+        <InfoRow label="Refund receiver" value={special.refundReceiver} />
+      </View>
+      {special.decodedCall ? (
+        <DecodedCallSection
+          call={special.decodedCall}
+          tokenContract={special.to}
+          chainId={chainId}
+        />
+      ) : (
+        special.data && (
+          <View style={styles.row}>
+            <InfoRow label="Data" value={special.data} />
+          </View>
+        )
+      )}
+    </>
+  );
+}
+
+function SpecialEip712Section({
+  special,
+  fallbackChainId,
+}: {
+  special: Eip712SpecialReview;
+  fallbackChainId: number | undefined;
+}) {
+  const chainId = fallbackChainId ?? special.chainId;
+  if (special.kind === 'permit' || special.kind === 'permit-single') {
+    return <PermitReviewSection special={special} chainId={chainId} />;
+  }
+  return <SafeTxReviewSection special={special} chainId={chainId} />;
+}
 
 export default function EthSignRequestDetail({
   request,
@@ -26,6 +173,7 @@ export default function EthSignRequestDetail({
     request.dataType === 2 && !eip712
       ? parseEip712Prehashed(request.signData)
       : null;
+  const specialEip712 = eip712?.special;
 
   return (
     <>
@@ -118,13 +266,16 @@ export default function EthSignRequestDetail({
         </>
       )}
 
-      {Object.keys(eip712?.message ?? {}).length > 0 && (
+      {specialEip712 && (
+        <SpecialEip712Section
+          special={specialEip712}
+          fallbackChainId={request.chainId}
+        />
+      )}
+
+      {!specialEip712 && Object.keys(eip712?.message ?? {}).length > 0 && (
         <>
-          <View style={styles.sectionHeader}>
-            <Text variant="labelMedium" style={styles.sectionHeaderText}>
-              Message Fields
-            </Text>
-          </View>
+          <SectionHeader title="Message Fields" />
           {Object.entries(eip712!.message).map(([key, value]) => (
             <View key={`message-${key}`} style={styles.row}>
               <InfoRow label={key} value={value} />
@@ -153,6 +304,7 @@ export default function EthSignRequestDetail({
       )}
 
       {!eip712Prehashed &&
+        !specialEip712 &&
         (!tx?.decodedCall || tx.decodedCall.kind === 'unknown-call') && (
           <View style={styles.row}>
             <InfoRow
@@ -193,5 +345,16 @@ const styles = StyleSheet.create({
   },
   sectionHeaderText: {
     color: theme.colors.onSurfaceVariant,
+  },
+  warningRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+  },
+  warningText: {
+    color: theme.colors.negative,
+    flexShrink: 1,
   },
 });

--- a/src/utils/eip712.ts
+++ b/src/utils/eip712.ts
@@ -1,6 +1,7 @@
 import { validateTypedData } from 'viem';
 
 import { ensureHexPrefix } from './hex';
+import { decodeCalldata, type DecodedCall } from './txParser';
 
 type JsonValue =
   | string
@@ -17,6 +18,7 @@ export type Eip712Summary = {
   primaryType?: string;
   domain: Record<string, string>;
   message: Record<string, string>;
+  special?: Eip712SpecialReview;
 };
 
 export type Eip712Prehashed = {
@@ -24,9 +26,48 @@ export type Eip712Prehashed = {
   messageHash: string;
 };
 
+export type Eip712SpecialReview =
+  | {
+      kind: 'permit';
+      tokenContract?: string;
+      chainId?: number;
+      spender: string;
+      amount: bigint;
+      deadline?: string;
+      unlimited: boolean;
+    }
+  | {
+      kind: 'permit-single';
+      tokenContract: string;
+      chainId?: number;
+      spender: string;
+      amount: bigint;
+      deadline?: string;
+      expiration?: string;
+      unlimited: boolean;
+    }
+  | {
+      kind: 'safe-tx';
+      safeAddress?: string;
+      chainId?: number;
+      to: string;
+      value: string;
+      data?: string;
+      decodedCall?: DecodedCall;
+      operation: string;
+      safeTxGas: string;
+      baseGas: string;
+      gasPrice: string;
+      gasToken: string;
+      refundReceiver: string;
+      nonce: string;
+    };
+
 // \x19\x01 prefix + 32-byte domain separator + 32-byte message hash = 66 bytes
 const PREHASHED_PREFIX = '1901';
 const PREHASHED_BYTE_LENGTH = 66;
+const UINT160_MAX = 2n ** 160n - 1n;
+const UINT256_MAX = 2n ** 256n - 1n;
 
 export function parseEip712Prehashed(
   signDataHex: string,
@@ -79,6 +120,133 @@ function toDisplayMap(value: unknown): Record<string, string> {
     }, {});
 }
 
+function toAddress(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return /^0x[0-9a-fA-F]{40}$/.test(value) ? value : undefined;
+}
+
+function toHexBytes(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return /^0x[0-9a-fA-F]*$/.test(value) ? value : undefined;
+}
+
+function toBigIntValue(value: unknown): bigint | undefined {
+  try {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number' && Number.isSafeInteger(value)) {
+      return BigInt(value);
+    }
+    if (typeof value === 'string' && /^\d+$/.test(value)) {
+      return BigInt(value);
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function toDisplayValue(value: unknown): string | undefined {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function toChainId(value: unknown): number | undefined {
+  const chainId = toBigIntValue(value);
+  if (chainId === undefined) return undefined;
+  const numeric = Number(chainId);
+  return Number.isSafeInteger(numeric) ? numeric : undefined;
+}
+
+function parsePermit(parsed: JsonObject): Eip712SpecialReview | null {
+  if (parsed.primaryType !== 'Permit') return null;
+  const domain = isJsonObject(parsed.domain) ? parsed.domain : {};
+  const message = isJsonObject(parsed.message) ? parsed.message : {};
+  const spender = toAddress(message.spender);
+  const amount = toBigIntValue(message.value);
+  if (!spender || amount === undefined) return null;
+
+  return {
+    kind: 'permit',
+    tokenContract: toAddress(domain.verifyingContract),
+    chainId: toChainId(domain.chainId),
+    spender,
+    amount,
+    deadline: toDisplayValue(message.deadline),
+    unlimited: amount === UINT256_MAX,
+  };
+}
+
+function parsePermitSingle(parsed: JsonObject): Eip712SpecialReview | null {
+  if (parsed.primaryType !== 'PermitSingle') return null;
+  const domain = isJsonObject(parsed.domain) ? parsed.domain : {};
+  const message = isJsonObject(parsed.message) ? parsed.message : {};
+  const details = isJsonObject(message.details) ? message.details : {};
+  const tokenContract = toAddress(details.token);
+  const spender = toAddress(message.spender);
+  const amount = toBigIntValue(details.amount);
+  if (!tokenContract || !spender || amount === undefined) return null;
+
+  return {
+    kind: 'permit-single',
+    tokenContract,
+    chainId: toChainId(domain.chainId),
+    spender,
+    amount,
+    deadline: toDisplayValue(message.sigDeadline),
+    expiration: toDisplayValue(details.expiration),
+    unlimited: amount === UINT160_MAX || amount === UINT256_MAX,
+  };
+}
+
+function parseSafeTx(parsed: JsonObject): Eip712SpecialReview | null {
+  if (parsed.primaryType !== 'SafeTx') return null;
+  const domain = isJsonObject(parsed.domain) ? parsed.domain : {};
+  const message = isJsonObject(parsed.message) ? parsed.message : {};
+  const to = toAddress(message.to);
+  const data = toHexBytes(message.data);
+  if (!to) return null;
+
+  return {
+    kind: 'safe-tx',
+    safeAddress: toAddress(domain.verifyingContract),
+    chainId: toChainId(domain.chainId),
+    to,
+    value: toDisplayValue(message.value) ?? '0',
+    data,
+    decodedCall: data ? decodeCalldata(data) ?? undefined : undefined,
+    operation:
+      toDisplayValue(message.operation) === '0'
+        ? 'Call'
+        : toDisplayValue(message.operation) === '1'
+        ? 'Delegate call'
+        : toDisplayValue(message.operation) ?? 'Unknown',
+    safeTxGas: toDisplayValue(message.safeTxGas) ?? '0',
+    baseGas: toDisplayValue(message.baseGas) ?? '0',
+    gasPrice: toDisplayValue(message.gasPrice) ?? '0',
+    gasToken: toAddress(message.gasToken) ?? String(message.gasToken ?? ''),
+    refundReceiver:
+      toAddress(message.refundReceiver) ?? String(message.refundReceiver ?? ''),
+    nonce: toDisplayValue(message.nonce) ?? '0',
+  };
+}
+
+function parseSpecialReview(
+  parsed: JsonObject,
+): Eip712SpecialReview | undefined {
+  return (
+    parsePermit(parsed) ??
+    parsePermitSingle(parsed) ??
+    parseSafeTx(parsed) ??
+    undefined
+  );
+}
+
 export function parseEip712Summary(signDataHex: string): Eip712Summary | null {
   const json = decodeUtf8(signDataHex);
   if (!json) {
@@ -107,6 +275,7 @@ export function parseEip712Summary(signDataHex: string): Eip712Summary | null {
         typeof parsed.primaryType === 'string' ? parsed.primaryType : undefined,
       domain: toDisplayMap(parsed.domain),
       message: toDisplayMap(parsed.message),
+      special: parseSpecialReview(parsed),
     };
   } catch {
     return null;

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-bitwise */
 import { RLP } from '@ethereumjs/rlp';
 import {
   decodeAbiParameters,
   formatEther,
   formatGwei,
   type AbiParameter,
+  parseAbiParameters,
 } from 'viem';
 
 import { DATA_TYPE_LABELS } from '../types';
@@ -29,10 +31,26 @@ export type DecodedCallArg = {
   value: string;
 };
 
+export type UniversalRouterCommand = {
+  index: number;
+  command: string;
+  name: string;
+  allowRevert: boolean;
+  args: DecodedCallArg[];
+  rawInput?: string;
+  error?: string;
+};
+
 export type DecodedCall =
   | { kind: 'erc20-transfer'; to: string; amount: bigint }
   | { kind: 'erc20-transferFrom'; from: string; to: string; amount: bigint }
   | { kind: 'erc20-approve'; spender: string; amount: bigint }
+  | {
+      kind: 'universal-router-execute';
+      deadline?: string;
+      commands: UniversalRouterCommand[];
+      error?: string;
+    }
   | {
       kind: 'contract-call';
       selector: string;
@@ -46,6 +64,87 @@ export type DecodedCall =
 
 const selectors = (selectorsData as SelectorsData).selectors;
 
+const UNIVERSAL_ROUTER_COMMAND_MASK = 0x1f;
+const UNIVERSAL_ROUTER_ALLOW_REVERT = 0x80;
+
+const UNIVERSAL_ROUTER_COMMANDS: Record<
+  number,
+  { name: string; params?: string }
+> = {
+  0x00: {
+    name: 'V3 Swap Exact In',
+    params:
+      'address recipient, uint256 amountIn, uint256 amountOutMin, bytes path, bool payerIsUser',
+  },
+  0x01: {
+    name: 'V3 Swap Exact Out',
+    params:
+      'address recipient, uint256 amountOut, uint256 amountInMax, bytes path, bool payerIsUser',
+  },
+  0x02: {
+    name: 'Permit2 Transfer From',
+    params: 'address token, address recipient, uint160 amount',
+  },
+  0x03: {
+    name: 'Permit2 Permit Batch',
+  },
+  0x04: {
+    name: 'Sweep',
+    params: 'address token, address recipient, uint256 amountMin',
+  },
+  0x05: {
+    name: 'Transfer',
+    params: 'address token, address recipient, uint256 value',
+  },
+  0x06: {
+    name: 'Pay Portion',
+    params: 'address token, address recipient, uint256 bips',
+  },
+  0x08: {
+    name: 'V2 Swap Exact In',
+    params:
+      'address recipient, uint256 amountIn, uint256 amountOutMin, address[] path, bool payerIsUser',
+  },
+  0x09: {
+    name: 'V2 Swap Exact Out',
+    params:
+      'address recipient, uint256 amountOut, uint256 amountInMax, address[] path, bool payerIsUser',
+  },
+  0x0a: {
+    name: 'Permit2 Permit',
+  },
+  0x0b: {
+    name: 'Wrap ETH',
+    params: 'address recipient, uint256 amountMin',
+  },
+  0x0c: {
+    name: 'Unwrap WETH',
+    params: 'address recipient, uint256 amountMin',
+  },
+  0x0d: {
+    name: 'Permit2 Transfer From Batch',
+  },
+  0x0e: {
+    name: 'Balance Check ERC-20',
+    params: 'address owner, address token, uint256 minBalance',
+  },
+  0x10: {
+    name: 'V4 Swap',
+  },
+  0x11: {
+    name: 'V3 Position Manager Permit',
+  },
+  0x12: {
+    name: 'V3 Position Manager Call',
+  },
+  0x13: {
+    name: 'V4 Initialize Pool',
+  },
+  0x14: {
+    name: 'V4 Position Manager Call',
+  },
+};
+
 function formatDecodedValue(value: unknown): string {
   if (typeof value === 'bigint') return value.toString();
   if (typeof value === 'string') return value;
@@ -56,10 +155,93 @@ function formatDecodedValue(value: unknown): string {
   );
 }
 
+function formatCommandByte(command: number): string {
+  return `0x${command.toString(16).padStart(2, '0')}`;
+}
+
+function decodeUniversalRouterCommand(
+  input: string,
+  commandByte: number,
+  index: number,
+): UniversalRouterCommand {
+  const command = commandByte & UNIVERSAL_ROUTER_COMMAND_MASK;
+  const definition = UNIVERSAL_ROUTER_COMMANDS[command];
+  const name =
+    definition?.name ?? `Unknown command ${formatCommandByte(command)}`;
+  const base = {
+    index,
+    command: formatCommandByte(command),
+    name,
+    allowRevert: (commandByte & UNIVERSAL_ROUTER_ALLOW_REVERT) !== 0,
+  };
+
+  if (!definition?.params) {
+    return {
+      ...base,
+      args: [],
+      rawInput: input,
+      error: definition ? 'Unsupported command input' : 'Unknown command',
+    };
+  }
+
+  try {
+    const params = parseAbiParameters(definition.params);
+    const decodedArgs = decodeAbiParameters(params, input as `0x${string}`);
+    return {
+      ...base,
+      args: params.map((arg, argIndex) => ({
+        name: arg.name || `arg${argIndex}`,
+        type: arg.type,
+        value: formatDecodedValue(decodedArgs[argIndex]),
+      })),
+    };
+  } catch {
+    return {
+      ...base,
+      args: [],
+      rawInput: input,
+      error: 'Could not decode command input',
+    };
+  }
+}
+
+function decodeUniversalRouterExecute(
+  decodedArgs: readonly unknown[],
+): DecodedCall | null {
+  const commandsHex = decodedArgs[0];
+  const inputs = decodedArgs[1];
+  const deadline = decodedArgs[2];
+
+  if (typeof commandsHex !== 'string' || !Array.isArray(inputs)) {
+    return null;
+  }
+
+  const commands = Buffer.from(commandsHex.replace(/^0x/, ''), 'hex');
+  if (commands.length !== inputs.length) {
+    return {
+      kind: 'universal-router-execute',
+      deadline: typeof deadline === 'bigint' ? deadline.toString() : undefined,
+      commands: [],
+      error: `Command count ${commands.length} does not match input count ${inputs.length}`,
+    };
+  }
+
+  return {
+    kind: 'universal-router-execute',
+    deadline: typeof deadline === 'bigint' ? deadline.toString() : undefined,
+    commands: Array.from(commands).map((command, index) =>
+      decodeUniversalRouterCommand(String(inputs[index]), command, index),
+    ),
+  };
+}
+
 function toSpecializedDecodedCall(
   entry: SelectorEntry,
   decodedArgs: readonly unknown[],
 ): DecodedCall | null {
+  if (entry.signature === 'execute(bytes,bytes[],uint256)') {
+    return decodeUniversalRouterExecute(decodedArgs);
+  }
   if (entry.signature === 'transfer(address,uint256)') {
     return {
       kind: 'erc20-transfer',


### PR DESCRIPTION
## Summary

- Detect EIP-712 `Permit` and `PermitSingle` payloads and render spender, allowance, deadline/expiration, and unlimited permit warnings
- Detect EIP-712 `SafeTx` payloads and decode embedded calldata through the existing selector database
- Decode Uniswap Universal Router `execute(bytes,bytes[],uint256)` calldata into individual command rows
- Preserve graceful fallback behavior for malformed or unsupported Universal Router command inputs
- Add renderer and parser coverage for Permit, PermitSingle, SafeTx, and Universal Router reviews
