### PR TITLE
feat: enforce seed review timer and 3-strike quiz on mnemonic generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Enforce seed review on generate: 30s mandatory timer on word/share display, return to word list after 3 wrong verify answers (keycard-shell parity)
 - Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985
 - Add special review renderers for EIP-712 Permit, PermitSingle, SafeTx, and Uniswap Universal Router calls
 - Apply EIP-55 checksum formatting and shell-style address chunk coloring to displayed addresses

--- a/__tests__/ConfirmKeyScreen.test.tsx
+++ b/__tests__/ConfirmKeyScreen.test.tsx
@@ -9,6 +9,12 @@ import PinPad from '../src/components/PinPad';
 // Mocks
 // ---------------------------------------------------------------------------
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => {
+    require('react').useEffect(cb, []);
+  },
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -203,6 +209,29 @@ describe('ConfirmKeyScreen', () => {
       renderScreen();
       await pressChoice(CORRECT_WORDS[0]);
       expect(mockStart).not.toHaveBeenCalled();
+    });
+
+    it('shows "Wrong answer · 2 retries left" after first wrong answer', async () => {
+      renderScreen();
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      expect(screen.getByText('Wrong answer · 2 retries left')).toBeTruthy();
+    });
+
+    it('shows "Wrong answer · 1 retry left" after second wrong answer', async () => {
+      renderScreen();
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      expect(screen.getByText('Wrong answer · 1 retry left')).toBeTruthy();
+    });
+
+    it('calls goBack only after third wrong answer', async () => {
+      renderScreen();
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      expect(navigation.goBack).not.toHaveBeenCalled();
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      expect(navigation.goBack).not.toHaveBeenCalled();
+      await pressChoice(WRONG_WORD_FOR_SLOT_0);
+      expect(navigation.goBack).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/GenerateKeyScreen.test.tsx
+++ b/__tests__/GenerateKeyScreen.test.tsx
@@ -8,6 +8,12 @@ import NFCBottomSheet from '../src/components/NFCBottomSheet';
 // Mocks
 // ---------------------------------------------------------------------------
 
+jest.mock('../src/hooks/useSeedReviewTimer', () => ({
+  useSeedReviewTimer: jest.fn(),
+}));
+const useSeedReviewTimerMock = require('../src/hooks/useSeedReviewTimer')
+  .useSeedReviewTimer as jest.Mock;
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -55,23 +61,49 @@ const WORDS = [
 
 const navigation = {
   goBack: jest.fn(),
-  replace: jest.fn(),
+  navigate: jest.fn(),
   setOptions: jest.fn(),
 } as any;
 
-const route = {
-  key: 'GenerateKey',
-  name: 'GenerateKey',
-  params: { size: 12 },
-} as any;
+const route = (withPassphrase = false) =>
+  ({
+    key: 'GenerateKey',
+    name: 'GenerateKey',
+    params: { size: 12, passphrase: withPassphrase },
+  } as any);
 
 function hookMock(phase: string, result: string[] | null = null) {
   return { phase, status: '', result, start: mockStart, cancel: mockCancel };
 }
 
-function renderScreen(phase = 'idle', result: string[] | null = null) {
+function renderScreen(
+  phase = 'idle',
+  result: string[] | null = null,
+  timer: { timeLeft: number; done: boolean; start: jest.Mock } = {
+    timeLeft: 0,
+    done: true,
+    start: jest.fn(),
+  },
+) {
+  useSeedReviewTimerMock.mockReturnValue(timer);
   mockUseGenerateKey.mockReturnValue(hookMock(phase, result));
-  return render(<GenerateKeyScreen navigation={navigation} route={route} />);
+  return render(<GenerateKeyScreen navigation={navigation} route={route()} />);
+}
+
+function renderScreenWithPassphrase(
+  phase = 'done',
+  result: string[] | null = WORDS,
+  timer: { timeLeft: number; done: boolean; start: jest.Mock } = {
+    timeLeft: 0,
+    done: true,
+    start: jest.fn(),
+  },
+) {
+  useSeedReviewTimerMock.mockReturnValue(timer);
+  mockUseGenerateKey.mockReturnValue(hookMock(phase, result));
+  return render(
+    <GenerateKeyScreen navigation={navigation} route={route(true)} />,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -84,8 +116,9 @@ describe('GenerateKeyScreen', () => {
     mockCancel.mockClear();
     MockNFCBottomSheet.mockClear();
     navigation.goBack.mockClear();
-    navigation.replace.mockClear();
+    navigation.navigate.mockClear();
     navigation.setOptions.mockClear();
+    useSeedReviewTimerMock.mockClear();
   });
 
   describe('on mount', () => {
@@ -127,25 +160,72 @@ describe('GenerateKeyScreen', () => {
       expect(screen.getByText('Reveal recovery phrase')).toBeTruthy();
     });
 
-    it('shows "Done" after revealing', async () => {
+    it('shows "I\'ve written it down" after revealing', async () => {
       renderScreen('done', WORDS);
       await act(async () => {
         fireEvent.press(screen.getByText('Reveal recovery phrase'));
       });
-      expect(screen.getByText('Done')).toBeTruthy();
+      expect(screen.getByText("I've written it down")).toBeTruthy();
     });
 
-    it('calls navigation.replace to ConfirmKey when "Done" is pressed', async () => {
+    it('calls navigation.navigate to ConfirmKey when "I\'ve written it down" is pressed', async () => {
       renderScreen('done', WORDS);
       await act(async () => {
         fireEvent.press(screen.getByText('Reveal recovery phrase'));
       });
       await act(async () => {
-        fireEvent.press(screen.getByText('Done'));
+        fireEvent.press(screen.getByText("I've written it down"));
       });
-      expect(navigation.replace).toHaveBeenCalledWith('ConfirmKey', {
+      expect(navigation.navigate).toHaveBeenCalledWith('ConfirmKey', {
         words: WORDS,
       });
+    });
+
+    it('passes passphrase to ConfirmKey when withPassphrase is true', async () => {
+      const timer = { timeLeft: 0, done: true, start: jest.fn() };
+      renderScreenWithPassphrase('done', WORDS, timer);
+      await act(async () => {
+        fireEvent.press(screen.getByText('Reveal recovery phrase'));
+      });
+      const passphraseInput = screen.getByPlaceholderText('Enter passphrase');
+      fireEvent.changeText(passphraseInput, 'test-pass');
+      await act(async () => {
+        fireEvent.press(screen.getByText("I've written it down"));
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith('ConfirmKey', {
+        words: WORDS,
+        passphrase: 'test-pass',
+      });
+    });
+
+    it('disables button while timer is running', async () => {
+      const timer = { timeLeft: 15, done: false, start: jest.fn() };
+      renderScreen('done', WORDS, timer);
+      await act(async () => {
+        fireEvent.press(screen.getByText('Reveal recovery phrase'));
+      });
+      const btn = screen.getByTestId('primary-button');
+      expect(btn?.props?.accessibilityState?.disabled).toBe(true);
+    });
+
+    it('enables button after timer completes', async () => {
+      const timer = { timeLeft: 0, done: true, start: jest.fn() };
+      renderScreen('done', WORDS, timer);
+      await act(async () => {
+        fireEvent.press(screen.getByText('Reveal recovery phrase'));
+      });
+      const btn = screen.getByTestId('primary-button');
+      expect(btn?.props?.accessibilityState?.disabled).toBe(false);
+    });
+
+    it('disables button when passphrase is required but empty', async () => {
+      const timer = { timeLeft: 0, done: true, start: jest.fn() };
+      renderScreenWithPassphrase('done', WORDS, timer);
+      await act(async () => {
+        fireEvent.press(screen.getByText('Reveal recovery phrase'));
+      });
+      const btn = screen.getByTestId('primary-button');
+      expect(btn?.props?.accessibilityState?.disabled).toBe(true);
     });
   });
 

--- a/__tests__/Slip39Screen.test.tsx
+++ b/__tests__/Slip39Screen.test.tsx
@@ -30,6 +30,10 @@ const mockUseLoadKey = jest.fn();
 const mockUseVerifyFingerprint = jest.fn();
 const mockGenerateSlip39SharesFromKeycardEntropy = jest.fn();
 
+jest.mock('../src/hooks/useSeedReviewTimer', () => ({
+  useSeedReviewTimer: () => ({ timeLeft: 0, done: true, start: jest.fn() }),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -296,6 +300,67 @@ describe('Slip39Screen', () => {
     await flushTimers();
     expect(mockStartLoad).toHaveBeenCalledTimes(1);
     expect(mockResetGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error when adding share with invalid word', async () => {
+    renderScreen('import');
+
+    await act(async () => {
+      fireEvent.changeText(
+        getTextInputs()[0],
+        'valid wordz here that are not slip39',
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Next share'));
+    });
+
+    expect(screen.getByText(/"wordz" is not a valid SLIP39 word/)).toBeTruthy();
+  });
+
+  it('shows error for invalid share in handleImportOrVerify', async () => {
+    renderScreen('import');
+
+    await act(async () => {
+      fireEvent.changeText(
+        getTextInputs()[0],
+        SHARE_1.replace('very', 'invalidword'),
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Next share'));
+    });
+
+    expect(
+      screen.getByText(/"invalidword" is not a valid SLIP39 word/),
+    ).toBeTruthy();
+  });
+
+  it('handles generateSlip39SharesFromKeycardEntropy error', async () => {
+    const entropy = new Uint8Array([1, 2, 3]);
+    renderScreen('generate', 'idle', null, 'done', entropy);
+    mockGenerateSlip39SharesFromKeycardEntropy.mockImplementation(() => {
+      throw new Error('entropy error');
+    });
+
+    await flushTimers();
+
+    expect(screen.getByText('entropy error')).toBeTruthy();
+  });
+
+  it('handles handleGenerateShares error', async () => {
+    renderScreen('generate');
+    mockStartGenerate.mockImplementation(() => {
+      throw new Error('generate error');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Generate SLIP39 shares'));
+    });
+
+    expect(screen.getByText('generate error')).toBeTruthy();
   });
 
   it('passes NFC props through the bottom sheet', async () => {

--- a/__tests__/useSeedReviewTimer.test.ts
+++ b/__tests__/useSeedReviewTimer.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { SEED_REVIEW_SECONDS } from '../src/constants/backup';
+import { useSeedReviewTimer } from '../src/hooks/useSeedReviewTimer';
+
+jest.useFakeTimers();
+
+describe('useSeedReviewTimer', () => {
+  it('starts with full time and not done', () => {
+    const { result } = renderHook(() => useSeedReviewTimer());
+    expect(result.current.timeLeft).toBe(SEED_REVIEW_SECONDS);
+    expect(result.current.done).toBe(false);
+  });
+
+  it('counts down each second after start()', () => {
+    const { result } = renderHook(() => useSeedReviewTimer());
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.timeLeft).toBe(SEED_REVIEW_SECONDS - 1);
+    expect(result.current.done).toBe(false);
+  });
+
+  it('sets done=true when timer expires', () => {
+    const { result } = renderHook(() => useSeedReviewTimer());
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(SEED_REVIEW_SECONDS * 1000);
+    });
+    expect(result.current.timeLeft).toBe(0);
+    expect(result.current.done).toBe(true);
+  });
+
+  it('resets and restarts when start() is called again', () => {
+    const { result } = renderHook(() => useSeedReviewTimer());
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.timeLeft).toBe(SEED_REVIEW_SECONDS);
+    expect(result.current.done).toBe(false);
+  });
+});

--- a/src/components/MnemonicBackupCheck.tsx
+++ b/src/components/MnemonicBackupCheck.tsx
@@ -5,6 +5,7 @@ import { Text } from 'react-native-paper';
 import theme from '../theme';
 
 import { Icons } from '../assets/icons';
+import { SEED_VERIFY_FAILURE_THRESHOLD } from '../constants/backup';
 
 const DEFAULT_CHALLENGE_COUNT = 4;
 const DEFAULT_CHOICE_COUNT = 4;
@@ -30,16 +31,20 @@ type Props = {
   words: string[];
   description: string;
   onComplete: () => void;
+  onFailure?: () => void;
   challengeCount?: number;
   choiceCount?: number;
+  failureThreshold?: number;
 };
 
 export default function MnemonicBackupCheck({
   words,
   description,
   onComplete,
+  onFailure,
   challengeCount = DEFAULT_CHALLENGE_COUNT,
   choiceCount = DEFAULT_CHOICE_COUNT,
+  failureThreshold = SEED_VERIFY_FAILURE_THRESHOLD,
 }: Props) {
   const [challengePositions] = useState(() => {
     const indices = words.map((_, i) => i);
@@ -53,6 +58,8 @@ export default function MnemonicBackupCheck({
   );
   const [currentIndex, setCurrentIndex] = useState(0);
   const [wrongIndex, setWrongIndex] = useState<number | null>(null);
+  const [wrongCount, setWrongCount] = useState(0);
+  const [remainingRetries, setRemainingRetries] = useState(failureThreshold);
 
   const choices = useMemo(() => {
     if (currentIndex >= challengeCount) {
@@ -70,7 +77,14 @@ export default function MnemonicBackupCheck({
     (word: string) => {
       const correct = words[challengePositions[currentIndex]];
       if (word !== correct) {
+        const nextWrongCount = wrongCount + 1;
+        const remaining = failureThreshold - nextWrongCount;
         setWrongIndex(currentIndex);
+        setWrongCount(nextWrongCount);
+        setRemainingRetries(remaining);
+        if (remaining <= 0) {
+          onFailure?.();
+        }
         return;
       }
 
@@ -87,7 +101,16 @@ export default function MnemonicBackupCheck({
         onComplete();
       }
     },
-    [challengeCount, currentIndex, challengePositions, onComplete, words],
+    [
+      challengeCount,
+      currentIndex,
+      challengePositions,
+      failureThreshold,
+      onComplete,
+      onFailure,
+      words,
+      wrongCount,
+    ],
   );
 
   const allDone = currentIndex >= challengeCount;
@@ -136,6 +159,13 @@ export default function MnemonicBackupCheck({
           );
         })}
       </View>
+
+      {wrongIndex !== null && remainingRetries > 0 && (
+        <Text style={styles.wrongFeedback}>
+          Wrong answer · {remainingRetries}{' '}
+          {remainingRetries === 1 ? 'retry' : 'retries'} left
+        </Text>
+      )}
 
       <View style={styles.spacer} />
 
@@ -240,5 +270,11 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     letterSpacing: -0.135,
     lineHeight: 15 * 1.45,
+  },
+  wrongFeedback: {
+    color: theme.colors.error,
+    fontSize: 13,
+    marginBottom: 8,
+    textAlign: 'center',
   },
 });

--- a/src/constants/backup.ts
+++ b/src/constants/backup.ts
@@ -1,0 +1,2 @@
+export const SEED_REVIEW_SECONDS = 30;
+export const SEED_VERIFY_FAILURE_THRESHOLD = 3;

--- a/src/hooks/useSeedReviewTimer.ts
+++ b/src/hooks/useSeedReviewTimer.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { SEED_REVIEW_SECONDS } from '../constants/backup';
+
+export interface SeedReviewTimer {
+  timeLeft: number;
+  done: boolean;
+  start: () => void;
+}
+
+export function useSeedReviewTimer(): SeedReviewTimer {
+  const [timeLeft, setTimeLeft] = useState(SEED_REVIEW_SECONDS);
+  const [done, setDone] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const start = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+    }
+    setTimeLeft(SEED_REVIEW_SECONDS);
+    setDone(false);
+    timerRef.current = setInterval(() => {
+      setTimeLeft(t => {
+        if (t <= 1) {
+          clearInterval(timerRef.current!);
+          timerRef.current = null;
+          setDone(true);
+          return 0;
+        }
+        return t - 1;
+      });
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+      }
+    };
+  }, []);
+
+  return { timeLeft, done, start };
+}

--- a/src/screens/keypair/ConfirmKeyScreen.tsx
+++ b/src/screens/keypair/ConfirmKeyScreen.tsx
@@ -1,5 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ConfirmKeySreenProps } from '../../navigation/types';
@@ -46,6 +53,19 @@ export default function ConfirmKeyScreen({
     });
   }, [navigation, phase]);
 
+  const [attemptKey, setAttemptKey] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      setAttemptKey(k => k + 1);
+    }, []),
+  );
+
+  const handleFailure = useCallback(() => {
+    cancel();
+    navigation.goBack();
+  }, [cancel, navigation]);
+
   return (
     <View
       style={[
@@ -54,9 +74,11 @@ export default function ConfirmKeyScreen({
       ]}
     >
       <MnemonicBackupCheck
+        key={attemptKey}
         words={words}
         description="Confirm word positions in your recovery phrase."
         onComplete={() => start(keyPair)}
+        onFailure={handleFailure}
       />
 
       <NFCBottomSheet nfc={keycard} onCancel={handleCancel} />

--- a/src/screens/keypair/GenerateKeyScreen.tsx
+++ b/src/screens/keypair/GenerateKeyScreen.tsx
@@ -11,6 +11,7 @@ import NFCBottomSheet from '../../components/NFCBottomSheet';
 import PrimaryButton from '../../components/PrimaryButton';
 
 import { useGenerateKey } from '../../hooks/keycard/useGenerateKey';
+import { useSeedReviewTimer } from '../../hooks/useSeedReviewTimer';
 
 export default function GenerateKeyScreen({
   navigation,
@@ -18,6 +19,7 @@ export default function GenerateKeyScreen({
 }: GenerateKeyScreenProps) {
   const insets = useSafeAreaInsets();
   const [revealed, setRevealed] = useState(false);
+  const timer = useSeedReviewTimer();
 
   const keycard = useGenerateKey(route.params.size);
   const { phase, result, start, cancel } = keycard;
@@ -28,17 +30,27 @@ export default function GenerateKeyScreen({
     start();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    if (revealed) {
+      timer.start();
+    }
+  }, [revealed]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleCancel = useCallback(() => {
     cancel();
     navigation.goBack();
   }, [cancel, navigation]);
+
+  const [hasAttemptedConfirm, setHasAttemptedConfirm] = useState(false);
+  const timerDone = timer.done || hasAttemptedConfirm;
 
   const handleButton = useCallback(() => {
     if (!revealed) {
       setRevealed(true);
       return;
     }
-    navigation.replace('ConfirmKey', {
+    setHasAttemptedConfirm(true);
+    navigation.navigate('ConfirmKey', {
       words: result ?? [],
       passphrase: withPassphrase ? passphrase : undefined,
     });
@@ -109,9 +121,19 @@ export default function GenerateKeyScreen({
       {phase === 'done' && (
         <View style={styles.buttonArea}>
           <PrimaryButton
-            label={revealed ? 'Done' : 'Reveal recovery phrase'}
+            testID="primary-button"
+            label={
+              !revealed
+                ? 'Reveal recovery phrase'
+                : !timerDone
+                ? `Write down your recovery phrase (${timer.timeLeft}s)`
+                : "I've written it down"
+            }
             onPress={handleButton}
-            disabled={revealed && withPassphrase && passphrase.trim() === ''}
+            disabled={
+              (revealed && !timerDone) ||
+              (revealed && withPassphrase && passphrase.trim() === '')
+            }
           />
         </View>
       )}

--- a/src/screens/keypair/Slip39Screen.tsx
+++ b/src/screens/keypair/Slip39Screen.tsx
@@ -28,6 +28,7 @@ import PrimaryButton from '../../components/PrimaryButton';
 
 import { useGenerateSlip39Shares } from '../../hooks/keycard/useGenerateSlip39Shares';
 import { useLoadKey } from '../../hooks/keycard/useLoadKey';
+import { useSeedReviewTimer } from '../../hooks/useSeedReviewTimer';
 import { useVerifyFingerprint } from '../../hooks/keycard/useVerifyFingerprint';
 import { pubKeyFingerprint } from '../../utils/cryptoAccount';
 import {
@@ -67,6 +68,18 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
   const [backupStep, setBackupStep] = useState<'display' | 'confirm'>(
     'display',
   );
+  const shareTimer = useSeedReviewTimer();
+
+  useEffect(() => {
+    if (
+      mode === 'generate' &&
+      backupStep === 'display' &&
+      currentGeneratedShare !== null
+    ) {
+      shareTimer.start();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generatedShareIndex, backupStep]);
 
   useEffect(() => {
     const show = Keyboard.addListener(
@@ -342,6 +355,10 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
     setBackupStep('display');
   }, []);
 
+  const handleShareVerifyFailure = useCallback(() => {
+    setBackupStep('display');
+  }, []);
+
   if (
     mode === 'generate' &&
     backupStep === 'confirm' &&
@@ -355,6 +372,7 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
             words={currentGeneratedWords}
             description="Confirm word positions in your backup share."
             onComplete={handleBackupComplete}
+            onFailure={handleShareVerifyFailure}
           />
         </View>
 
@@ -556,11 +574,14 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
           currentGeneratedShare ? (
           <PrimaryButton
             label={
-              generatedShareIndex + 1 === generatedShares.length
+              !shareTimer.done
+                ? `Review this share (${shareTimer.timeLeft}s)`
+                : generatedShareIndex + 1 === generatedShares.length
                 ? 'I saved the last share'
                 : 'I saved this share'
             }
             onPress={handleGeneratedShareSaved}
+            disabled={!shareTimer.done}
           />
         ) : mode !== 'generate' && !importComplete && !isPreparingSlip39 ? (
           <PrimaryButton


### PR DESCRIPTION
## Summary

- 30-second mandatory review timer on first word/share reveal; timer runs once and does not restart on return from a failed quiz
- After 3 wrong answers in the backup quiz, returns the user to the word list (keycard-shell parity: 3 shared retries across all challenges, with "Wrong answer · N retries left" feedback on each miss)
- Button labels updated: "Write down your recovery phrase (Ns)" while timer runs, "I've written it down" when ready; SLIP39 share timer also gates the "I saved this share" button
- `MnemonicBackupCheck` gains `onFailure` callback and retry counter; `ConfirmKeyScreen` resets quiz state on every focus via `key` prop so retries are always fresh
