### PR TITLE
feat: format displayed crypto addresses for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 - Add special review renderers for EIP-712 Permit, PermitSingle, SafeTx, and Uniswap Universal Router calls
+- Apply EIP-55 checksum formatting and shell-style address chunk coloring to displayed addresses
 - Bundle offline token logo assets for the no-INTERNET Android flavor while keeping remote token logos for network-enabled builds
 
 ## [1.4.0] - 2026-05-02

--- a/__tests__/AddressText.test.tsx
+++ b/__tests__/AddressText.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+
+import AddressText, { isDisplayAddress } from '../src/components/AddressText';
+import theme from '../src/theme';
+
+describe('AddressText', () => {
+  it('recognizes Ethereum and Bitcoin addresses', () => {
+    expect(isDisplayAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')).toBe(
+      true,
+    );
+    expect(isDisplayAddress('bc1qpncfjnresszndse506zmvjya05xcs6493cm8xf')).toBe(
+      true,
+    );
+    expect(isDisplayAddress('0xa9059cbb')).toBe(false);
+  });
+
+  it('renders Ethereum addresses in alternating four-character chunks after the prefix', () => {
+    const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+    const { UNSAFE_getAllByType } = render(<AddressText address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+
+    const spans = UNSAFE_getAllByType(Text).filter(
+      span => typeof span.props.children === 'string',
+    );
+    expect(spans.map(span => span.props.children)).toEqual([
+      '0x',
+      'd8dA',
+      '6BF2',
+      '6964',
+      'aF9D',
+      '7eEd',
+      '9e03',
+      'E534',
+      '15D3',
+      '7aA9',
+      '6045',
+    ]);
+    expect(StyleSheet.flatten(spans[0].props.style).color).toBe(
+      theme.colors.onSurfaceMuted,
+    );
+    expect(StyleSheet.flatten(spans[1].props.style).color).toBe(
+      theme.colors.onSurface,
+    );
+    expect(StyleSheet.flatten(spans[2].props.style).color).toBe(
+      theme.colors.onSurfaceSubtle,
+    );
+    expect(StyleSheet.flatten(spans[1].props.style).fontWeight).toBe('600');
+    expect(
+      StyleSheet.flatten(spans[1].props.style).backgroundColor,
+    ).toBeUndefined();
+    expect(StyleSheet.flatten(spans[2].props.style).fontWeight).toBeUndefined();
+    expect(
+      StyleSheet.flatten(spans[2].props.style).backgroundColor,
+    ).toBeUndefined();
+  });
+});

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -236,6 +236,25 @@ describe('EthSignRequestDetail — transaction type labels', () => {
   });
 });
 
+describe('EthSignRequestDetail — EIP-55 address display', () => {
+  it('checksums signer and transaction recipient addresses before display', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+      address: '0xabcdef1234567890abcdef1234567890abcdef12',
+    });
+
+    expect(
+      screen.getByText('0xabCDEF1234567890ABcDEF1234567890aBCDeF12'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef'),
+    ).toBeTruthy();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Zero value + decoded ERC-20 call hides native amount row
 // ---------------------------------------------------------------------------
@@ -298,6 +317,32 @@ describe('EthSignRequestDetail — amount row visibility', () => {
 });
 
 describe('EthSignRequestDetail — EIP-712 special renderers', () => {
+  it('shows message fields for generic EIP-712 typed data', () => {
+    renderDetail({
+      signData: typedDataHex({
+        types: {
+          EIP712Domain: [{ name: 'name', type: 'string' }],
+          Message: [{ name: 'contents', type: 'string' }],
+        },
+        primaryType: 'Message',
+        domain: { name: 'Example Dapp' },
+        message: {
+          contents: 'Approve login',
+          approved: true,
+        },
+      }),
+      dataType: 2,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+    });
+
+    expect(screen.getByText('Message Fields')).toBeTruthy();
+    expect(screen.getByText('contents')).toBeTruthy();
+    expect(screen.getByText('Approve login')).toBeTruthy();
+    expect(screen.getByText('approved')).toBeTruthy();
+    expect(screen.getByText('true')).toBeTruthy();
+  });
+
   it('shows Permit allowance, spender, and deadline with token formatting', () => {
     renderDetail({
       signData: typedDataHex({
@@ -339,6 +384,9 @@ describe('EthSignRequestDetail — EIP-712 special renderers', () => {
     expect(screen.getByText('EIP-712 Permit')).toBeTruthy();
     expect(
       screen.getByText('0x1111111111111111111111111111111111111111'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
     ).toBeTruthy();
     expect(screen.getByText('1 USDC')).toBeTruthy();
     expect(screen.getByText('1712345678')).toBeTruthy();

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -204,7 +204,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       request: fullRequest,
     });
     expect(
-      screen.getByText('0xabcdef1234567890abcdef1234567890abcdef12'),
+      screen.getByText('0xabCDEF1234567890ABcDEF1234567890aBCDeF12'),
     ).toBeTruthy();
     expect(screen.getByText('MetaMask')).toBeTruthy();
     expect(screen.getByText('01020304')).toBeTruthy();

--- a/__tests__/eip712.test.ts
+++ b/__tests__/eip712.test.ts
@@ -1,5 +1,9 @@
 import { parseEip712Prehashed, parseEip712Summary } from '../src/utils/eip712';
 
+function typedDataHex(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('hex');
+}
+
 describe('parseEip712Summary', () => {
   it('parses utf8 JSON typed data into domain and message summaries', () => {
     const signDataHex = Buffer.from(
@@ -66,6 +70,10 @@ describe('parseEip712Summary', () => {
 
   it('returns null for non-json data', () => {
     expect(parseEip712Summary('deadbeef')).toBeNull();
+  });
+
+  it('returns null for empty data', () => {
+    expect(parseEip712Summary('')).toBeNull();
   });
 
   it('returns null for JSON that is not an object', () => {
@@ -155,7 +163,7 @@ describe('parseEip712Summary', () => {
 
     expect(parseEip712Summary(signDataHex)?.special).toEqual({
       kind: 'permit',
-      tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      tokenContract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       chainId: 1,
       spender: '0x1111111111111111111111111111111111111111',
       amount: 1000000n,
@@ -208,7 +216,7 @@ describe('parseEip712Summary', () => {
 
     expect(parseEip712Summary(signDataHex)?.special).toEqual({
       kind: 'permit-single',
-      tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      tokenContract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       chainId: 1,
       spender: '0x1111111111111111111111111111111111111111',
       amount: 2n ** 160n - 1n,
@@ -264,13 +272,148 @@ describe('parseEip712Summary', () => {
       kind: 'safe-tx',
       safeAddress: '0x3333333333333333333333333333333333333333',
       chainId: 1,
-      to: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       operation: 'Call',
       nonce: '12',
       decodedCall: {
         kind: 'erc20-transfer',
         amount: 1000000n,
       },
+    });
+  });
+
+  it('does not treat incomplete Permit typed data as a special review', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [{ name: 'name', type: 'string' }],
+        Permit: [{ name: 'owner', type: 'address' }],
+      },
+      primaryType: 'Permit',
+      domain: {
+        name: 'Token',
+      },
+      message: {
+        owner: '0x2222222222222222222222222222222222222222',
+      },
+    };
+
+    expect(parseEip712Summary(typedDataHex(payload))).toMatchObject({
+      primaryType: 'Permit',
+      special: undefined,
+    });
+  });
+
+  it('flags max uint256 Permit approvals as unlimited', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Permit: [
+          { name: 'owner', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Permit',
+      domain: {
+        chainId: 1,
+        verifyingContract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      },
+      message: {
+        owner: '0x2222222222222222222222222222222222222222',
+        spender: '0x1111111111111111111111111111111111111111',
+        value: (2n ** 256n - 1n).toString(),
+        nonce: '1',
+        deadline: 0,
+      },
+    };
+
+    expect(parseEip712Summary(typedDataHex(payload))?.special).toMatchObject({
+      kind: 'permit',
+      tokenContract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      unlimited: true,
+      deadline: '0',
+    });
+  });
+
+  it('does not treat incomplete PermitSingle typed data as a special review', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [{ name: 'name', type: 'string' }],
+        PermitSingle: [{ name: 'spender', type: 'address' }],
+      },
+      primaryType: 'PermitSingle',
+      domain: { name: 'Permit2' },
+      message: {
+        spender: '0x2222222222222222222222222222222222222222',
+      },
+    };
+
+    expect(parseEip712Summary(typedDataHex(payload))).toMatchObject({
+      primaryType: 'PermitSingle',
+      special: undefined,
+    });
+  });
+
+  it('detects SafeTx delegate calls and preserves fallback values', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        SafeTx: [
+          { name: 'to', type: 'address' },
+          { name: 'data', type: 'bytes' },
+          { name: 'operation', type: 'uint8' },
+          { name: 'gasToken', type: 'string' },
+          { name: 'refundReceiver', type: 'string' },
+        ],
+      },
+      primaryType: 'SafeTx',
+      domain: {
+        chainId: '1',
+        verifyingContract: '0x3333333333333333333333333333333333333333',
+      },
+      message: {
+        to: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+        data: '0x1234',
+        operation: 1,
+        gasToken: 'native',
+        refundReceiver: '',
+      },
+    };
+
+    expect(parseEip712Summary(typedDataHex(payload))?.special).toMatchObject({
+      kind: 'safe-tx',
+      to: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      operation: 'Delegate call',
+      value: '0',
+      data: '0x1234',
+      gasToken: 'native',
+      refundReceiver: '',
+      nonce: '0',
+    });
+  });
+
+  it('does not treat SafeTx typed data without a target as a special review', () => {
+    const payload = {
+      types: {
+        EIP712Domain: [{ name: 'chainId', type: 'uint256' }],
+        SafeTx: [{ name: 'nonce', type: 'uint256' }],
+      },
+      primaryType: 'SafeTx',
+      domain: { chainId: 1 },
+      message: { nonce: '1' },
+    };
+
+    expect(parseEip712Summary(typedDataHex(payload))).toMatchObject({
+      primaryType: 'SafeTx',
+      special: undefined,
     });
   });
 });

--- a/__tests__/ethereumAddress.test.ts
+++ b/__tests__/ethereumAddress.test.ts
@@ -1,4 +1,7 @@
-import { pubKeyToEthAddress } from '../src/utils/ethereumAddress';
+import {
+  checksumEthAddress,
+  pubKeyToEthAddress,
+} from '../src/utils/ethereumAddress';
 
 // ---------------------------------------------------------------------------
 // Fixtures — secp256k1 generator point G (well-known, definitely on curve)
@@ -52,5 +55,17 @@ describe('pubKeyToEthAddress', () => {
 
   it('different keys produce different addresses', () => {
     expect(pubKeyToEthAddress(G)).not.toBe(pubKeyToEthAddress(G2));
+  });
+});
+
+describe('checksumEthAddress', () => {
+  it('applies EIP-55 checksum formatting to valid addresses', () => {
+    expect(
+      checksumEthAddress('0xabcdef1234567890abcdef1234567890abcdef12'),
+    ).toBe('0xabCDEF1234567890ABcDEF1234567890aBCDeF12');
+  });
+
+  it('returns the original value when the address is invalid', () => {
+    expect(checksumEthAddress('not-an-address')).toBe('not-an-address');
   });
 });

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -6,7 +6,12 @@ import {
   parseAbiParameters,
 } from 'viem';
 
-import { decodeCalldata, getTxLabel, parseTx } from '../src/utils/txParser';
+import {
+  decodeCalldata,
+  getTxLabel,
+  parseTx,
+  validateEthTransactionSignData,
+} from '../src/utils/txParser';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -107,9 +112,7 @@ describe('parseTx', () => {
     it('parses to address', () => {
       const hex = buildLegacyTxHex();
       const tx = parseTx(hex, 1);
-      expect(tx?.to?.toLowerCase()).toBe(
-        '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
-      );
+      expect(tx?.to).toBe('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef');
     });
 
     it('parses value as ETH string', () => {
@@ -127,15 +130,26 @@ describe('parseTx', () => {
         expect(tx.fees.gasLimit).toBe('21000');
       }
     });
+
+    it('handles contract creation and zero gas price', () => {
+      const hex = buildLegacyTxHex({
+        gasPrice: 0n,
+        to: '0x',
+      });
+      const tx = parseTx(hex, 1);
+      expect(tx?.to).toBeUndefined();
+      expect(tx?.fees.kind).toBe('legacy');
+      if (tx?.fees.kind === 'legacy') {
+        expect(tx.fees.gasPrice).toBe('0');
+      }
+    });
   });
 
   describe('EIP-2930 (dataType=1, 0x01 prefix)', () => {
     it('parses to address', () => {
       const hex = buildEIP2930TxHex();
       const tx = parseTx(hex, 1);
-      expect(tx?.to?.toLowerCase()).toBe(
-        '0xd3cda913deb6f4967b2ef3aa68f5a843da74c4ef',
-      );
+      expect(tx?.to).toBe('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef');
     });
 
     it('parses value as ETH string', () => {
@@ -186,6 +200,42 @@ describe('parseTx', () => {
 
   it('returns null for malformed hex', () => {
     expect(parseTx('zzzz', 1)).toBeNull();
+  });
+
+  it('returns null for incomplete legacy payloads', () => {
+    expect(parseTx(Buffer.from(RLP.encode([])).toString('hex'), 1)).toBeNull();
+  });
+
+  it('returns null when legacy fields are not byte values', () => {
+    const malformed = RLP.encode([
+      [], // nonce must be bytes
+      bigIntToMinBytes(1n),
+      bigIntToMinBytes(21000n),
+      hexToBytes('0x0000000000000000000000000000000000000001'),
+      bigIntToMinBytes(1n),
+      new Uint8Array(0),
+    ]);
+
+    expect(parseTx(Buffer.from(malformed).toString('hex'), 1)).toBeNull();
+  });
+
+  it('returns null for typed transaction payloads with wrong field counts', () => {
+    const eip1559 = Buffer.from(
+      new Uint8Array([0x02, ...RLP.encode([])]),
+    ).toString('hex');
+    const eip2930 = Buffer.from(
+      new Uint8Array([0x01, ...RLP.encode([])]),
+    ).toString('hex');
+
+    expect(parseTx(eip1559, 4)).toBeNull();
+    expect(parseTx(eip2930, 1)).toBeNull();
+  });
+
+  it('validates transaction sign data only for transaction data types', () => {
+    expect(() => validateEthTransactionSignData('deadbeef', 2)).not.toThrow();
+    expect(() => validateEthTransactionSignData('deadbeef', 1)).toThrow(
+      'Invalid Ethereum transaction payload',
+    );
   });
 
   describe('nativeCurrencySymbol param', () => {
@@ -502,6 +552,99 @@ describe('decodeCalldata', () => {
           rawInput: '0xdeadbeef',
         },
       ],
+    });
+  });
+
+  it('keeps unsupported Universal Router commands visible', () => {
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x0a', ['0x1234'], 1712345678n],
+    });
+
+    expect(decodeCalldata(data)).toMatchObject({
+      kind: 'universal-router-execute',
+      commands: [
+        {
+          command: '0x0a',
+          name: 'Permit2 Permit',
+          args: [],
+          rawInput: '0x1234',
+          error: 'Unsupported command input',
+        },
+      ],
+    });
+  });
+
+  it('keeps unknown Universal Router commands visible', () => {
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x1f', ['0x1234'], 1712345678n],
+    });
+
+    expect(decodeCalldata(data)).toMatchObject({
+      kind: 'universal-router-execute',
+      commands: [
+        {
+          command: '0x1f',
+          name: 'Unknown command 0x1f',
+          args: [],
+          rawInput: '0x1234',
+          error: 'Unknown command',
+        },
+      ],
+    });
+  });
+
+  it('shows Universal Router allow-revert flags', () => {
+    const input = encodeAbiParameters(
+      parseAbiParameters(
+        'address recipient, uint256 amountIn, uint256 amountOutMin, address[] path, bool payerIsUser',
+      ),
+      [
+        RECIPIENT,
+        1000000n,
+        990000n,
+        [
+          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          '0x6b175474e89094c44da98b954eedeac495271d0f',
+        ],
+        true,
+      ],
+    );
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x88', [input], 1712345678n],
+    });
+
+    expect(decodeCalldata(data)).toMatchObject({
+      kind: 'universal-router-execute',
+      commands: [{ command: '0x08', allowRevert: true }],
+    });
+  });
+
+  it('returns a Universal Router count mismatch error', () => {
+    const data = encodeFunctionData({
+      abi: parseAbi([
+        'function execute(bytes commands, bytes[] inputs, uint256 deadline)',
+      ]),
+      functionName: 'execute',
+      args: ['0x0805', ['0x1234'], 1712345678n],
+    });
+
+    expect(decodeCalldata(data)).toEqual({
+      kind: 'universal-router-execute',
+      deadline: '1712345678',
+      commands: [],
+      error: 'Command count 2 does not match input count 1',
     });
   });
 

--- a/src/components/AddressText.tsx
+++ b/src/components/AddressText.tsx
@@ -1,0 +1,72 @@
+import { StyleSheet, Text, type TextStyle } from 'react-native';
+
+import theme from '../theme';
+
+const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const BTC_BECH32_RE =
+  /^(bc1|tb1|bcrt1)[023456789acdefghjklmnpqrstuvwxyz]{11,}$/i;
+const BTC_BASE58_RE = /^[13mn2][A-HJ-NP-Za-km-z1-9]{25,62}$/;
+
+export function isDisplayAddress(value: string): boolean {
+  return (
+    ETH_ADDRESS_RE.test(value) ||
+    BTC_BECH32_RE.test(value) ||
+    BTC_BASE58_RE.test(value)
+  );
+}
+
+function chunkAddress(address: string): { prefix: string; groups: string[] } {
+  const hasHexPrefix = address.startsWith('0x') || address.startsWith('0X');
+  const prefix = hasHexPrefix ? address.slice(0, 2) : '';
+  const body = hasHexPrefix ? address.slice(2) : address;
+  const groups = body.match(/.{1,4}/g) ?? [];
+  return { prefix, groups };
+}
+
+export default function AddressText({
+  address,
+  selectable = false,
+  style,
+}: {
+  address: string;
+  selectable?: boolean;
+  style?: TextStyle | TextStyle[];
+}) {
+  const { prefix, groups } = chunkAddress(address);
+  const flattened = StyleSheet.flatten(style);
+  const activeColor = flattened?.color ?? theme.colors.onSurface;
+
+  return (
+    <Text selectable={selectable} style={[styles.address, style]}>
+      {prefix ? (
+        <Text style={[styles.address, { color: theme.colors.onSurfaceMuted }]}>
+          {prefix}
+        </Text>
+      ) : null}
+      {groups.map((group, index) => (
+        <Text
+          key={`${index}-${group}`}
+          style={[
+            styles.address,
+            index % 2 === 0 ? styles.activeGroup : null,
+            {
+              color:
+                index % 2 === 0 ? activeColor : theme.colors.onSurfaceSubtle,
+            },
+          ]}
+        >
+          {group}
+        </Text>
+      ))}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  address: {
+    fontFamily: 'monospace',
+  },
+  activeGroup: {
+    fontWeight: '600',
+  },
+});

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -13,6 +13,7 @@ import {
   parseEip712Prehashed,
   parseEip712Summary,
 } from '../utils/eip712';
+import { checksumEthAddress } from '../utils/ethereumAddress';
 import { formatTokenAmount, lookupToken } from '../utils/tokenMetadata';
 import { getTxLabel, parseTx } from '../utils/txParser';
 
@@ -174,6 +175,9 @@ export default function EthSignRequestDetail({
       ? parseEip712Prehashed(request.signData)
       : null;
   const specialEip712 = eip712?.special;
+  const signer = request.address
+    ? checksumEthAddress(request.address)
+    : request.derivationPath;
 
   return (
     <>
@@ -185,10 +189,7 @@ export default function EthSignRequestDetail({
       </View>
 
       <View style={styles.row}>
-        <InfoRow
-          label="Signer"
-          value={request.address ?? request.derivationPath}
-        />
+        <InfoRow label="Signer" value={signer} />
       </View>
 
       {request.address && (

--- a/src/components/InfoRow.tsx
+++ b/src/components/InfoRow.tsx
@@ -1,6 +1,9 @@
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
+
 import theme from '../theme';
+
+import AddressText, { isDisplayAddress } from './AddressText';
 
 export default function InfoRow({
   label,
@@ -14,9 +17,13 @@ export default function InfoRow({
       <Text variant="bodySmall" style={styles.infoLabel}>
         {label}
       </Text>
-      <Text variant="bodyMedium" style={styles.infoValue} selectable>
-        {value}
-      </Text>
+      {isDisplayAddress(value) ? (
+        <AddressText address={value} style={styles.infoValue} selectable />
+      ) : (
+        <Text variant="bodyMedium" style={styles.infoValue} selectable>
+          {value}
+        </Text>
+      )}
     </View>
   );
 }

--- a/src/components/about/DonationList.tsx
+++ b/src/components/about/DonationList.tsx
@@ -2,8 +2,10 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { Icons } from '../../assets/icons';
 import theme from '../../theme';
+
+import { Icons } from '../../assets/icons';
+import AddressText from '../AddressText';
 
 const DONATION_ADDRESSES = [
   {
@@ -27,9 +29,7 @@ export default function DonationList({ onShowQR }: DonationListProps) {
         <View key={label} style={styles.row}>
           <View style={styles.text}>
             <Text style={styles.label}>{label}</Text>
-            <Text style={styles.address} selectable>
-              {address}
-            </Text>
+            <AddressText address={address} style={styles.address} selectable />
           </View>
           <View style={styles.actions}>
             <Pressable

--- a/src/screens/address/AddressDetailScreen.tsx
+++ b/src/screens/address/AddressDetailScreen.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useLayoutEffect } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import QRCode from 'react-native-qrcode-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Icons } from '../../assets/icons';
-import PrimaryButton from '../../components/PrimaryButton';
-import theme from '../../theme';
+
 import type { AddressDetailScreenProps } from '../../navigation/types';
+import theme from '../../theme';
+
+import { Icons } from '../../assets/icons';
+import AddressText from '../../components/AddressText';
+import PrimaryButton from '../../components/PrimaryButton';
 
 export default function AddressDetailScreen({
   route,
@@ -34,9 +37,7 @@ export default function AddressDetailScreen({
             backgroundColor="#ffffff"
           />
         </View>
-        <Text selectable style={styles.address}>
-          {address}
-        </Text>
+        <AddressText address={address} selectable style={styles.address} />
       </View>
       <PrimaryButton
         label="Copy Address"

--- a/src/screens/address/AddressListScreen.tsx
+++ b/src/screens/address/AddressListScreen.tsx
@@ -1,3 +1,4 @@
+import { HDKey } from '@scure/bip32';
 import {
   memo,
   useCallback,
@@ -14,16 +15,20 @@ import {
   Text,
   View,
 } from 'react-native';
-import { Icons } from '../../assets/icons';
-import { HDKey } from '@scure/bip32';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useAddresses } from '../../hooks/keycard/useAddresses';
-import { deriveAddresses } from '../../utils/hdAddress';
-import { pubKeyToEthAddress } from '../../utils/ethereumAddress';
-import { pubKeyToBtcAddress } from '../../utils/bitcoinAddress';
-import NFCBottomSheet from '../../components/NFCBottomSheet';
+
 import { AddressListScreenProps } from '../../navigation/types';
 import theme from '../../theme';
+
+import { Icons } from '../../assets/icons';
+import AddressText from '../../components/AddressText';
+import NFCBottomSheet from '../../components/NFCBottomSheet';
+
+import { useAddresses } from '../../hooks/keycard/useAddresses';
+
+import { pubKeyToBtcAddress } from '../../utils/bitcoinAddress';
+import { pubKeyToEthAddress } from '../../utils/ethereumAddress';
+import { deriveAddresses } from '../../utils/hdAddress';
 
 const BATCH = 20;
 const ADDR_FN = { eth: pubKeyToEthAddress, btc: pubKeyToBtcAddress };
@@ -37,7 +42,7 @@ type RowProps = {
 const AddressRow = memo(({ address, index, onNavigate }: RowProps) => (
   <Pressable style={styles.row} onPress={() => onNavigate(address, index)}>
     <Text style={styles.index}>{index}</Text>
-    <Text style={styles.address}>{address}</Text>
+    <AddressText address={address} style={styles.address} />
     <View style={styles.qrIcon}>
       <Icons.qr width={20} height={20} color={theme.colors.onSurfaceVariant} />
     </View>

--- a/src/utils/eip712.ts
+++ b/src/utils/eip712.ts
@@ -1,5 +1,6 @@
 import { validateTypedData } from 'viem';
 
+import { checksumEthAddress } from './ethereumAddress';
 import { ensureHexPrefix } from './hex';
 import { decodeCalldata, type DecodedCall } from './txParser';
 
@@ -122,7 +123,9 @@ function toDisplayMap(value: unknown): Record<string, string> {
 
 function toAddress(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
-  return /^0x[0-9a-fA-F]{40}$/.test(value) ? value : undefined;
+  return /^0x[0-9a-fA-F]{40}$/.test(value)
+    ? checksumEthAddress(value)
+    : undefined;
 }
 
 function toHexBytes(value: unknown): string | undefined {

--- a/src/utils/ethereumAddress.ts
+++ b/src/utils/ethereumAddress.ts
@@ -1,6 +1,14 @@
 import * as secp from '@noble/secp256k1';
 import { getAddress, keccak256 } from 'viem';
 
+export function checksumEthAddress(address: string): string {
+  try {
+    return getAddress(address);
+  } catch {
+    return address;
+  }
+}
+
 export function pubKeyToEthAddress(compressedPubKey: Uint8Array): string {
   const uncompressed = secp.Point.fromBytes(compressedPubKey).toBytes(false);
   const hash = keccak256(uncompressed.slice(1));

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -8,8 +8,10 @@ import {
   parseAbiParameters,
 } from 'viem';
 
-import { DATA_TYPE_LABELS } from '../types';
 import selectorsData from '../data/selectors.json';
+import { DATA_TYPE_LABELS } from '../types';
+
+import { checksumEthAddress } from './ethereumAddress';
 
 type SelectorArg = AbiParameter & { name: string };
 
@@ -362,7 +364,7 @@ function weiToGwei(wei: bigint): string {
 
 function toAddress(b: Uint8Array): string | undefined {
   if (b.length === 0) return undefined; // contract creation
-  return '0x' + Buffer.from(b).toString('hex');
+  return checksumEthAddress('0x' + Buffer.from(b).toString('hex'));
 }
 
 function isBytes(value: RlpValue | undefined): value is RlpBytes {


### PR DESCRIPTION
## Summary

- Apply EIP-55 checksum formatting to displayed Ethereum addresses in transaction review, EIP-712 summaries, parsed calldata, and address views
- Add shared `AddressText` rendering for Ethereum and Bitcoin addresses with shell-style four-character visual grouping
- Use grouped address rendering in review rows, address list/detail screens, and donation address display
- Add coverage for checksum formatting, address grouping, address screen rendering, and PR 140 Codecov gaps around Permit, SafeTx, and Universal Router edge cases