### PR TITLE
fix: support ERC-4527 typed transaction QR scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Show friendly error when tapping a card with no master key instead of crashing with SW 0x6985
 - Fix `crypto-hdkey` ETH export: use master key (`m`) fingerprint as `origin.sourceFingerprint` and set `parentFingerprint` on the HDKey (fixes Ambire and strict BIP32 wallets)
+- Accept ERC-4527 EIP-2930 transactions encoded as `dataType=4` typed transaction QR requests
 
 ## [1.4.0] - 2026-05-02
 

--- a/__tests__/ethSignature.test.ts
+++ b/__tests__/ethSignature.test.ts
@@ -168,6 +168,12 @@ describe('buildEthSignatureUR', () => {
       expect(sig[sig.length - 1]).toBe(recId);
       expect(sig[sig.length - 1]).not.toBe(37 + recId);
     });
+
+    it('EIP-1559 (txType=0x02, dataType=4): v equals recId', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 4, 1, undefined, 0x02);
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig[sig.length - 1]).toBe(recId);
+    });
   });
 
   describe('CBOR map structure', () => {

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -175,6 +175,24 @@ describe('parseTx', () => {
     });
   });
 
+  describe('EIP-2930 encoded as ERC-4527 typed transaction (dataType=4, 0x01 prefix)', () => {
+    it('parses to address', () => {
+      const hex = buildEIP2930TxHex();
+      const tx = parseTx(hex, 4);
+      expect(tx?.to).toBe('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef');
+    });
+
+    it('parses fees as legacy kind (gasPrice)', () => {
+      const hex = buildEIP2930TxHex();
+      const tx = parseTx(hex, 4);
+      expect(tx?.fees.kind).toBe('legacy');
+      if (tx?.fees.kind === 'legacy') {
+        expect(tx.fees.gasPrice).toMatch(/Gwei/);
+        expect(tx.fees.gasLimit).toBe('30000');
+      }
+    });
+  });
+
   describe('EIP-1559 (dataType=4, 0x02 prefix)', () => {
     it('parses a valid type-2 transaction with an empty access list', () => {
       const tx = parseTx(buildEIP1559TxHex(), 4);
@@ -233,6 +251,9 @@ describe('parseTx', () => {
 
   it('validates transaction sign data only for transaction data types', () => {
     expect(() => validateEthTransactionSignData('deadbeef', 2)).not.toThrow();
+    expect(() =>
+      validateEthTransactionSignData(buildEIP2930TxHex(), 4),
+    ).not.toThrow();
     expect(() => validateEthTransactionSignData('deadbeef', 1)).toThrow(
       'Invalid Ethereum transaction payload',
     );
@@ -256,6 +277,12 @@ describe('parseTx', () => {
       const tx = parseTx(hex, 1, 'AVAX');
       expect(tx?.value).toBe('1 AVAX');
     });
+
+    it('uses custom symbol in value for dataType=4 EIP-2930 tx', () => {
+      const hex = buildEIP2930TxHex({ value: 1_000_000_000_000_000_000n });
+      const tx = parseTx(hex, 4, 'AVAX');
+      expect(tx?.value).toBe('1 AVAX');
+    });
   });
 });
 
@@ -268,12 +295,20 @@ describe('getTxLabel', () => {
     expect(getTxLabel(buildEIP2930TxHex(), 1)).toBe('EIP-2930 Transaction');
   });
 
+  it('returns "EIP-2930 Transaction" for 0x01-prefixed dataType=4', () => {
+    expect(getTxLabel(buildEIP2930TxHex(), 4)).toBe('EIP-2930 Transaction');
+  });
+
   it('returns "Legacy Transaction" for plain dataType=1', () => {
     expect(getTxLabel(buildLegacyTxHex(), 1)).toBe('Legacy Transaction');
   });
 
   it('returns "EIP-1559 Transaction" for dataType=4', () => {
     expect(getTxLabel('02' + 'deadbeef', 4)).toBe('EIP-1559 Transaction');
+  });
+
+  it('returns the typed transaction fallback for unknown type bytes', () => {
+    expect(getTxLabel('03' + 'deadbeef', 4)).toBe('Typed Transaction');
   });
 
   it('returns "EIP-712 Typed Data" for dataType=2', () => {

--- a/__tests__/ur.test.ts
+++ b/__tests__/ur.test.ts
@@ -169,6 +169,27 @@ describe('handleUR', () => {
       expect(result.message).toMatch(/Failed to parse sign request/);
     }
   });
+
+  it('parses an EIP-2930 eth-sign-request encoded as ERC-4527 typed transaction', () => {
+    const eip2930Tx =
+      '01eb010285037e11d60082753094d3cda913deb6f4967b2ef3aa68f5a843da74c4ef8806f05b59d3b2000080c0';
+    const cbor = buildCbor(eip2930Tx, 4, "m/44'/60'/0'/0/0", {
+      uuid: 'b3281a82-950d-4076-934b-1aa8b4f87492',
+      chainId: 1,
+      address: '0xa786ec7488a340964fc4a0367144436beb7904ce',
+      origin: 'ERC-4527 Wallet',
+    });
+
+    const result = handleUR('eth-sign-request', cbor);
+
+    expect(result.kind).toBe('eth-sign-request');
+    if (result.kind === 'eth-sign-request') {
+      expect(result.request.signData).toBe(eip2930Tx);
+      expect(result.request.dataType).toBe(4);
+      expect(result.request.chainId).toBe(1);
+      expect(result.request.origin).toBe('ERC-4527 Wallet');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -290,6 +311,6 @@ describe('DATA_TYPE_LABELS', () => {
     expect(DATA_TYPE_LABELS[1]).toBe('Legacy Transaction');
     expect(DATA_TYPE_LABELS[2]).toBe('EIP-712 Typed Data');
     expect(DATA_TYPE_LABELS[3]).toBe('Personal Message');
-    expect(DATA_TYPE_LABELS[4]).toBe('EIP-1559 Transaction');
+    expect(DATA_TYPE_LABELS[4]).toBe('Typed Transaction');
   });
 });

--- a/android/app/src/main/java/tech/gapsign/CameraView.kt
+++ b/android/app/src/main/java/tech/gapsign/CameraView.kt
@@ -100,9 +100,7 @@ class CameraView
 
         private fun analyzeImage(imageProxy: ImageProxy) {
             try {
-                val buffer = imageProxy.planes[0].buffer
-                val data = ByteArray(buffer.remaining())
-                buffer.get(data)
+                val data = extractLuminanceData(imageProxy)
 
                 val source =
                     PlanarYUVLuminanceSource(
@@ -124,6 +122,27 @@ class CameraView
                 reader.reset()
                 imageProxy.close()
             }
+        }
+
+        private fun extractLuminanceData(imageProxy: ImageProxy): ByteArray {
+            val plane = imageProxy.planes[0]
+            val buffer = plane.buffer
+            val width = imageProxy.width
+            val height = imageProxy.height
+            val rowStride = plane.rowStride
+            val pixelStride = plane.pixelStride
+
+            if (rowStride == width && pixelStride == 1) {
+                return ByteArray(buffer.remaining()).also { buffer.get(it) }
+            }
+
+            val data = ByteArray(width * height)
+            for (row in 0 until height) {
+                for (col in 0 until width) {
+                    data[row * width + col] = buffer.get(row * rowStride + col * pixelStride)
+                }
+            }
+            return data
         }
 
         private fun dispatchCodeEvent(value: String) {

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -38,7 +38,8 @@ function buildEthResultUR(
   const firstByte = params.signData
     ? parseInt(params.signData.slice(0, 2), 16)
     : undefined;
-  const txType = firstByte === 0x01 ? 0x01 : undefined;
+  const txType =
+    firstByte === 0x01 || firstByte === 0x02 ? firstByte : undefined;
   return buildEthSignatureUR(
     Array.from(result)
       .map(b => b.toString(16).padStart(2, '0'))

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,5 +33,5 @@ export const DATA_TYPE_LABELS: Record<number, string> = {
   1: 'Legacy Transaction',
   2: 'EIP-712 Typed Data',
   3: 'Personal Message',
-  4: 'EIP-1559 Transaction',
+  4: 'Typed Transaction',
 };

--- a/src/utils/ethSignature.ts
+++ b/src/utils/ethSignature.ts
@@ -45,10 +45,10 @@ function encodeV(v: number): Uint8Array {
  *
  * @param signRespDataHex - hex string of `signResp.data` (TLV from Keycard)
  * @param hash            - the 32-byte hash that was signed (for recId recovery)
- * @param dataType        - eth-sign-request dataType (1=legacy, 2=typed, 3=personal, 4=EIP-1559)
+ * @param dataType        - eth-sign-request dataType (1=legacy, 2=typed, 3=personal, 4=typed transaction)
  * @param chainId         - chain ID (used for legacy tx v calculation)
  * @param requestId       - optional UUID hex from the original eth-sign-request
- * @param txType          - optional EIP-2718 transaction type byte (e.g. 0x01 for EIP-2930)
+ * @param txType          - optional EIP-2718 transaction type byte (0x01 EIP-2930, 0x02 EIP-1559)
  */
 export function buildEthSignatureUR(
   signRespDataHex: string,
@@ -68,15 +68,15 @@ export function buildEthSignatureUR(
   const s = pad32(sig.s!);
 
   let v: number;
-  if (txType === 0x01) {
-    // EIP-2930: v = recId (same as EIP-1559, no chain ID encoding)
+  if (txType === 0x01 || txType === 0x02) {
+    // Typed transactions use yParity directly: v = recId.
     v = recId;
   } else {
     switch (dataType) {
       case 1: // legacy transaction (EIP-155)
         v = V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
         break;
-      case 4: // EIP-1559
+      case 4: // typed transaction without an explicit txType
         v = recId;
         break;
       default: // EIP-712 (2), personal_sign (3), unknown

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -501,7 +501,7 @@ function parseEIP2930(bytes: Buffer, symbol: string): ParsedTx {
 
 /**
  * dataType 1 = Legacy transaction (or EIP-2930 if first byte is 0x01)
- * dataType 4 = EIP-1559 transaction
+ * dataType 4 = EIP-2718 typed transaction (0x01 EIP-2930 or 0x02 EIP-1559)
  * Others (EIP-712, personal sign) are not transactions — return null.
  */
 export function parseTx(
@@ -514,7 +514,10 @@ export function parseTx(
     if (dataType === 1 && bytes[0] === 0x01)
       return parseEIP2930(bytes, nativeCurrencySymbol);
     if (dataType === 1) return parseLegacy(bytes, nativeCurrencySymbol);
-    if (dataType === 4) return parseEIP1559(bytes, nativeCurrencySymbol);
+    if (dataType === 4 && bytes[0] === 0x01)
+      return parseEIP2930(bytes, nativeCurrencySymbol);
+    if (dataType === 4 && bytes[0] === 0x02)
+      return parseEIP1559(bytes, nativeCurrencySymbol);
     return null;
   } catch {
     return null;
@@ -537,12 +540,15 @@ export function validateEthTransactionSignData(
 
 /**
  * Returns a human-readable label for the transaction type.
- * Distinguishes EIP-2930 from legacy even though both arrive with dataType=1.
+ * Distinguishes typed transaction envelopes by the first byte.
  */
 export function getTxLabel(signDataHex: string, dataType: number): string {
-  if (dataType === 1) {
+  if (dataType === 1 || dataType === 4) {
     const bytes = Buffer.from(signDataHex, 'hex');
     if (bytes[0] === 0x01) return 'EIP-2930 Transaction';
+    if (bytes[0] === 0x02) return 'EIP-1559 Transaction';
+  }
+  if (dataType === 1) {
     return 'Legacy Transaction';
   }
   return DATA_TYPE_LABELS[dataType] ?? `Unknown (${dataType})`;


### PR DESCRIPTION
## Summary

- accept ERC-4527 `dataType=4` typed transaction requests for both EIP-2930 (`0x01`) and EIP-1559 (`0x02`)
- return the correct transaction labels and signature `v` value for typed Ethereum transactions
- normalize Android CameraX luminance buffers before ZXing scans QR frames, improving recognition of dense UR QRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ERC-4527 EIP-2930 transactions encoded as typed transaction QR requests.

* **Bug Fixes**
  * Improved Ethereum transaction parsing to correctly distinguish and handle different transaction envelope types.

* **Tests**
  * Extended test coverage for EIP-2930 and EIP-1559 transaction validation and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->