### PR TITLE
feat: add pairing slot management screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Add pairing slot management screen: check remaining slots, unpair any slot
 - Add SeedQR scan support for mnemonic import/verify
 - Enforce seed review on generate: 30s mandatory timer on word/share display, return to word list after 3 wrong verify answers (keycard-shell parity)
 - Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985

--- a/__tests__/KeycardMenuScreen.test.tsx
+++ b/__tests__/KeycardMenuScreen.test.tsx
@@ -43,6 +43,7 @@ describe('KeycardMenuScreen', () => {
     expect(screen.getByText('Keypair')).toBeTruthy();
     expect(screen.getByText('Set card name')).toBeTruthy();
     expect(screen.getByText('Secrets')).toBeTruthy();
+    expect(screen.getByText('Manage pairing slots')).toBeTruthy();
     expect(screen.getByText('Factory reset')).toBeTruthy();
   });
 
@@ -52,7 +53,8 @@ describe('KeycardMenuScreen', () => {
     expect(screen.queryByTestId('menu-nfc-indicator-1')).toBeNull();
     expect(screen.queryByTestId('menu-nfc-indicator-2')).toBeNull();
     expect(screen.queryByTestId('menu-nfc-indicator-3')).toBeNull();
-    expect(screen.queryByTestId('menu-nfc-indicator-4')).toBeNull();
+    expect(screen.getByTestId('menu-nfc-indicator-4')).toBeTruthy();
+    expect(screen.queryByTestId('menu-nfc-indicator-5')).toBeNull();
   });
 
   it('renders the NFC indicator with the primary accent color', () => {
@@ -69,6 +71,7 @@ describe('KeycardMenuScreen', () => {
       ['Keypair', 'KeyPairMenu'],
       ['Set card name', 'SetCardName'],
       ['Secrets', 'SecretsMenu'],
+      ['Manage pairing slots', 'PairingSlots'],
       ['Factory reset', 'FactoryReset'],
     ] as const) {
       fireEvent.press(screen.getByText(label));

--- a/__tests__/PairingSlotsScreen.test.tsx
+++ b/__tests__/PairingSlotsScreen.test.tsx
@@ -1,0 +1,438 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+
+import PairingSlotsScreen from '../src/screens/PairingSlotsScreen';
+import NFCBottomSheet from '../src/components/NFCBottomSheet';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const RN = require('react-native');
+  const Snackbar = ({
+    visible,
+    children,
+    onDismiss,
+  }: {
+    visible: boolean;
+    children: React.ReactNode;
+    onDismiss: () => void;
+  }) =>
+    visible ? (
+      <>
+        <RN.Text>{children}</RN.Text>
+        <RN.Pressable onPress={onDismiss}>
+          <RN.Text>Dismiss snackbar</RN.Text>
+        </RN.Pressable>
+      </>
+    ) : null;
+  return { MD3DarkTheme: { colors: {} }, Snackbar, Text: RN.Text };
+});
+
+jest.mock('react-native-encrypted-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockDeletePairing = jest.fn();
+jest.mock('../src/storage/pairingStorage', () => ({
+  deletePairing: (...args: any[]) => mockDeletePairing(...args),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => cb(),
+}));
+
+jest.mock('../src/components/ConfirmPropmpt', () => {
+  const { Pressable, Text } = require('react-native');
+  return ({
+    title,
+    yesLabel,
+    noLabel,
+    onYes,
+    onNo,
+  }: {
+    title: string;
+    yesLabel: string;
+    noLabel: string;
+    onYes: () => void;
+    onNo: () => void;
+  }) => (
+    <>
+      <Text>{title}</Text>
+      <Pressable onPress={onYes}>
+        <Text>{yesLabel}</Text>
+      </Pressable>
+      <Pressable onPress={onNo}>
+        <Text>{noLabel}</Text>
+      </Pressable>
+    </>
+  );
+});
+
+jest.mock('../src/components/NFCBottomSheet', () => jest.fn(() => null));
+const MockNFCBottomSheet = NFCBottomSheet as jest.MockedFunction<
+  typeof NFCBottomSheet
+>;
+
+jest.mock('../src/components/PrimaryButton', () => {
+  const { Pressable, Text } = require('react-native');
+  return ({ label, onPress }: { label: string; onPress: () => void }) => (
+    <Pressable onPress={onPress}>
+      <Text>{label}</Text>
+    </Pressable>
+  );
+});
+
+const mockCheckSlots = jest.fn();
+const mockCancel = jest.fn();
+const mockUsePairingSlots = jest.fn();
+
+jest.mock('../src/hooks/keycard/usePairingSlots', () => ({
+  usePairingSlots: () => mockUsePairingSlots(),
+}));
+
+const mockExecute = jest.fn(async (op: any) => {
+  const mockCmdSet = { unpair: jest.fn(() => Promise.resolve()) };
+  await op(mockCmdSet);
+  return mockCmdSet;
+});
+const mockUnpairCancel = jest.fn();
+const mockUseKeycardOperation = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOperation: () => mockUseKeycardOperation(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockNavigate = jest.fn();
+
+const navigation = {
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+  navigate: mockNavigate,
+} as any;
+
+function makeCheckHook(
+  phase: string,
+  slotInfo: {
+    totalSlots: number;
+    freeSlots: number;
+    ourSlotIndex: number | null;
+    cardUid: string;
+  } | null = null,
+) {
+  return {
+    phase,
+    status: phase === 'checking' ? 'Selecting applet...' : '',
+    slotInfo,
+    checkSlots: mockCheckSlots,
+    cancel: mockCancel,
+    reset: jest.fn(),
+  };
+}
+
+function makeUnpairHook(phase: string) {
+  return {
+    phase,
+    status: '',
+    result: null,
+    cardName: null,
+    pinError: null,
+    execute: mockExecute,
+    submitPin: jest.fn(),
+    clearPinError: jest.fn(),
+    cancel: mockUnpairCancel,
+    reset: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  };
+}
+
+function renderScreen(
+  checkPhase = 'idle',
+  slotInfo: ReturnType<typeof makeCheckHook>['slotInfo'] = null,
+  unpairPhase = 'idle',
+) {
+  mockUsePairingSlots.mockReturnValue(makeCheckHook(checkPhase, slotInfo));
+  mockUseKeycardOperation.mockReturnValue(makeUnpairHook(unpairPhase));
+  return render(
+    <PairingSlotsScreen navigation={navigation} route={undefined as any} />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PairingSlotsScreen', () => {
+  beforeEach(() => {
+    mockCheckSlots.mockClear();
+    mockCancel.mockClear();
+    mockExecute.mockClear();
+    mockUnpairCancel.mockClear();
+    mockDeletePairing.mockClear();
+    mockNavigate.mockClear();
+    mockUsePairingSlots.mockClear();
+    mockUseKeycardOperation.mockClear();
+    MockNFCBottomSheet.mockClear();
+  });
+
+  describe('auto-start on focus', () => {
+    it('calls checkSlots automatically when idle and no slotInfo', () => {
+      renderScreen();
+      expect(mockCheckSlots).toHaveBeenCalled();
+    });
+
+    it('does not auto-start when slotInfo is already present', () => {
+      const slotInfo = {
+        totalSlots: 10,
+        freeSlots: 7,
+        ourSlotIndex: 3,
+        cardUid: 'abcd',
+      };
+      renderScreen('ready', slotInfo);
+      expect(mockCheckSlots).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idle state', () => {
+    it('renders tap prompt', () => {
+      renderScreen();
+      expect(screen.getByText(/Tap your Keycard to read/)).toBeTruthy();
+    });
+
+    it('passes check hook to NFCBottomSheet', () => {
+      renderScreen('checking');
+      const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
+      expect(lastCall?.[0].nfc.phase).toBe('nfc');
+      expect(lastCall?.[0].showOnDone).toBe(false);
+    });
+  });
+
+  describe('error state', () => {
+    it('renders error message and Try again button', () => {
+      renderScreen('error');
+      expect(screen.getByText(/Could not read pairing slot data/)).toBeTruthy();
+      expect(screen.getByText('Try again')).toBeTruthy();
+    });
+
+    it('calls checkSlots when Try again is pressed', () => {
+      renderScreen('error');
+      fireEvent.press(screen.getByText('Try again'));
+      expect(mockCheckSlots).toHaveBeenCalled();
+    });
+  });
+
+  describe('ready state', () => {
+    const slotInfo = {
+      totalSlots: 10,
+      freeSlots: 7,
+      ourSlotIndex: 3,
+      cardUid: 'abcd',
+    };
+
+    it('renders slot summary', () => {
+      renderScreen('ready', slotInfo);
+      expect(screen.getByText('Slots free')).toBeTruthy();
+      expect(screen.getByText('7 / 10')).toBeTruthy();
+    });
+
+    it('renders all 10 slots with 1-based numbering', () => {
+      renderScreen('ready', slotInfo);
+      for (let i = 0; i < 10; i++) {
+        expect(screen.getByText(`Slot ${i + 1}`)).toBeTruthy();
+      }
+    });
+
+    it('marks our slot as This device', () => {
+      renderScreen('ready', slotInfo);
+      expect(screen.getByText('This device')).toBeTruthy();
+    });
+  });
+
+  describe('unpair via slot press', () => {
+    const slotInfo = {
+      totalSlots: 10,
+      freeSlots: 7,
+      ourSlotIndex: 3,
+      cardUid: 'abcd',
+    };
+
+    it('shows ConfirmPrompt with correct slot number when a row is pressed', () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 1'));
+      expect(screen.getByText('Unpair slot 1?')).toBeTruthy();
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('executes unpair after user confirms', async () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 3'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+      expect(mockExecute).toHaveBeenCalled();
+    });
+
+    it('returns to slot list when user cancels confirmation', () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 3'));
+      fireEvent.press(screen.getByText('Cancel'));
+      expect(mockExecute).not.toHaveBeenCalled();
+      expect(screen.getByText('Slots free')).toBeTruthy();
+    });
+
+    it('deletes local pairing when unpairing our own slot', async () => {
+      renderScreen('ready', slotInfo);
+      // ourSlotIndex is 3, so Slot 4 (1-based) is our slot
+      fireEvent.press(screen.getByText('Slot 4'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+      expect(mockExecute).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockDeletePairing).toHaveBeenCalledWith('abcd');
+      });
+    });
+
+    it('keeps unpair success path when local pairing cleanup fails', async () => {
+      mockDeletePairing.mockRejectedValueOnce(new Error('storage failed'));
+      renderScreen('ready', slotInfo);
+
+      fireEvent.press(screen.getByText('Slot 4'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Slot 4 was unpaired')).toBeTruthy();
+      });
+    });
+
+    it('does not delete local pairing when unpairing another slot', async () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 1'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+      expect(mockExecute).toHaveBeenCalled();
+      expect(mockDeletePairing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unpairing state', () => {
+    it('passes unpair hook to NFCBottomSheet with showOnDone', () => {
+      renderScreen('ready', null, 'nfc');
+      const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
+      expect(lastCall?.[0].nfc.phase).toBe('nfc');
+      expect(lastCall?.[0].showOnDone).toBe(true);
+    });
+  });
+
+  describe('cancel NFC', () => {
+    it('calls cancelCheck when cancelling during slot check', () => {
+      renderScreen('checking');
+      const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
+      lastCall?.[0].onCancel();
+      expect(mockCancel).toHaveBeenCalled();
+      expect(mockUnpairCancel).not.toHaveBeenCalled();
+    });
+
+    it('calls cancelUnpair when cancelling during unpair', () => {
+      renderScreen('ready', null, 'nfc');
+      const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
+      lastCall?.[0].onCancel();
+      expect(mockUnpairCancel).toHaveBeenCalled();
+      expect(mockCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unpair done', () => {
+    const slotInfo = {
+      totalSlots: 10,
+      freeSlots: 7,
+      ourSlotIndex: 3,
+      cardUid: 'abcd',
+    };
+
+    it('resets unpair hook, resets check, and re-checks slots when unpair finishes', () => {
+      const mockResetCheck = jest.fn();
+      const mockResetUnpair = jest.fn();
+      mockUsePairingSlots.mockReturnValue({
+        ...makeCheckHook('ready', slotInfo),
+        reset: mockResetCheck,
+      });
+      mockUseKeycardOperation.mockReturnValue({
+        ...makeUnpairHook('idle'),
+        reset: mockResetUnpair,
+      });
+      const { rerender } = render(
+        <PairingSlotsScreen navigation={navigation} route={undefined as any} />,
+      );
+
+      mockUsePairingSlots.mockReturnValue({
+        ...makeCheckHook('ready', slotInfo),
+        reset: mockResetCheck,
+      });
+      mockUseKeycardOperation.mockReturnValue({
+        ...makeUnpairHook('done'),
+        reset: mockResetUnpair,
+      });
+      rerender(
+        <PairingSlotsScreen navigation={navigation} route={undefined as any} />,
+      );
+
+      expect(mockResetUnpair).toHaveBeenCalled();
+      expect(mockResetCheck).toHaveBeenCalled();
+      expect(mockCheckSlots).toHaveBeenCalled();
+    });
+  });
+
+  describe('snackbar notification', () => {
+    const slotInfo = {
+      totalSlots: 10,
+      freeSlots: 7,
+      ourSlotIndex: 3,
+      cardUid: 'abcd',
+    };
+
+    it('shows snackbar with slot number after unpair operation runs', async () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 2'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+      expect(screen.getByText('Slot 2 was unpaired')).toBeTruthy();
+    });
+
+    it('hides snackbar when dismissed', async () => {
+      renderScreen('ready', slotInfo);
+      fireEvent.press(screen.getByText('Slot 2'));
+      await act(async () => {
+        fireEvent.press(screen.getByText('Unpair'));
+      });
+
+      fireEvent.press(screen.getByText('Dismiss snackbar'));
+
+      expect(screen.queryByText('Slot 2 was unpaired')).toBeNull();
+    });
+  });
+});

--- a/__tests__/hex.test.ts
+++ b/__tests__/hex.test.ts
@@ -1,0 +1,25 @@
+import { ensureHexPrefix, toHex } from '../src/utils/hex';
+
+describe('ensureHexPrefix', () => {
+  it('adds 0x prefix when missing', () => {
+    expect(ensureHexPrefix('deadbeef')).toBe('0xdeadbeef');
+  });
+
+  it('keeps existing 0x prefix', () => {
+    expect(ensureHexPrefix('0xdeadbeef')).toBe('0xdeadbeef');
+  });
+});
+
+describe('toHex', () => {
+  it('converts Uint8Array to lowercase hex string', () => {
+    expect(toHex(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe('deadbeef');
+  });
+
+  it('pads single-byte values', () => {
+    expect(toHex(new Uint8Array([0x01, 0x0a, 0xff]))).toBe('010aff');
+  });
+
+  it('handles empty array', () => {
+    expect(toHex(new Uint8Array([]))).toBe('');
+  });
+});

--- a/__tests__/usePairingSlots.test.ts
+++ b/__tests__/usePairingSlots.test.ts
@@ -1,0 +1,195 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { usePairingSlots } from '../src/hooks/keycard/usePairingSlots';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let capturedOnConnected: ((...args: any[]) => Promise<void>) | null = null;
+
+const mockStartNFC = jest.fn();
+const mockStopNFC = jest.fn();
+
+jest.mock('react-native-keycard', () => ({
+  __esModule: true,
+  default: {
+    Core: {
+      onKeycardConnected: (cb: (...args: any[]) => Promise<void>) => {
+        capturedOnConnected = cb;
+        return { remove: jest.fn() };
+      },
+      onKeycardDisconnected: () => ({ remove: jest.fn() }),
+      onNFCUserCancelled: () => ({ remove: jest.fn() }),
+      onNFCTimeout: () => ({ remove: jest.fn() }),
+      startNFC: (msg: string) => mockStartNFC(msg),
+      stopNFC: () => mockStopNFC(),
+    },
+    NFCCardChannel: class {},
+  },
+}));
+
+const mockSelect = jest.fn();
+const mockApplicationInfo = {
+  instanceUID: new Uint8Array([0xab, 0xcd]),
+  freePairingSlots: 7,
+};
+const mockCmdSet = {
+  select: mockSelect,
+  applicationInfo: mockApplicationInfo,
+};
+
+jest.mock('keycard-sdk', () => ({
+  __esModule: true,
+  default: {
+    Commandset: jest.fn().mockImplementation(() => mockCmdSet),
+  },
+}));
+
+const mockLoadPairing = jest.fn();
+
+jest.mock('../src/storage/pairingStorage', () => ({
+  loadPairing: (...args: any[]) => mockLoadPairing(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePairingSlots', () => {
+  beforeEach(() => {
+    mockStartNFC.mockResolvedValue(undefined);
+    mockStopNFC.mockResolvedValue(undefined);
+    mockStartNFC.mockClear();
+    mockStopNFC.mockClear();
+    mockSelect.mockClear();
+    mockSelect.mockResolvedValue({ sw: 0x9000 });
+    mockLoadPairing.mockClear();
+    mockLoadPairing.mockResolvedValue(null);
+    mockCmdSet.applicationInfo = {
+      instanceUID: new Uint8Array([0xab, 0xcd]),
+      freePairingSlots: 7,
+    };
+    capturedOnConnected = null;
+  });
+
+  describe('initial state', () => {
+    it('starts idle with empty status and null slotInfo', () => {
+      const { result } = renderHook(() => usePairingSlots());
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.status).toBe('');
+      expect(result.current.slotInfo).toBeNull();
+    });
+  });
+
+  describe('checkSlots', () => {
+    it('transitions to checking and calls startNFC', async () => {
+      const { result } = renderHook(() => usePairingSlots());
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      expect(result.current.phase).toBe('checking');
+      expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+    });
+
+    it('reads slot info from SELECT response and loadPairing', async () => {
+      mockLoadPairing.mockResolvedValue({ pairingIndex: 3 });
+      const { result } = renderHook(() => usePairingSlots());
+
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.phase).toBe('ready');
+      expect(result.current.slotInfo).toEqual({
+        totalSlots: 10,
+        freeSlots: 7,
+        ourSlotIndex: 3,
+        cardUid: 'abcd',
+      });
+      expect(mockLoadPairing).toHaveBeenCalledWith('abcd');
+    });
+
+    it('sets ourSlotIndex to null when no local pairing exists', async () => {
+      mockLoadPairing.mockResolvedValue(null);
+      const { result } = renderHook(() => usePairingSlots());
+
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.slotInfo?.ourSlotIndex).toBeNull();
+    });
+
+    it('transitions to error when SELECT fails', async () => {
+      mockSelect.mockResolvedValue({ sw: 0x6a82 });
+      const { result } = renderHook(() => usePairingSlots());
+
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.phase).toBe('error');
+    });
+
+    it('transitions to error when SELECT response has no application info', async () => {
+      (mockCmdSet as any).applicationInfo = null;
+      const { result } = renderHook(() => usePairingSlots());
+
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe('No application info in SELECT response');
+    });
+  });
+
+  describe('cancel', () => {
+    it('returns to idle and stops NFC', async () => {
+      const { result } = renderHook(() => usePairingSlots());
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        result.current.cancel();
+      });
+      expect(result.current.phase).toBe('idle');
+      expect(mockStopNFC).toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears slotInfo and stops NFC', async () => {
+      mockLoadPairing.mockResolvedValue({ pairingIndex: 2 });
+      const { result } = renderHook(() => usePairingSlots());
+
+      await act(async () => {
+        result.current.checkSlots();
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+      expect(result.current.slotInfo).not.toBeNull();
+
+      await act(async () => {
+        result.current.reset();
+      });
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.slotInfo).toBeNull();
+      expect(mockStopNFC).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,11 +1,13 @@
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import theme from '../theme';
+
 import { Icons } from '../assets/icons';
+import theme from '../theme';
 
 type Entry = {
   label: string;
   onPress: () => void;
   requiresNfc?: boolean;
+  detail?: string;
 };
 
 type Props = {
@@ -25,7 +27,24 @@ export default function Menu({ entries }: Props) {
             key={i}
             onPress={action.onPress}
           >
-            <Text style={styles.itemLabel}>{action.label}</Text>
+            <View style={styles.labelRow}>
+              <Text
+                style={styles.itemLabel}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {action.label}
+              </Text>
+              {action.detail ? (
+                <Text
+                  style={styles.itemDetail}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {action.detail}
+                </Text>
+              ) : null}
+            </View>
             <View style={styles.trailingIcons}>
               {action.requiresNfc ? (
                 <Icons.nfcActivate
@@ -77,6 +96,13 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.surface,
   },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: 10,
+    marginRight: 12,
+  },
   itemLabel: {
     fontFamily: 'Inter_18pt-Medium',
     fontWeight: '500',
@@ -84,6 +110,14 @@ const styles = StyleSheet.create({
     lineHeight: 15 * 1.45,
     letterSpacing: -0.135,
     color: theme.colors.onSurface,
+    flexShrink: 1,
+  },
+  itemDetail: {
+    fontFamily: 'Inter_18pt-Regular',
+    fontSize: 13,
+    lineHeight: 13 * 1.45,
+    color: theme.colors.onSurfaceMuted,
+    flexShrink: 1,
   },
   trailingIcons: {
     flexDirection: 'row',

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -1,5 +1,4 @@
 import { useCallback, useRef, useState } from 'react';
-
 import Keycard from 'keycard-sdk';
 import { WrongPINException } from 'keycard-sdk/dist/apdu-exception';
 import { Commandset } from 'keycard-sdk/dist/commandset';
@@ -7,14 +6,9 @@ import { Commandset } from 'keycard-sdk/dist/commandset';
 import { PAIRING_PASSWORD } from '../../constants/keycard';
 import { loadPairing, savePairing } from '../../storage/pairingStorage';
 import { checkGenuine } from '../../utils/genuineCheck';
+import { toHex } from '../../utils/hex';
 import { displayKeycardName, parseKeycardName } from '../../utils/keycardName';
 import useNFCSession from './useNFCSession';
-
-function toHex(arr: Uint8Array): string {
-  return Array.from(arr)
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
-}
 
 export type Phase =
   | 'idle'

--- a/src/hooks/keycard/usePairingSlots.ts
+++ b/src/hooks/keycard/usePairingSlots.ts
@@ -1,0 +1,87 @@
+import { useCallback, useState } from 'react';
+import { Commandset } from 'keycard-sdk/dist/commandset';
+
+import { loadPairing } from '../../storage/pairingStorage';
+import { toHex } from '../../utils/hex';
+import { useNFCOperation } from './useNFCOperation';
+
+const TOTAL_SLOTS = 10;
+
+export interface SlotInfo {
+  totalSlots: number;
+  freeSlots: number;
+  ourSlotIndex: number | null;
+  cardUid: string;
+}
+
+export type PairingSlotsPhase = 'idle' | 'checking' | 'ready' | 'error';
+
+export interface UsePairingSlots {
+  phase: PairingSlotsPhase;
+  slotInfo: SlotInfo | null;
+  status: string;
+  checkSlots: () => void;
+  cancel: () => void;
+  reset: () => void;
+}
+
+export function usePairingSlots(): UsePairingSlots {
+  const [slotInfo, setSlotInfo] = useState<SlotInfo | null>(null);
+
+  const handleConnected = useCallback(async (cmdSet: Commandset) => {
+    const appInfo = cmdSet.applicationInfo;
+    if (!appInfo) {
+      throw new Error('No application info in SELECT response');
+    }
+
+    const uid = toHex(appInfo.instanceUID);
+    const existingPairing = await loadPairing(uid);
+
+    setSlotInfo({
+      totalSlots: TOTAL_SLOTS,
+      freeSlots: appInfo.freePairingSlots,
+      ourSlotIndex: existingPairing?.pairingIndex ?? null,
+      cardUid: uid,
+    });
+  }, []);
+
+  const {
+    start,
+    cancel: nfcCancel,
+    reset: nfcReset,
+    phase: nfcPhase,
+    status,
+  } = useNFCOperation(handleConnected);
+
+  const checkSlots = useCallback(() => {
+    setSlotInfo(null);
+    start();
+  }, [start]);
+
+  const cancel = useCallback(() => {
+    nfcCancel();
+  }, [nfcCancel]);
+
+  const reset = useCallback(() => {
+    setSlotInfo(null);
+    nfcReset();
+  }, [nfcReset]);
+
+  let phase: PairingSlotsPhase = 'idle';
+  if (nfcPhase === 'nfc') {
+    phase = 'checking';
+  } else if (nfcPhase === 'done' && slotInfo) {
+    phase = 'ready';
+  } else if (nfcPhase === 'error') {
+    phase = 'error';
+  }
+
+  return {
+    phase,
+    slotInfo,
+    status,
+    checkSlots,
+    cancel,
+    reset,
+  };
+}

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -7,17 +7,18 @@ import type { RootStackParamList } from './types';
 // Top-level screens
 import AboutScreen from '../screens/AboutScreen';
 import DashboardScreen from '../screens/DashboardScreen';
-import LicenseDetailScreen from '../screens/LicenseDetailScreen';
-import UrlQRScreen from '../screens/UrlQRScreen';
 import ExportKeyScreen from '../screens/ExportKeyScreen';
 import FactoryResetScreen from '../screens/FactoryResetScreen';
 import InitCardScreen from '../screens/InitCardScreen';
 import KeycardMenuScreen from '../screens/KeycardMenuScreen';
 import KeycardScreen from '../screens/KeycardScreen';
+import LicenseDetailScreen from '../screens/LicenseDetailScreen';
+import PairingSlotsScreen from '../screens/PairingSlotsScreen';
 import QRResultScreen from '../screens/QRResultScreen';
 import QRScannerScreen from '../screens/QRScannerScreen';
 import SetCardNameScreen from '../screens/SetCardNameScreen';
 import TransactionDetailScreen from '../screens/TransactionDetailScreen';
+import UrlQRScreen from '../screens/UrlQRScreen';
 
 // Address screens
 import AddressDetailScreen from '../screens/address/AddressDetailScreen';
@@ -77,6 +78,11 @@ export const routes: Route[] = [
     name: 'FactoryReset',
     component: FactoryResetScreen,
     options: defaultHeaderOptions,
+  },
+  {
+    name: 'PairingSlots',
+    component: PairingSlotsScreen,
+    options: { ...defaultHeaderOptions, title: 'Pairing slots' },
   },
   {
     name: 'ExportKey',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -54,6 +54,7 @@ export type RootStackParamList = {
   Mnemonic: { mode?: 'import' | 'verify' } | undefined;
   Slip39: { mode: 'generate' | 'import' | 'verify' };
   FactoryReset: undefined;
+  PairingSlots: undefined;
   AddressMenu: undefined;
   AddressList: { coin: 'btc' | 'eth' };
   AddressDetail: { address: string; index: number; title?: string };
@@ -130,6 +131,11 @@ export type Slip39ScreenProps = NativeStackScreenProps<
 export type FactoryResetSreenProps = NativeStackScreenProps<
   RootStackParamList,
   'FactoryReset'
+>;
+
+export type PairingSlotsScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'PairingSlots'
 >;
 
 export type KeyPairMenuScreenProps = NativeStackScreenProps<

--- a/src/screens/KeycardMenuScreen.tsx
+++ b/src/screens/KeycardMenuScreen.tsx
@@ -31,6 +31,11 @@ export default function KeycardMenuScreen({
       onPress: () => navigation.navigate('SecretsMenu'),
     },
     {
+      label: 'Manage pairing slots',
+      requiresNfc: true,
+      onPress: () => navigation.navigate('PairingSlots'),
+    },
+    {
       label: 'Factory reset',
       onPress: () => navigation.navigate('FactoryReset'),
     },

--- a/src/screens/PairingSlotsScreen.tsx
+++ b/src/screens/PairingSlotsScreen.tsx
@@ -1,0 +1,251 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Snackbar, Text } from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { PairingSlotsScreenProps } from '../navigation/types';
+import theme from '../theme';
+
+import ConfirmPrompt from '../components/ConfirmPropmpt';
+import Menu from '../components/Menu';
+import NFCBottomSheet, { NFCOperation } from '../components/NFCBottomSheet';
+import PrimaryButton from '../components/PrimaryButton';
+
+import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
+import { usePairingSlots } from '../hooks/keycard/usePairingSlots';
+
+import { deletePairing } from '../storage/pairingStorage';
+
+export default function PairingSlotsScreen({
+  navigation,
+}: PairingSlotsScreenProps) {
+  const insets = useSafeAreaInsets();
+  const [pendingSlotIndex, setPendingSlotIndex] = useState<number | null>(null);
+  const [unpairNotice, setUnpairNotice] = useState<string | null>(null);
+
+  const {
+    phase: checkPhase,
+    slotInfo,
+    status: checkStatus,
+    checkSlots,
+    cancel: cancelCheck,
+    reset: resetCheck,
+  } = usePairingSlots();
+
+  const unpairHook = useKeycardOperation<void>();
+  const {
+    phase: unpairPhase,
+    execute: executeUnpair,
+    cancel: cancelUnpair,
+    reset: resetUnpair,
+  } = unpairHook;
+
+  const isUnpairing = unpairPhase !== 'idle';
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'Pairing slots' });
+  }, [navigation]);
+
+  // Auto-start NFC check when the screen is focused and we have no data yet.
+  useFocusEffect(
+    useCallback(() => {
+      if (checkPhase === 'idle' && !slotInfo) {
+        checkSlots();
+      }
+    }, [checkPhase, slotInfo, checkSlots]),
+  );
+
+  useEffect(() => {
+    if (unpairPhase === 'done') {
+      resetUnpair();
+      resetCheck();
+      checkSlots();
+    }
+  }, [unpairPhase, resetUnpair, resetCheck, checkSlots]);
+
+  const handleUnpairPress = useCallback((slotIndex: number) => {
+    setPendingSlotIndex(slotIndex);
+  }, []);
+
+  const handleConfirmUnpair = useCallback(() => {
+    const slotIndex = pendingSlotIndex!;
+    setPendingSlotIndex(null);
+    executeUnpair(
+      async cmdSet => {
+        await cmdSet.unpair(slotIndex);
+        // If we unpaired our own slot, remove the local pairing so the
+        // next use triggers a fresh autoPair instead of a stale key.
+        if (slotInfo?.ourSlotIndex === slotIndex) {
+          try {
+            await deletePairing(slotInfo.cardUid);
+          } catch {
+            // Card-side unpair already succeeded; local cleanup is best-effort.
+          }
+        }
+        setUnpairNotice(`Slot ${slotIndex + 1} was unpaired`);
+      },
+      { requiresPin: true, requiresMasterKey: false },
+    );
+  }, [pendingSlotIndex, executeUnpair, slotInfo]);
+
+  const handleCancelUnpairConfirm = useCallback(() => {
+    setPendingSlotIndex(null);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    if (isUnpairing) {
+      cancelUnpair();
+    } else {
+      cancelCheck();
+    }
+  }, [isUnpairing, cancelUnpair, cancelCheck]);
+
+  // Build the NFCOperation object passed to NFCBottomSheet.
+  // The check flow maps 'checking' → 'nfc' so the bottom sheet shows.
+  const activeNfc: NFCOperation = isUnpairing
+    ? unpairHook
+    : {
+        phase:
+          checkPhase === 'checking'
+            ? 'nfc'
+            : checkPhase === 'ready'
+            ? 'done'
+            : checkPhase,
+        status: checkStatus,
+      };
+
+  if (pendingSlotIndex !== null) {
+    return (
+      <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
+        <ConfirmPrompt
+          title={`Unpair slot ${pendingSlotIndex + 1}?`}
+          description="The device paired to this slot will need to re-pair before it can use this card again."
+          yesLabel="Unpair"
+          noLabel="Cancel"
+          onYes={handleConfirmUnpair}
+          onNo={handleCancelUnpairConfirm}
+        />
+      </View>
+    );
+  }
+
+  const showContent =
+    !isUnpairing &&
+    (checkPhase === 'idle' || checkPhase === 'ready' || checkPhase === 'error');
+
+  const menuEntries = slotInfo?.totalSlots
+    ? Array.from({ length: slotInfo.totalSlots }, (_, i) => {
+        const isOurSlot = i === slotInfo.ourSlotIndex;
+        return {
+          label: `Slot ${i + 1}`,
+          detail: isOurSlot ? 'This device' : undefined,
+          onPress: () => handleUnpairPress(i),
+        };
+      })
+    : [];
+
+  return (
+    <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
+      {showContent && (
+        <View style={styles.content}>
+          {!slotInfo && checkPhase !== 'error' && (
+            <View style={styles.centeredContent}>
+              <Text style={styles.description}>
+                Tap your Keycard to read the pairing slot status.
+              </Text>
+            </View>
+          )}
+
+          {checkPhase === 'error' && (
+            <View style={styles.centeredContent}>
+              <Text style={styles.description}>
+                Could not read pairing slot data. Make sure you are tapping the
+                correct card.
+              </Text>
+              <PrimaryButton label="Try again" onPress={checkSlots} />
+            </View>
+          )}
+
+          {slotInfo && (
+            <View style={styles.listContent}>
+              <View style={styles.summaryRow}>
+                <Text style={styles.summaryLabel}>Slots free</Text>
+                <Text style={styles.summaryValue}>
+                  {slotInfo.freeSlots} / {slotInfo.totalSlots}
+                </Text>
+              </View>
+
+              <Menu entries={menuEntries} />
+            </View>
+          )}
+        </View>
+      )}
+
+      <NFCBottomSheet
+        nfc={activeNfc}
+        onCancel={handleCancel}
+        showOnDone={isUnpairing}
+      />
+
+      <Snackbar
+        visible={unpairNotice !== null}
+        onDismiss={() => setUnpairNotice(null)}
+      >
+        {unpairNotice ?? ''}
+      </Snackbar>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    flex: 1,
+  },
+  centeredContent: {
+    flex: 1,
+    justifyContent: 'center',
+    gap: 24,
+    paddingHorizontal: 24,
+  },
+  description: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+  listContent: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 16,
+    gap: 16,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: theme.colors.surfaceList,
+    borderRadius: 12,
+  },
+  summaryLabel: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 15,
+  },
+  summaryValue: {
+    color: theme.colors.onSurface,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -3,3 +3,9 @@ export type HexString = `0x${string}`;
 export function ensureHexPrefix(value: string): HexString {
   return (value.startsWith('0x') ? value : `0x${value}`) as HexString;
 }
+
+export function toHex(arr: Uint8Array): string {
+  return Array.from(arr)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}


### PR DESCRIPTION
## Summary

- New screen in the Keycard menu to view and manage pairing slots
- Shows how many of the 10 slots are free and which one belongs to this device
- Any slot can be unpaired with PIN confirmation; unpairing your own slot removes the local pairing so the next use re-pairs automatically
- Snackbar confirmation shown after a slot is unpaired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pairing slots management screen to view remaining slots and unpair devices, with NFC prompts during actions
  * "Manage pairing slots" menu item added for quick access
  * List rows can show secondary detail text for clearer item summaries
  * Dismissible notice shown after a slot is unpaired

* **Tests**
  * Extensive test coverage added for pairing slots flows and hex utilities

* **Docs**
  * CHANGELOG updated with the new pairing slots entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->