### PR TITLE
fix: align crypto-hdkey wallet export fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985
+- Fix `crypto-hdkey` ETH export: use master key (`m`) fingerprint as `origin.sourceFingerprint` and set `parentFingerprint` on the HDKey (fixes Ambire and strict BIP32 wallets)
 
 ## [1.4.0] - 2026-05-02
 

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -84,6 +84,7 @@ describe('ExportKeyScreen', () => {
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
         derivationPath: "m/44'/60'/0'",
+        source: 'account.standard',
       });
     });
 

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -123,6 +123,7 @@ const ethExportRoute = {
   params: {
     operation: 'export_key',
     derivationPath: "m/44'/60'/0'",
+    source: 'account.standard',
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -294,6 +295,7 @@ describe('KeycardScreen', () => {
         result: {
           exportRespData: new Uint8Array([1, 2, 3]),
           sourceFingerprint: 0xdeadbeef,
+          parentFingerprint: 0xaabbccdd,
         },
       });
       await renderWithMockedHook(ethExportRoute);
@@ -305,7 +307,8 @@ describe('KeycardScreen', () => {
         new Uint8Array([1, 2, 3]),
         "m/44'/60'/0'",
         0xdeadbeef,
-        undefined,
+        0xaabbccdd,
+        'account.standard',
       );
       expect(navigation.reset).toHaveBeenCalledTimes(1);
     });

--- a/__tests__/cryptoHdKey.test.ts
+++ b/__tests__/cryptoHdKey.test.ts
@@ -1,5 +1,6 @@
 import { URDecoder } from '@ngraveio/bc-ur';
 import CBOR from 'cbor-sync';
+
 import { buildCryptoHdKeyUR } from '../src/utils/cryptoHdKey';
 
 /* eslint-disable no-bitwise */
@@ -95,6 +96,7 @@ const CHAIN_CODE = new Uint8Array(32).fill(0xcc);
 
 const DERIVATION_PATH = "m/44'/60'/0'";
 const SOURCE_FINGERPRINT = 0xdeadbeef;
+const PARENT_FINGERPRINT = 0xcafebabe;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -108,8 +110,13 @@ describe('buildCryptoHdKeyUR', () => {
   });
 
   it('returns a ur:crypto-hdkey string', () => {
-    const ur = buildCryptoHdKeyUR(tlvData, DERIVATION_PATH, SOURCE_FINGERPRINT);
-    expect(ur.toLowerCase()).toMatch(/^ur:crypto-hdkey\//);
+    const ur = buildCryptoHdKeyUR(
+      tlvData,
+      DERIVATION_PATH,
+      SOURCE_FINGERPRINT,
+      PARENT_FINGERPRINT,
+    );
+    expect(ur).toMatch(/^ur:crypto-hdkey\//);
   });
 
   describe('CBOR structure', () => {
@@ -120,6 +127,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
       );
       decoded = decodeUR(ur);
     });
@@ -154,6 +162,10 @@ describe('buildCryptoHdKeyUR', () => {
       expect(keypathMap[2]).toBe(SOURCE_FINGERPRINT);
     });
 
+    it('key 8 (parent-fingerprint) matches PARENT_FINGERPRINT', () => {
+      expect(decoded[8]).toBe(PARENT_FINGERPRINT);
+    });
+
     it('key 9 (name) is "GapSign"', () => {
       expect(decoded[9]).toBe('GapSign');
     });
@@ -165,6 +177,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
       );
       const decoded = decodeUR(ur);
       // The origin (key 6) is a CBOR tagged value (tag 304).
@@ -176,7 +189,12 @@ describe('buildCryptoHdKeyUR', () => {
     });
 
     it('encodes a non-hardened path correctly', () => {
-      const ur = buildCryptoHdKeyUR(tlvData, 'm/0/1', SOURCE_FINGERPRINT);
+      const ur = buildCryptoHdKeyUR(
+        tlvData,
+        'm/0/1',
+        SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
+      );
       const decoded = decodeUR(ur);
       const origin = decoded[6];
       const keypathMap = origin?.value ?? origin;
@@ -190,6 +208,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
         'account.ledger_live',
       );
       const decoded = decodeUR(ur);
@@ -201,6 +220,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
         'account.ledger_legacy',
       );
       const decoded = decodeUR(ur);
@@ -212,6 +232,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
         'account.ledger_live',
       );
       const decoded = decodeUR(ur);
@@ -223,6 +244,7 @@ describe('buildCryptoHdKeyUR', () => {
         tlvData,
         DERIVATION_PATH,
         SOURCE_FINGERPRINT,
+        PARENT_FINGERPRINT,
       );
       const decoded = decodeUR(ur);
       expect(decoded[10]).toBeUndefined();

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -97,6 +97,7 @@ describe('buildExportUr', () => {
       {
         exportRespData: new Uint8Array([1, 2, 3]),
         sourceFingerprint: 0xdeadbeef,
+        parentFingerprint: 0xaabbccdd,
       },
       "m/44'/60'/0'",
       'MetaMask',
@@ -105,6 +106,7 @@ describe('buildExportUr', () => {
       new Uint8Array([1, 2, 3]),
       "m/44'/60'/0'",
       0xdeadbeef,
+      0xaabbccdd,
       'MetaMask',
     );
     expect(result).toBe('ur:crypto-hdkey/mock');
@@ -151,17 +153,24 @@ describe('exportKeyForWallet', () => {
     expect(exportKeysForBitget).toHaveBeenCalledWith(cmdSet, setStatus);
   });
 
-  it('exports an Ethereum hdkey with the parent fingerprint', async () => {
+  it('exports an Ethereum hdkey with master and parent fingerprints', async () => {
+    const masterResp = response([0, 1, 2]);
     const parentResp = response([1, 2, 3]);
     const extendedResp = response([4, 5, 6]);
+    pubKeyFingerprint.mockReturnValueOnce(0xaaaa).mockReturnValueOnce(0xbbbb);
     const cmdSet = {
-      exportKey: jest.fn().mockResolvedValue(parentResp),
+      exportKey: jest
+        .fn()
+        .mockResolvedValueOnce(masterResp)
+        .mockResolvedValueOnce(parentResp),
       exportExtendedKey: jest.fn().mockResolvedValue(extendedResp),
     } as any;
 
     const result = await exportKeyForWallet(cmdSet, "m/44'/60'/0'/0/0");
 
-    expect(cmdSet.exportKey).toHaveBeenCalledWith(
+    expect(cmdSet.exportKey).toHaveBeenNthCalledWith(1, 0, true, 'm', false);
+    expect(cmdSet.exportKey).toHaveBeenNthCalledWith(
+      2,
       0,
       true,
       "m/44'/60'/0'/0",
@@ -172,11 +181,13 @@ describe('exportKeyForWallet', () => {
       "m/44'/60'/0'/0/0",
       false,
     );
+    expect(masterResp.checkOK).toHaveBeenCalled();
     expect(parentResp.checkOK).toHaveBeenCalled();
     expect(extendedResp.checkOK).toHaveBeenCalled();
     expect(result).toEqual({
       exportRespData: new Uint8Array([4, 5, 6]),
-      sourceFingerprint: 0xdeadbeef,
+      sourceFingerprint: 0xaaaa,
+      parentFingerprint: 0xbbbb,
     });
   });
 

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -3,6 +3,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DashboardAction, ExportKeyScreenProps } from '../navigation/types';
 import theme from '../theme';
+
 import Menu from '../components/Menu';
 
 export const dashboardEntry: DashboardAction = {
@@ -21,6 +22,7 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
         navigation.navigate('Keycard', {
           operation: 'export_key',
           derivationPath: "m/44'/60'/0'",
+          source: 'account.standard',
         }),
     },
     {

--- a/src/utils/cryptoHdKey.ts
+++ b/src/utils/cryptoHdKey.ts
@@ -6,9 +6,13 @@ import {
 import { UR, UREncoder } from '@ngraveio/bc-ur';
 import Keycard from 'keycard-sdk';
 
-import { derivationPathToKeypath } from './hdKeyUtils';
+import {
+  derivationPathToKeypath,
+  numberToFingerprintBuffer,
+} from './hdKeyUtils';
 
 const LEDGER_LEGACY_SOURCE = 'account.ledger_legacy';
+const CRYPTO_HDKEY_NAME = 'GapSign';
 
 /**
  * Parse the raw Keycard exportKey TLV response, encode it as a
@@ -24,16 +28,19 @@ export function buildCryptoHdKeyUR(
   exportRespData: Uint8Array,
   derivationPath: string,
   sourceFingerprint: number,
+  parentFingerprint: number,
   source?: string,
 ): string {
   const parsed = Keycard.BIP32KeyPair.fromTLV(exportRespData);
 
   const hdKey = new CryptoHDKey({
     isMaster: false,
+    isPrivateKey: false,
     key: Buffer.from(Keycard.CryptoUtils.compressPublicKey(parsed.publicKey)),
     chainCode: Buffer.from(parsed.chainCode),
     origin: derivationPathToKeypath(derivationPath, sourceFingerprint),
-    name: 'GapSign',
+    parentFingerprint: numberToFingerprintBuffer(parentFingerprint),
+    name: CRYPTO_HDKEY_NAME,
     ...(source !== undefined && { note: source }),
     ...(source === LEDGER_LEGACY_SOURCE && {
       children: new CryptoKeypath([

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -19,6 +19,7 @@ export type ExportKeyResult =
   | {
       exportRespData: Uint8Array;
       sourceFingerprint: number;
+      parentFingerprint: number;
     }
   | BitcoinCryptoAccount
   | BitgetExportResult;
@@ -59,6 +60,7 @@ export function buildExportUr(
       result.exportRespData,
       derivationPath,
       result.sourceFingerprint,
+      result.parentFingerprint,
       source,
     );
   }
@@ -78,6 +80,9 @@ export async function exportKeyForWallet(
   }
 
   if (!isBitcoinPath(derivationPath)) {
+    const masterResp = await cmdSet.exportKey(0, true, 'm', false);
+    masterResp.checkOK();
+
     const parentPath = derivationPath.split('/').slice(0, -1).join('/') || 'm';
     const parentResp = await cmdSet.exportKey(0, true, parentPath, false);
     parentResp.checkOK();
@@ -87,6 +92,9 @@ export async function exportKeyForWallet(
     return {
       exportRespData: resp.data,
       sourceFingerprint: pubKeyFingerprint(
+        Keycard.BIP32KeyPair.fromTLV(masterResp.data).publicKey,
+      ),
+      parentFingerprint: pubKeyFingerprint(
         Keycard.BIP32KeyPair.fromTLV(parentResp.data).publicKey,
       ),
     };


### PR DESCRIPTION
## Summary

- Use the master key fingerprint as the `crypto-hdkey` origin source fingerprint
- Add the parent path fingerprint to the exported HD key
- Mark Ethereum software wallet export as `account.standard`
- Keep exported `crypto-hdkey` URs lowercase for wallet compatibility
- Add regression coverage for export params, CBOR fields, and fingerprint derivation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethereum HDKey export compatibility: exports now include correct master and parent fingerprint data so exported keys are accepted by Ambire and strict BIP32 wallets.
  * Export workflow refined for Ethereum keys to ensure derived-key exports include the necessary fingerprint context for broader wallet interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->