### PR TITLE
feat: add SeedQR scanning to mnemonic import screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Add SeedQR scan support for mnemonic import/verify
 - Enforce seed review on generate: 30s mandatory timer on word/share display, return to word list after 3 wrong verify answers (keycard-shell parity)
 - Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985
 - Add special review renderers for EIP-712 Permit, PermitSingle, SafeTx, and Uniswap Universal Router calls

--- a/__tests__/CameraView.test.tsx
+++ b/__tests__/CameraView.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+
+import CameraView from '../src/components/CameraView';
+
+jest.mock('../src/components/Camera', () => ({
+  Camera: ({ onReadCode }: any) => {
+    const { View } = require('react-native');
+    return <View testID="camera" onReadCode={onReadCode} />;
+  },
+}));
+
+describe('CameraView', () => {
+  it('renders the camera', () => {
+    render(<CameraView onReadCode={jest.fn()} />);
+    expect(screen.getByTestId('camera')).toBeTruthy();
+  });
+
+  it('passes onReadCode to Camera', () => {
+    const handler = jest.fn();
+    render(<CameraView onReadCode={handler} />);
+    expect(screen.getByTestId('camera').props.onReadCode).toBe(handler);
+  });
+
+  it('renders children', () => {
+    render(
+      <CameraView onReadCode={jest.fn()}>
+        <Text>overlay</Text>
+      </CameraView>,
+    );
+    expect(screen.getByText('overlay')).toBeTruthy();
+  });
+});

--- a/__tests__/MnemonicScreen.test.tsx
+++ b/__tests__/MnemonicScreen.test.tsx
@@ -1,5 +1,5 @@
 import React, { act } from 'react';
-import { TextInput } from 'react-native';
+import { Keyboard, TextInput } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
@@ -26,7 +26,14 @@ const MockNFCBottomSheet = NFCBottomSheet as jest.MockedFunction<
 jest.mock('../src/components/PinPad', () => () => null);
 
 jest.mock('../src/assets/icons', () => ({
-  Icons: { nfcActivate: () => null },
+  Icons: { nfcActivate: () => null, qr: () => null },
+}));
+
+jest.mock('../src/components/Camera', () => ({
+  Camera: ({ onReadCode }: any) => {
+    const { View } = require('react-native');
+    return <View testID="camera" onReadCode={onReadCode} />;
+  },
 }));
 
 const mockStart = jest.fn();
@@ -51,14 +58,16 @@ jest.mock('../src/hooks/keycard/useVerifyFingerprint', () => ({
 const VALID_12 =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
-// 24 valid words
 const VALID_24 =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+
+const VALID_12_HEX = '00000000000000000000000000000000';
 
 const navigation = {
   navigate: jest.fn(),
   reset: jest.fn(),
   setOptions: jest.fn(),
+  addListener: jest.fn(() => jest.fn()),
 } as any;
 
 const route = { key: 'Mnemonic', name: 'Mnemonic', params: undefined } as any;
@@ -126,6 +135,14 @@ function setInput(text: string) {
   });
 }
 
+function triggerScan(hex: string) {
+  act(() => {
+    screen.getByTestId('camera').props.onReadCode({
+      nativeEvent: { codeStringValue: hex },
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -165,6 +182,11 @@ describe('MnemonicScreen', () => {
       renderScreen();
       expect(screen.getByText('Continue')).toBeTruthy();
     });
+
+    it('renders Scan SeedQR button', async () => {
+      renderScreen();
+      expect(screen.getByText('Scan SeedQR')).toBeTruthy();
+    });
   });
 
   describe('word count selector', () => {
@@ -190,7 +212,6 @@ describe('MnemonicScreen', () => {
   describe('Continue button disabled state', () => {
     it('is disabled when input is empty', async () => {
       renderScreen();
-      // clear the test prefill
       await setInput('');
       expect(getButton().props.disabled).toBe(true);
     });
@@ -203,7 +224,6 @@ describe('MnemonicScreen', () => {
 
     it('remains disabled when word count does not match selector (24 mode, 12 words)', async () => {
       renderScreen();
-      // switch to 24-word mode
       await act(async () => {
         fireEvent.press(screen.getByText('24 words'));
       });
@@ -292,16 +312,102 @@ describe('MnemonicScreen', () => {
     });
   });
 
+  describe('SeedQR scanner', () => {
+    it('shows camera overlay when Scan SeedQR is pressed', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      expect(screen.getByTestId('camera')).toBeTruthy();
+    });
+
+    it('fills word input and dismisses overlay after valid scan', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      triggerScan(VALID_12_HEX);
+      expect(screen.queryByTestId('camera')).toBeNull();
+      expect(getWordInput().props.value).toBe(VALID_12);
+    });
+
+    it('shows error message for invalid QR payload', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      triggerScan('notahex!!!');
+      expect(screen.getByText(/Not a valid SeedQR/)).toBeTruthy();
+      expect(screen.getByTestId('camera')).toBeTruthy();
+    });
+
+    it('shows error when decodeSeedQr fails on valid-length hex', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      const bip39 = require('@scure/bip39');
+      jest.spyOn(bip39, 'entropyToMnemonic').mockImplementationOnce(() => {
+        throw new Error('decode failure');
+      });
+      triggerScan(VALID_12_HEX);
+      expect(screen.getByText(/decode failure/)).toBeTruthy();
+      expect(screen.getByTestId('camera')).toBeTruthy();
+      jest.restoreAllMocks();
+    });
+
+    it('clears error when Tap to retry is pressed', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      triggerScan('notahex!!!');
+      expect(screen.getByText(/Not a valid SeedQR/)).toBeTruthy();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Tap to retry'));
+      });
+      expect(screen.queryByText(/Not a valid SeedQR/)).toBeNull();
+    });
+
+    it('dismisses overlay when beforeRemove fires while scanning', async () => {
+      let capturedCallback: ((e: any) => void) | null = null;
+      navigation.addListener.mockImplementation(
+        (_event: string, cb: (e: any) => void) => {
+          capturedCallback = cb;
+          return jest.fn();
+        },
+      );
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      expect(screen.getByTestId('camera')).toBeTruthy();
+      await act(async () => {
+        capturedCallback!({ preventDefault: jest.fn() });
+      });
+      expect(screen.queryByTestId('camera')).toBeNull();
+    });
+
+    it('does not navigate anywhere on scan', async () => {
+      renderScreen();
+      await act(async () => {
+        fireEvent.press(screen.getByText('Scan SeedQR'));
+      });
+      triggerScan(VALID_12_HEX);
+      expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+  });
+
   describe('navigation', () => {
     it('navigates to Dashboard with toast when phase is done (import mode)', async () => {
-      await renderScreen('done');
+      renderScreen('done');
       expect(navigation.navigate).toHaveBeenCalledWith('Dashboard', {
         toast: 'Key pair has been added to Keycard',
       });
     });
 
     it('does not navigate when phase is not done', async () => {
-      await renderScreen('idle');
+      renderScreen('idle');
       expect(navigation.navigate).not.toHaveBeenCalled();
     });
   });
@@ -335,7 +441,7 @@ describe('MnemonicScreen', () => {
     });
 
     it('resets to Dashboard with match toast', async () => {
-      await renderVerify('done', 'match');
+      renderVerify('done', 'match');
       expect(navigation.reset).toHaveBeenCalledWith({
         index: 0,
         routes: [
@@ -345,7 +451,7 @@ describe('MnemonicScreen', () => {
     });
 
     it('resets to Dashboard with mismatch toast', async () => {
-      await renderVerify('done', 'mismatch');
+      renderVerify('done', 'mismatch');
       expect(navigation.reset).toHaveBeenCalledWith({
         index: 0,
         routes: [
@@ -365,18 +471,70 @@ describe('MnemonicScreen', () => {
     }
 
     it('nfc.phase is idle when phase is idle', async () => {
-      await renderScreen('idle');
+      renderScreen('idle');
       expect(lastProps().nfc.phase).toBe('idle');
     });
 
     it('nfc.phase is nfc when phase is nfc', async () => {
-      await renderScreen('nfc');
+      renderScreen('nfc');
       expect(lastProps().nfc.phase).toBe('nfc');
     });
 
     it('nfc.phase is error when phase is error', async () => {
-      await renderScreen('error');
+      renderScreen('error');
       expect(lastProps().nfc.phase).toBe('error');
+    });
+  });
+
+  describe('keyboard handling', () => {
+    let listeners: Record<string, (e: any) => void>;
+
+    beforeEach(() => {
+      listeners = {};
+      jest
+        .spyOn(Keyboard, 'addListener')
+        .mockImplementation((event: string, cb: (e: any) => void) => {
+          listeners[event] = cb;
+          return { remove: jest.fn() } as any;
+        });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('updates keyboardHeight when keyboard shows', async () => {
+      renderScreen();
+      await act(async () => {
+        listeners['keyboardDidShow']?.({
+          endCoordinates: { height: 300, screenX: 0, screenY: 0, width: 0 },
+        });
+      });
+      expect(screen.getByText('Continue')).toBeTruthy();
+    });
+
+    it('resets keyboardHeight when keyboard hides', async () => {
+      renderScreen();
+      await act(async () => {
+        listeners['keyboardDidShow']?.({
+          endCoordinates: { height: 300, screenX: 0, screenY: 0, width: 0 },
+        });
+      });
+      await act(async () => {
+        listeners['keyboardDidHide']?.({});
+      });
+      expect(screen.getByText('Continue')).toBeTruthy();
+    });
+  });
+
+  describe('NFC cancel', () => {
+    it('calls cancel() when NFCBottomSheet onCancel is triggered', async () => {
+      renderScreen();
+      const props = MockNFCBottomSheet.mock.calls[0][0];
+      act(() => {
+        props.onCancel();
+      });
+      expect(mockCancel).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/__tests__/seedQr.test.ts
+++ b/__tests__/seedQr.test.ts
@@ -1,0 +1,97 @@
+import { decodeSeedQr, isSeedQrPayload } from '../src/utils/seedQr';
+
+const HEX_12 = '00000000000000000000000000000000'; // 16 bytes → 12 words
+const HEX_24 =
+  '0000000000000000000000000000000000000000000000000000000000000000'; // 32 bytes → 24 words
+
+const WORDS_12 =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const WORDS_24 =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+
+describe('isSeedQrPayload', () => {
+  it('accepts 16-byte hex', () => {
+    expect(isSeedQrPayload(HEX_12)).toBe(true);
+  });
+
+  it('accepts 32-byte hex', () => {
+    expect(isSeedQrPayload(HEX_24)).toBe(true);
+  });
+
+  it('accepts uppercase hex', () => {
+    expect(isSeedQrPayload(HEX_12.toUpperCase())).toBe(true);
+  });
+
+  it('rejects non-hex string', () => {
+    expect(isSeedQrPayload('notahex!!!')).toBe(false);
+  });
+
+  it('rejects wrong byte length', () => {
+    expect(isSeedQrPayload('deadbeef')).toBe(false); // 4 bytes
+  });
+});
+
+describe('decodeSeedQr', () => {
+  it('decodes 12-word entropy correctly', () => {
+    const result = decodeSeedQr(HEX_12);
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.words.join(' ')).toBe(WORDS_12);
+      expect(result.words).toHaveLength(12);
+    }
+  });
+
+  it('decodes 24-word entropy correctly', () => {
+    const result = decodeSeedQr(HEX_24);
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.words.join(' ')).toBe(WORDS_24);
+      expect(result.words).toHaveLength(24);
+    }
+  });
+
+  it('accepts uppercase hex input', () => {
+    const result = decodeSeedQr(HEX_12.toUpperCase());
+    expect(result.kind).toBe('success');
+  });
+
+  it('returns error for non-hex input', () => {
+    const result = decodeSeedQr('notahex!!!');
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/hex/i);
+    }
+  });
+
+  it('returns error for wrong byte length', () => {
+    const result = decodeSeedQr('deadbeef'); // 4 bytes
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/got 4/);
+    }
+  });
+
+  it('returns error when decoded mnemonic fails checksum', () => {
+    const bip39 = require('@scure/bip39');
+    jest.spyOn(bip39, 'validateMnemonic').mockReturnValueOnce(false);
+    const result = decodeSeedQr(HEX_12);
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/checksum/);
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('returns error when entropyToMnemonic throws', () => {
+    const bip39 = require('@scure/bip39');
+    jest.spyOn(bip39, 'entropyToMnemonic').mockImplementationOnce(() => {
+      throw new Error('bad entropy');
+    });
+    const result = decodeSeedQr(HEX_12);
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toMatch(/bad entropy/);
+    }
+    jest.restoreAllMocks();
+  });
+});

--- a/src/components/CameraView.tsx
+++ b/src/components/CameraView.tsx
@@ -1,0 +1,85 @@
+import { StyleSheet, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import theme from '../theme';
+
+import { Camera, type ReadCodeEvent } from './Camera';
+
+type Props = {
+  onReadCode: (event: ReadCodeEvent) => void;
+  style?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+};
+
+export default function CameraView({ onReadCode, style, children }: Props) {
+  return (
+    <View style={[styles.container, style]}>
+      <Camera style={StyleSheet.absoluteFill} onReadCode={onReadCode} />
+      <View style={styles.viewfinderContainer}>
+        <View style={styles.viewfinder}>
+          <View style={[styles.corner, styles.cornerTL]} />
+          <View style={[styles.corner, styles.cornerTR]} />
+          <View style={[styles.corner, styles.cornerBL]} />
+          <View style={[styles.corner, styles.cornerBR]} />
+        </View>
+      </View>
+      {children}
+    </View>
+  );
+}
+
+const CORNER = 24;
+const BORDER = 3;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.colors.cameraBackground,
+    flex: 1,
+  },
+  viewfinderContainer: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  viewfinder: {
+    height: 250,
+    width: 250,
+  },
+  corner: {
+    height: CORNER,
+    position: 'absolute',
+    width: CORNER,
+  },
+  cornerTL: {
+    borderColor: theme.colors.primary,
+    borderLeftWidth: BORDER,
+    borderTopLeftRadius: 8,
+    borderTopWidth: BORDER,
+    left: 0,
+    top: 0,
+  },
+  cornerTR: {
+    borderColor: theme.colors.primary,
+    borderRightWidth: BORDER,
+    borderTopRightRadius: 8,
+    borderTopWidth: BORDER,
+    right: 0,
+    top: 0,
+  },
+  cornerBL: {
+    bottom: 0,
+    borderBottomLeftRadius: 8,
+    borderBottomWidth: BORDER,
+    borderColor: theme.colors.primary,
+    borderLeftWidth: BORDER,
+    left: 0,
+  },
+  cornerBR: {
+    bottom: 0,
+    borderBottomRightRadius: 8,
+    borderBottomWidth: BORDER,
+    borderColor: theme.colors.primary,
+    borderRightWidth: BORDER,
+    right: 0,
+  },
+});

--- a/src/screens/QRScannerScreen.tsx
+++ b/src/screens/QRScannerScreen.tsx
@@ -20,7 +20,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { QRScannerScreenProps } from '../navigation/types';
 import theme from '../theme';
 
-import { Camera, type ReadCodeEvent } from '../components/Camera';
+import CameraView from '../components/CameraView';
+import { type ReadCodeEvent } from '../components/Camera';
 import { handleUR } from '../utils/ur';
 
 export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
@@ -138,20 +139,7 @@ export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
   }
 
   return (
-    <View style={styles.fullscreen}>
-      {isFocused && (
-        <Camera style={StyleSheet.absoluteFill} onReadCode={onCodeScanned} />
-      )}
-
-      <View style={styles.viewfinderContainer}>
-        <View style={styles.viewfinder}>
-          <View style={[styles.corner, styles.cornerTL]} />
-          <View style={[styles.corner, styles.cornerTR]} />
-          <View style={[styles.corner, styles.cornerBL]} />
-          <View style={[styles.corner, styles.cornerBR]} />
-        </View>
-      </View>
-
+    <CameraView onReadCode={isFocused ? onCodeScanned : () => {}}>
       {progress > 0 && (
         <View style={styles.progressTrack}>
           <View
@@ -159,18 +147,11 @@ export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
           />
         </View>
       )}
-    </View>
+    </CameraView>
   );
 }
 
-const CORNER_SIZE = 24;
-const CORNER_WIDTH = 3;
-
 const styles = StyleSheet.create({
-  fullscreen: {
-    flex: 1,
-    backgroundColor: theme.colors.cameraBackground,
-  },
   centered: {
     flex: 1,
     justifyContent: 'center',
@@ -189,52 +170,6 @@ const styles = StyleSheet.create({
   },
   permissionButton: {
     marginTop: 8,
-  },
-  viewfinderContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  viewfinder: {
-    width: 250,
-    height: 250,
-  },
-  corner: {
-    position: 'absolute',
-    width: CORNER_SIZE,
-    height: CORNER_SIZE,
-  },
-  cornerTL: {
-    top: 0,
-    left: 0,
-    borderTopWidth: CORNER_WIDTH,
-    borderLeftWidth: CORNER_WIDTH,
-    borderColor: theme.colors.primary,
-    borderTopLeftRadius: 8,
-  },
-  cornerTR: {
-    top: 0,
-    right: 0,
-    borderTopWidth: CORNER_WIDTH,
-    borderRightWidth: CORNER_WIDTH,
-    borderColor: theme.colors.primary,
-    borderTopRightRadius: 8,
-  },
-  cornerBL: {
-    bottom: 0,
-    left: 0,
-    borderBottomWidth: CORNER_WIDTH,
-    borderLeftWidth: CORNER_WIDTH,
-    borderColor: theme.colors.primary,
-    borderBottomLeftRadius: 8,
-  },
-  cornerBR: {
-    bottom: 0,
-    right: 0,
-    borderBottomWidth: CORNER_WIDTH,
-    borderRightWidth: CORNER_WIDTH,
-    borderColor: theme.colors.primary,
-    borderBottomRightRadius: 8,
   },
   progressTrack: {
     position: 'absolute',

--- a/src/screens/keypair/MnemonicScreen.tsx
+++ b/src/screens/keypair/MnemonicScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import {
   Keyboard,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   TextInput,
@@ -9,12 +10,15 @@ import {
 } from 'react-native';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
+import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { MnemonicScreenProps } from '../../navigation/types';
 import theme from '../../theme';
 
 import { Icons } from '../../assets/icons';
+import CameraView from '../../components/CameraView';
+import { type ReadCodeEvent } from '../../components/Camera';
 import MnemonicWordEntry from '../../components/MnemonicWordEntry';
 import NFCBottomSheet from '../../components/NFCBottomSheet';
 import PrimaryButton from '../../components/PrimaryButton';
@@ -25,6 +29,7 @@ import {
 } from '../../hooks/keycard/useLoadKey';
 import { useVerifyFingerprint } from '../../hooks/keycard/useVerifyFingerprint';
 import { deriveMnemonicFingerprint } from '../../hooks/keycard/useVerifyMnemonic';
+import { decodeSeedQr, isSeedQrPayload } from '../../utils/seedQr';
 
 export default function MnemonicScreen({
   navigation,
@@ -38,6 +43,8 @@ export default function MnemonicScreen({
   const [passphrase, setPassphrase] = useState('');
   const [phraseError, setPhraseError] = useState<string | null>(null);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [scanning, setScanning] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
 
   useEffect(() => {
     const show = Keyboard.addListener(
@@ -110,14 +117,46 @@ export default function MnemonicScreen({
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      title:
-        phase === 'pin_entry'
-          ? 'Enter Keycard PIN'
-          : mode === 'verify'
-          ? 'Verify recovery phrase'
-          : 'Import recovery phrase',
+      title: scanning
+        ? 'Scan SeedQR'
+        : phase === 'pin_entry'
+        ? 'Enter Keycard PIN'
+        : mode === 'verify'
+        ? 'Verify recovery phrase'
+        : 'Import recovery phrase',
     });
-  }, [navigation, phase, mode]);
+  }, [navigation, phase, mode, scanning]);
+
+  useEffect(() => {
+    if (!scanning) return;
+    return navigation.addListener('beforeRemove', e => {
+      e.preventDefault();
+      setScanning(false);
+      setScanError(null);
+    });
+  }, [navigation, scanning]);
+
+  const handleCodeScanned = useCallback((event: ReadCodeEvent) => {
+    const value = event.nativeEvent.codeStringValue;
+    if (!value) return;
+
+    const cleaned = value.trim().toLowerCase();
+    if (!isSeedQrPayload(cleaned)) {
+      setScanError('Not a valid SeedQR. Scan a hex-encoded BIP39 entropy QR.');
+      return;
+    }
+
+    const decoded = decodeSeedQr(cleaned);
+    if (decoded.kind === 'error') {
+      setScanError(decoded.message);
+      return;
+    }
+
+    setInput(decoded.words.join(' '));
+    setWordCount(decoded.words.length === 24 ? 24 : 12);
+    setScanning(false);
+    setScanError(null);
+  }, []);
 
   const isComplete = words.length === wordCount;
 
@@ -141,7 +180,6 @@ export default function MnemonicScreen({
           onWordsChange={setWords}
         />
 
-        {/* Passphrase input */}
         <TextInput
           style={styles.passphraseInput}
           value={passphrase}
@@ -150,6 +188,16 @@ export default function MnemonicScreen({
           placeholderTextColor={theme.colors.onSurfacePlaceholder}
           autoCapitalize="none"
           autoCorrect={false}
+        />
+
+        <PrimaryButton
+          label="Scan SeedQR"
+          icon={Icons.qr}
+          onPress={() => {
+            setScanError(null);
+            setScanning(true);
+          }}
+          testID="scan-seedqr-button"
         />
       </ScrollView>
 
@@ -168,6 +216,22 @@ export default function MnemonicScreen({
       </View>
 
       <NFCBottomSheet nfc={keycard} onCancel={handleCancel} />
+
+      {scanning && (
+        <CameraView
+          style={[StyleSheet.absoluteFill, { paddingTop: insets.top }]}
+          onReadCode={handleCodeScanned}
+        >
+          {scanError && (
+            <View style={styles.scanErrorContainer}>
+              <Text style={styles.scanErrorText}>{scanError}</Text>
+              <Pressable onPress={() => setScanError(null)}>
+                <Text style={styles.scanRetryText}>Tap to retry</Text>
+              </Pressable>
+            </View>
+          )}
+        </CameraView>
+      )}
     </View>
   );
 }
@@ -181,23 +245,43 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    padding: 16,
     gap: 20,
+    padding: 16,
   },
   passphraseInput: {
     backgroundColor: theme.colors.surfaceVariant,
+    borderBottomColor: theme.colors.onSurface,
+    borderBottomWidth: 3,
     borderTopLeftRadius: 4,
     borderTopRightRadius: 4,
-    borderBottomWidth: 3,
-    borderBottomColor: theme.colors.onSurface,
-    paddingHorizontal: 16,
-    paddingTop: 4,
-    paddingBottom: 4,
     color: theme.colors.onSurface,
     fontSize: 16,
     height: 52,
+    paddingBottom: 4,
+    paddingHorizontal: 16,
+    paddingTop: 4,
   },
   buttonContainer: {
     paddingHorizontal: 16,
+  },
+  scanErrorContainer: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    bottom: 100,
+    left: 24,
+    padding: 16,
+    position: 'absolute',
+    right: 24,
+    borderRadius: 8,
+    gap: 8,
+  },
+  scanErrorText: {
+    color: theme.colors.error,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  scanRetryText: {
+    color: theme.colors.primary,
+    fontSize: 14,
   },
 });

--- a/src/utils/seedQr.ts
+++ b/src/utils/seedQr.ts
@@ -1,0 +1,41 @@
+import { entropyToMnemonic, validateMnemonic } from '@scure/bip39';
+import { wordlist as englishWordlist } from '@scure/bip39/wordlists/english.js';
+
+export type SeedQrDecodeResult =
+  | { kind: 'success'; words: string[] }
+  | { kind: 'error'; message: string };
+
+const VALID_ENTROPY_LENGTHS = [16, 32];
+
+export function decodeSeedQr(payload: string): SeedQrDecodeResult {
+  const cleaned = payload.trim().toLowerCase();
+  if (!/^[0-9a-f]+$/.test(cleaned)) {
+    return { kind: 'error', message: 'SeedQR payload must be a hex string' };
+  }
+
+  const bytes = Buffer.from(cleaned, 'hex');
+  if (!VALID_ENTROPY_LENGTHS.includes(bytes.length)) {
+    return {
+      kind: 'error',
+      message: `Invalid SeedQR: expected 16 or 32 bytes, got ${bytes.length}`,
+    };
+  }
+
+  try {
+    const phrase = entropyToMnemonic(bytes, englishWordlist);
+    if (!validateMnemonic(phrase, englishWordlist)) {
+      return { kind: 'error', message: 'Decoded mnemonic failed checksum' };
+    }
+    return { kind: 'success', words: phrase.split(' ') };
+  } catch (e: any) {
+    return { kind: 'error', message: `Failed to decode SeedQR: ${e.message}` };
+  }
+}
+
+export function isSeedQrPayload(value: string): boolean {
+  const cleaned = value.trim().toLowerCase();
+  return (
+    /^[0-9a-f]+$/.test(cleaned) &&
+    VALID_ENTROPY_LENGTHS.includes(cleaned.length / 2)
+  );
+}


### PR DESCRIPTION
## Summary

- Adds "Scan SeedQR" button to the mnemonic import/verify screen; scanning fills the word grid inline without leaving the screen
- Extracts shared `CameraView` component (camera + viewfinder corners) reused by both `MnemonicScreen` and `QRScannerScreen`
- New `seedQr.ts` utility decodes hex-encoded BIP39 entropy QR codes to mnemonic words via `entropyToMnemonic`

## Details

The scanner opens as an overlay on top of the import screen. The navigation header title changes to "Scan SeedQR" and the native back button dismisses the overlay (via `beforeRemove` listener) instead of popping the screen, so the back stack stays clean.

Supported formats: 16-byte hex (12 words) and 32-byte hex (24 words). Invalid payloads show an inline error with a tap-to-retry prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SeedQR camera scanning support for importing recovery phrases during mnemonic setup.
  * Camera display now includes visual viewfinder overlay for better scanning guidance.
  * Enhanced error messaging and retry functionality for invalid QR scan payloads.

* **Tests**
  * Added comprehensive test coverage for camera scanning and QR decoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->