### PR TITLE
feat: abort with friendly error when card has no master key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985
 - Add special review renderers for EIP-712 Permit, PermitSingle, SafeTx, and Uniswap Universal Router calls
 - Apply EIP-55 checksum formatting and shell-style address chunk coloring to displayed addresses
 - Bundle offline token logo assets for the no-INTERNET Android flavor while keeping remote token logos for network-enabled builds

--- a/__tests__/useChangeSecret.test.ts
+++ b/__tests__/useChangeSecret.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useChangeSecret } from '../src/hooks/keycard/useChangeSecret';
+
+type OperationFn = (cmdSet: any) => Promise<void>;
+
+let capturedOperation: OperationFn | null = null;
+let capturedOptions: {
+  requiresPin?: boolean;
+  requiresMasterKey?: boolean;
+} | null = null;
+
+const mockExecute = jest.fn(
+  (
+    fn: OperationFn,
+    opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
+  ) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+  },
+);
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOperation: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    result: null,
+    pinError: null,
+    execute: mockExecute,
+    cancel: jest.fn(),
+    reset: jest.fn(),
+    submitPin: jest.fn(),
+    clearPinError: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+
+describe('useChangeSecret', () => {
+  beforeEach(() => {
+    mockExecute.mockClear();
+    capturedOperation = null;
+    capturedOptions = null;
+  });
+
+  it('does not require master key', async () => {
+    const { result } = renderHook(() => useChangeSecret('pin'));
+    await act(async () => {
+      result.current.start('123456');
+    });
+
+    expect(capturedOptions).toEqual({ requiresMasterKey: false });
+  });
+
+  it('changes PIN', async () => {
+    const { result } = renderHook(() => useChangeSecret('pin'));
+    await act(async () => {
+      result.current.start('123456');
+    });
+
+    const checkOK = jest.fn();
+    const cmdSet = { changePIN: jest.fn().mockResolvedValue({ checkOK }) };
+    await capturedOperation!(cmdSet);
+
+    expect(cmdSet.changePIN).toHaveBeenCalledWith('123456');
+    expect(checkOK).toHaveBeenCalledTimes(1);
+  });
+
+  it('changes PUK', async () => {
+    const { result } = renderHook(() => useChangeSecret('puk'));
+    await act(async () => {
+      result.current.start('123456789012');
+    });
+
+    const checkOK = jest.fn();
+    const cmdSet = { changePUK: jest.fn().mockResolvedValue({ checkOK }) };
+    await capturedOperation!(cmdSet);
+
+    expect(cmdSet.changePUK).toHaveBeenCalledWith('123456789012');
+    expect(checkOK).toHaveBeenCalledTimes(1);
+  });
+
+  it('changes pairing password', async () => {
+    const { result } = renderHook(() => useChangeSecret('pairing'));
+    await act(async () => {
+      result.current.start('newpassword');
+    });
+
+    const checkOK = jest.fn();
+    const cmdSet = {
+      changePairingPassword: jest.fn().mockResolvedValue({ checkOK }),
+    };
+    await capturedOperation!(cmdSet);
+
+    expect(cmdSet.changePairingPassword).toHaveBeenCalledWith('newpassword');
+    expect(checkOK).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/useGenerateKey.test.ts
+++ b/__tests__/useGenerateKey.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useGenerateKey } from '../src/hooks/keycard/useGenerateKey';
+
+type OperationFn = (cmdSet: any) => Promise<string[]>;
+
+let capturedOperation: OperationFn | null = null;
+let capturedOptions: {
+  requiresPin?: boolean;
+  requiresMasterKey?: boolean;
+} | null = null;
+
+const mockExecute = jest.fn(
+  (
+    fn: OperationFn,
+    opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
+  ) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+  },
+);
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOperation: () => ({
+    phase: 'idle',
+    status: '',
+    result: null,
+    execute: mockExecute,
+    cancel: jest.fn(),
+    reset: jest.fn(),
+    submitPin: jest.fn(),
+  }),
+}));
+
+jest.mock('keycard-sdk/dist/constants', () => ({
+  Constants: {
+    GENERATE_MNEMONIC_12_WORDS: 12,
+    GENERATE_MNEMONIC_24_WORDS: 24,
+  },
+}));
+
+const mockGetWords = jest.fn().mockReturnValue(['word1', 'word2']);
+const mockSetWordlist = jest.fn();
+jest.mock('keycard-sdk/dist/mnemonic', () => ({
+  Mnemonic: jest.fn().mockImplementation(() => ({
+    setWordlist: mockSetWordlist,
+    getWords: mockGetWords,
+  })),
+}));
+
+jest.mock('@scure/bip39/wordlists/english.js', () => ({
+  wordlist: ['english', 'wordlist'],
+}));
+
+describe('useGenerateKey', () => {
+  beforeEach(() => {
+    mockExecute.mockClear();
+    capturedOperation = null;
+    capturedOptions = null;
+  });
+
+  it('does not require PIN or master key', async () => {
+    const { result } = renderHook(() => useGenerateKey(12));
+    await act(async () => {
+      result.current.start();
+    });
+
+    expect(capturedOptions).toEqual({
+      requiresPin: false,
+      requiresMasterKey: false,
+    });
+  });
+
+  it('uses 12-word checksum constant for size 12', async () => {
+    const { result } = renderHook(() => useGenerateKey(12));
+    await act(async () => {
+      result.current.start();
+    });
+
+    const checkOK = jest.fn();
+    const data = new Uint8Array([1, 2, 3]);
+    const words = await capturedOperation!({
+      generateMnemonic: jest.fn().mockResolvedValue({ data, checkOK }),
+    });
+
+    expect(checkOK).toHaveBeenCalledTimes(1);
+    expect(mockSetWordlist).toHaveBeenCalledWith(['english', 'wordlist']);
+    expect(words).toEqual(['word1', 'word2']);
+  });
+
+  it('uses 24-word checksum constant for size 24', async () => {
+    const { result } = renderHook(() => useGenerateKey(24));
+    await act(async () => {
+      result.current.start();
+    });
+
+    const generateMnemonic = jest
+      .fn()
+      .mockResolvedValue({ data: new Uint8Array(), checkOK: jest.fn() });
+    await capturedOperation!({ generateMnemonic });
+
+    expect(generateMnemonic).toHaveBeenCalledWith(24);
+  });
+});

--- a/__tests__/useGenerateSlip39Shares.test.ts
+++ b/__tests__/useGenerateSlip39Shares.test.ts
@@ -5,10 +5,16 @@ import { useGenerateSlip39Shares } from '../src/hooks/keycard/useGenerateSlip39S
 type OperationFn = (cmdSet: any, helpers: any) => Promise<Uint8Array>;
 
 let capturedOperation: OperationFn | null = null;
-let capturedOptions: { requiresPin?: boolean } | null = null;
+let capturedOptions: {
+  requiresPin?: boolean;
+  requiresMasterKey?: boolean;
+} | null = null;
 
 const mockExecute = jest.fn(
-  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+  (
+    fn: OperationFn,
+    opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
+  ) => {
     capturedOperation = fn;
     capturedOptions = opts;
   },
@@ -40,7 +46,10 @@ describe('useGenerateSlip39Shares', () => {
     });
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
-    expect(capturedOptions).toEqual({ requiresPin: false });
+    expect(capturedOptions).toEqual({
+      requiresPin: false,
+      requiresMasterKey: false,
+    });
 
     const entropy = new Uint8Array([1, 2, 3]);
     const checkOK = jest.fn();

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -234,7 +234,7 @@ describe('useKeycardOperation', () => {
         instanceUID: new Uint8Array([0xaa, 0xbb]),
         initializedCard: true,
         freePairingSlots: 5,
-        hasMasterKey: () => false,
+        hasMasterKey: () => true,
       },
       select: jest.fn().mockResolvedValue({ sw: 0x9000 }),
       identifyCard: jest.fn(),
@@ -393,6 +393,55 @@ describe('useKeycardOperation', () => {
       });
       expect(result.current.phase).toBe('idle');
       expect(result.current.result).toBeNull();
+    });
+
+    it('enters error phase with friendly message when card has no master key', async () => {
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        applicationInfo: {
+          instanceUID: new Uint8Array([0xaa, 0xbb]),
+          initializedCard: true,
+          freePairingSlots: 5,
+          hasMasterKey: () => false,
+        },
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'This card has no master key. Generate or import a key first.',
+      );
+    });
+
+    it('skips master key check when requiresMasterKey is false', async () => {
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        applicationInfo: {
+          instanceUID: new Uint8Array([0xaa, 0xbb]),
+          initializedCard: true,
+          freePairingSlots: 5,
+          hasMasterKey: () => false,
+        },
+      }));
+
+      const mockOp = jest.fn().mockResolvedValue('ok');
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(mockOp, {
+          requiresPin: false,
+          requiresMasterKey: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(mockOp).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/useLoadKey.test.ts
+++ b/__tests__/useLoadKey.test.ts
@@ -11,10 +11,16 @@ const mockFromBinarySeed = jest.fn().mockReturnValue({ type: 'keypair' });
 type OperationFn = (cmdSet: any) => Promise<void>;
 
 let capturedOperation: OperationFn | null = null;
-let capturedOptions: { requiresPin?: boolean } | null = null;
+let capturedOptions: {
+  requiresPin?: boolean;
+  requiresMasterKey?: boolean;
+} | null = null;
 
 const mockExecute = jest.fn(
-  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+  (
+    fn: OperationFn,
+    opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
+  ) => {
     capturedOperation = fn;
     capturedOptions = opts;
   },
@@ -106,7 +112,10 @@ describe('useLoadKey', () => {
     });
 
     expect(mockExecute).toHaveBeenCalledTimes(1);
-    expect(capturedOptions).toEqual({ requiresPin: true });
+    expect(capturedOptions).toEqual({
+      requiresPin: true,
+      requiresMasterKey: false,
+    });
   });
 
   it('loads the prepared BIP32 keypair onto an empty card', async () => {

--- a/__tests__/useSetCardName.test.ts
+++ b/__tests__/useSetCardName.test.ts
@@ -7,10 +7,16 @@ import { useSetCardName } from '../src/hooks/keycard/useSetCardName';
 type OperationFn = (cmdSet: any, helpers: any) => Promise<void>;
 
 let capturedOperation: OperationFn | null = null;
-let capturedOptions: { requiresPin?: boolean } | null = null;
+let capturedOptions: {
+  requiresPin?: boolean;
+  requiresMasterKey?: boolean;
+} | null = null;
 
 const mockExecute = jest.fn(
-  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+  (
+    fn: OperationFn,
+    opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
+  ) => {
     capturedOperation = fn;
     capturedOptions = opts;
   },
@@ -42,7 +48,10 @@ describe('useSetCardName', () => {
       result.current.start('Vault');
     });
 
-    expect(capturedOptions).toEqual({ requiresPin: true });
+    expect(capturedOptions).toEqual({
+      requiresPin: true,
+      requiresMasterKey: false,
+    });
 
     const storeData = jest.fn().mockResolvedValue({ sw: 0x9000 });
     const getData = jest.fn().mockResolvedValue({

--- a/src/hooks/keycard/useChangeSecret.ts
+++ b/src/hooks/keycard/useChangeSecret.ts
@@ -24,18 +24,21 @@ export function useChangeSecret(
   const start = useCallback(
     (newSecret: string) => {
       newSecretRef.current = newSecret;
-      execute(async cmdSet => {
-        let resp;
-        if (secretType === 'pin') {
-          resp = await cmdSet.changePIN(newSecretRef.current);
-        } else if (secretType === 'puk') {
-          resp = await cmdSet.changePUK(newSecretRef.current);
-        } else {
-          resp = await cmdSet.changePairingPassword(newSecretRef.current);
-        }
-        newSecretRef.current = '';
-        resp.checkOK();
-      });
+      execute(
+        async cmdSet => {
+          let resp;
+          if (secretType === 'pin') {
+            resp = await cmdSet.changePIN(newSecretRef.current);
+          } else if (secretType === 'puk') {
+            resp = await cmdSet.changePUK(newSecretRef.current);
+          } else {
+            resp = await cmdSet.changePairingPassword(newSecretRef.current);
+          }
+          newSecretRef.current = '';
+          resp.checkOK();
+        },
+        { requiresMasterKey: false },
+      );
     },
     [execute, secretType],
   );

--- a/src/hooks/keycard/useGenerateKey.ts
+++ b/src/hooks/keycard/useGenerateKey.ts
@@ -20,7 +20,7 @@ export function useGenerateKey(size: 12 | 24) {
         mnemonic.setWordlist(wordlist);
         return mnemonic.getWords();
       },
-      { requiresPin: false },
+      { requiresPin: false, requiresMasterKey: false },
     );
   }, [keycard, size]);
 

--- a/src/hooks/keycard/useGenerateSlip39Shares.ts
+++ b/src/hooks/keycard/useGenerateSlip39Shares.ts
@@ -21,7 +21,7 @@ export function useGenerateSlip39Shares(shareCount: number, threshold: number) {
         response.checkOK();
         return response.data;
       },
-      { requiresPin: false },
+      { requiresPin: false, requiresMasterKey: false },
     );
   }, [keycard, shareCount, threshold]);
 

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -31,6 +31,7 @@ export type KeycardOperationFn<T> = (
 
 export interface ExecuteOptions {
   requiresPin?: boolean;
+  requiresMasterKey?: boolean;
 }
 
 export interface UseKeycardOperation<T> {
@@ -57,6 +58,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const pinRef = useRef('');
   const operationRef = useRef<KeycardOperationFn<T> | null>(null);
   const requiresPinRef = useRef(true);
+  const requiresMasterKeyRef = useRef(true);
   const operationRunningRef = useRef(false);
   const approvedNonGenuineUidsRef = useRef<Set<string>>(new Set());
   const pendingUidRef = useRef<string | null>(null);
@@ -138,6 +140,12 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
           }, hasMasterKey: ${appInfo.hasMasterKey()}`,
       );
 
+      if (requiresMasterKeyRef.current && !appInfo.hasMasterKey()) {
+        throw new Error(
+          'This card has no master key. Generate or import a key first.',
+        );
+      }
+
       const dataResp = await cmdSet.getData(0x00);
       if (dataResp.sw !== 0x9000) {
         throw new Error(
@@ -187,6 +195,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     (op: KeycardOperationFn<T>, options: ExecuteOptions = {}) => {
       operationRef.current = op;
       requiresPinRef.current = options.requiresPin ?? true;
+      requiresMasterKeyRef.current = options.requiresMasterKey ?? true;
       operationRunningRef.current = false;
 
       if (!requiresPinRef.current) {

--- a/src/hooks/keycard/useLoadKey.ts
+++ b/src/hooks/keycard/useLoadKey.ts
@@ -19,7 +19,7 @@ export function useLoadKey() {
           const response = await cmdSet.loadBIP32KeyPair(keyPair);
           response.checkOK();
         },
-        { requiresPin: true },
+        { requiresPin: true, requiresMasterKey: false },
       );
     },
     [keycard],

--- a/src/hooks/keycard/useSetCardName.ts
+++ b/src/hooks/keycard/useSetCardName.ts
@@ -30,7 +30,7 @@ export function useSetCardName() {
             );
           }
         },
-        { requiresPin: true },
+        { requiresPin: true, requiresMasterKey: false },
       );
     },
     [keycard],


### PR DESCRIPTION
## Summary

- Adds `requiresMasterKey` option (default `true`) to `ExecuteOptions` in `useKeycardOperation`
- Checks `hasMasterKey()` from the SELECT response before pairing or PIN entry; throws "This card has no master key. Generate or import a key first." if the flag is unset
- Opts out (`requiresMasterKey: false`) the five operations that work on keyless cards: `useLoadKey`, `useGenerateKey`, `useGenerateSlip39Shares`, `useSetCardName`, `useChangeSecret`
- Adds test files for `useGenerateKey` and `useChangeSecret` (previously untested); updates option assertions in `useLoadKey`, `useSetCardName`, and `useGenerateSlip39Shares` tests

## Before

Tapping a blank card on any key-dependent screen crashed deep in the APDU stack with `SW 0x6985` and no user-visible explanation.

## After

The error is caught at SELECT time and surfaces as a readable error state before any pairing or PIN prompt is shown.
