### PR TITLE
feat: add opt-in ENS reverse resolution (online build only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Add opt-in ENS reverse resolution: toggle + custom RPC URL in Settings, ENS name display on address rows, "no ens" indicator for unregistered addresses
+
 ## [1.5.0] - 2026-05-06
 
 ### Added

--- a/__tests__/AddressDetailScreen.test.tsx
+++ b/__tests__/AddressDetailScreen.test.tsx
@@ -17,6 +17,12 @@ jest.mock('react-native-paper', () => {
 
 jest.mock('react-native-qrcode-svg', () => 'QRCode');
 
+const mockEnsAddressLabel = jest.fn();
+jest.mock('../src/components/ens/EnsAddressLabel.online', () => ({
+  __esModule: true,
+  default: (props: { address: string }) => mockEnsAddressLabel(props),
+}));
+
 const mockSetString = jest.fn();
 jest.mock('@react-native-clipboard/clipboard', () => ({
   __esModule: true,
@@ -34,6 +40,25 @@ const MockPrimaryButton = PrimaryButton as jest.MockedFunction<
 jest.mock('../src/assets/icons', () => ({
   Icons: { copy: 'CopyIcon', qr: 'QrIcon' },
 }));
+
+// Default: EnsAddressLabel renders just the raw address (no ENS name)
+function setupEnsDefault() {
+  const { Text } = require('react-native');
+  mockEnsAddressLabel.mockImplementation(({ address }: { address: string }) => (
+    <Text>{address}</Text>
+  ));
+}
+
+// ENS resolved: render name above raw address
+function setupEnsResolved(name: string) {
+  const { Text, View } = require('react-native');
+  mockEnsAddressLabel.mockImplementation(({ address }: { address: string }) => (
+    <View>
+      <Text>{name}</Text>
+      <Text>{address}</Text>
+    </View>
+  ));
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -69,7 +94,9 @@ describe('AddressDetailScreen', () => {
   beforeEach(() => {
     mockSetString.mockClear();
     MockPrimaryButton.mockClear();
+    mockEnsAddressLabel.mockClear();
     navigation.setOptions.mockClear();
+    setupEnsDefault();
   });
 
   describe('layout', () => {
@@ -124,6 +151,30 @@ describe('AddressDetailScreen', () => {
 
   describe('copy', () => {
     it('copies the address to clipboard when the button is pressed', () => {
+      renderScreen();
+      const onPress = MockPrimaryButton.mock.calls[0][0].onPress;
+      onPress();
+      expect(mockSetString).toHaveBeenCalledWith(ETH_ADDRESS);
+    });
+  });
+
+  describe('ENS', () => {
+    it('shows ENS name and raw address when name resolves', () => {
+      setupEnsResolved('vitalik.eth');
+      renderScreen();
+      expect(screen.getByText('vitalik.eth')).toBeTruthy();
+      expect(screen.getByText(ETH_ADDRESS)).toBeTruthy();
+    });
+
+    it('passes raw address to QRCode even when ENS name is shown', () => {
+      setupEnsResolved('vitalik.eth');
+      const { toJSON } = renderScreen();
+      const json = JSON.stringify(toJSON());
+      expect(json).toContain(ETH_ADDRESS);
+    });
+
+    it('copy button still copies raw address when ENS name is shown', () => {
+      setupEnsResolved('vitalik.eth');
       renderScreen();
       const onPress = MockPrimaryButton.mock.calls[0][0].onPress;
       onPress();

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
 // Full App render test requires mocking an entire stack of native modules
-// (react-native-get-random-values, react-native-camera-kit, @ngraveio/bc-ur,
+// (react-native-get-random-values, CameraView, @ngraveio/bc-ur,
 // react-native-paper, react-native-screens, @react-navigation/*, etc.).
 // Business logic is covered in ur.test.ts and TransactionDetailScreen.test.tsx.
 it.todo('renders correctly');

--- a/__tests__/DecodedCallSection.test.tsx
+++ b/__tests__/DecodedCallSection.test.tsx
@@ -25,6 +25,13 @@ jest.mock('../src/components/InfoRow', () => {
   );
 });
 
+jest.mock('../src/components/ens/AddressInfoRow.online', () => {
+  const { Text } = require('react-native');
+  return ({ label, value }: { label: string; value: string }) => (
+    <Text>{`${label}: ${value}`}</Text>
+  );
+});
+
 jest.mock('../src/utils/buildConfig', () => ({
   INTERNET_ENABLED: false,
 }));

--- a/__tests__/EnsAddressLabel.test.tsx
+++ b/__tests__/EnsAddressLabel.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import EnsAddressLabel from '../src/components/ens/EnsAddressLabel.online';
+import EnsAddressLabelOffline from '../src/components/ens/EnsAddressLabel.offline';
+
+const mockUseEnsName = jest.fn();
+
+jest.mock('../src/hooks/ens/useEnsName.online', () => ({
+  useEnsName: () => mockUseEnsName(),
+}));
+
+const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+beforeEach(() => {
+  mockUseEnsName.mockReset();
+});
+
+describe('EnsAddressLabel.online', () => {
+  it('confirmed name renders above raw address', () => {
+    mockUseEnsName.mockReturnValue({
+      name: 'vitalik.eth',
+      loading: false,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText('vitalik.eth')).toBeTruthy();
+    expect(screen.getByText(address)).toBeTruthy();
+  });
+
+  it('cache hit renders name synchronously with no loading state', () => {
+    mockUseEnsName.mockReturnValue({
+      name: 'vitalik.eth',
+      loading: false,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText('vitalik.eth')).toBeTruthy();
+    expect(screen.getByText(address)).toBeTruthy();
+  });
+
+  it('cache miss renders raw address until name resolves', () => {
+    mockUseEnsName.mockReturnValue({
+      name: null,
+      loading: true,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+    expect(screen.queryByText('vitalik.eth')).toBeNull();
+  });
+
+  it('not-found renders raw address only, no error indicator, no Refresh', () => {
+    mockUseEnsName.mockReturnValue({
+      name: null,
+      loading: false,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+    expect(screen.queryByText('ENS unavailable')).toBeNull();
+    expect(screen.queryByText('Refresh')).toBeNull();
+  });
+
+  it('mismatch renders raw address only, no error indicator, no Refresh', () => {
+    mockUseEnsName.mockReturnValue({
+      name: null,
+      loading: false,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+    expect(screen.queryByText('ENS unavailable')).toBeNull();
+    expect(screen.queryByText('Refresh')).toBeNull();
+  });
+
+  it('no-ens renders raw address + "no ens" label, no error indicator', () => {
+    mockUseEnsName.mockReturnValue({
+      name: '',
+      loading: false,
+      error: false,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+    expect(screen.getByText('no ens')).toBeTruthy();
+    expect(screen.queryByText(/ENS unavailable/)).toBeNull();
+    expect(screen.queryByText('Refresh')).toBeNull();
+  });
+
+  it('rpc-error renders raw address + error indicator + Refresh button', () => {
+    mockUseEnsName.mockReturnValue({
+      name: null,
+      loading: false,
+      error: true,
+      retry: jest.fn(),
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+    expect(screen.getByText(/ENS unavailable/)).toBeTruthy();
+    expect(screen.getByText('Refresh')).toBeTruthy();
+  });
+
+  it('tapping Refresh calls retry', () => {
+    const retry = jest.fn();
+    mockUseEnsName.mockReturnValue({
+      name: null,
+      loading: false,
+      error: true,
+      retry,
+    });
+
+    render(<EnsAddressLabel address={address} />);
+
+    fireEvent.press(screen.getByText('Refresh'));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('EnsAddressLabel.offline', () => {
+  it('renders only raw address', () => {
+    render(<EnsAddressLabelOffline address={address} />);
+
+    expect(screen.getByText(address)).toBeTruthy();
+  });
+});

--- a/__tests__/EnsSettingsSection.test.tsx
+++ b/__tests__/EnsSettingsSection.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+
+import EnsSettingsSection from '../src/components/settings/EnsSettingsSection.online';
+import EnsSettingsSectionOffline from '../src/components/settings/EnsSettingsSection.offline';
+
+const mockLoadEnsSettings = jest.fn();
+const mockSaveEnsEnabled = jest.fn();
+const mockSaveEnsRpcUrl = jest.fn();
+const mockValidateRpcUrl = jest.fn();
+
+jest.mock('../src/storage/ensSettings.online', () => ({
+  DEFAULT_ENS_RPC_URL: 'https://ethereum-rpc.publicnode.com',
+  loadEnsSettings: (...args: any[]) => mockLoadEnsSettings(...args),
+  saveEnsEnabled: (...args: any[]) => mockSaveEnsEnabled(...args),
+  saveEnsRpcUrl: (...args: any[]) => mockSaveEnsRpcUrl(...args),
+}));
+
+jest.mock('../src/utils/ens/client.online', () => ({
+  validateRpcUrl: (...args: any[]) => mockValidateRpcUrl(...args),
+}));
+
+function settingsWithUrl(rpcUrl: string, enabled = true) {
+  return { enabled, rpcUrl };
+}
+
+describe('EnsSettingsSection.online', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveEnsEnabled.mockResolvedValue(undefined);
+    mockSaveEnsRpcUrl.mockResolvedValue(undefined);
+  });
+
+  it('shows toggle off when ENS disabled on mount', async () => {
+    mockLoadEnsSettings.mockResolvedValue({ enabled: false, rpcUrl: '' });
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeTruthy();
+    });
+    expect(screen.getByRole('switch').props.value).toBe(false);
+    expect(
+      screen.queryByPlaceholderText('https://ethereum-rpc.publicnode.com'),
+    ).toBeNull();
+  });
+
+  it('shows toggle on and RPC input when ENS enabled on mount', async () => {
+    mockLoadEnsSettings.mockResolvedValue(
+      settingsWithUrl('https://custom.rpc'),
+    );
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('https://custom.rpc')).toBeTruthy();
+    });
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+
+  it('enabling with no saved URL auto-fills default, saves both', async () => {
+    mockLoadEnsSettings.mockResolvedValue({ enabled: false, rpcUrl: '' });
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+
+    fireEvent(screen.getByRole('switch'), 'valueChange', true);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue('https://ethereum-rpc.publicnode.com'),
+      ).toBeTruthy();
+    });
+    expect(mockSaveEnsEnabled).toHaveBeenCalledWith(true);
+    expect(mockSaveEnsRpcUrl).toHaveBeenCalledWith(
+      'https://ethereum-rpc.publicnode.com',
+    );
+  });
+
+  it('enabling with existing URL saves only enabled flag', async () => {
+    mockLoadEnsSettings.mockResolvedValue({
+      enabled: false,
+      rpcUrl: 'https://saved.rpc',
+    });
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+
+    fireEvent(screen.getByRole('switch'), 'valueChange', true);
+
+    await waitFor(() => {
+      expect(mockSaveEnsEnabled).toHaveBeenCalledWith(true);
+    });
+    expect(mockSaveEnsRpcUrl).not.toHaveBeenCalled();
+  });
+
+  it('disabling saves enabled flag, keeps URL in input', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    fireEvent(screen.getByRole('switch'), 'valueChange', false);
+
+    await waitFor(() => {
+      expect(mockSaveEnsEnabled).toHaveBeenCalledWith(false);
+    });
+    expect(mockSaveEnsRpcUrl).not.toHaveBeenCalled();
+    expect(screen.queryByDisplayValue('https://saved.rpc')).toBeNull();
+  });
+
+  it('loadEnsSettings failure still renders toggle', async () => {
+    mockLoadEnsSettings.mockRejectedValue(new Error('storage error'));
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeTruthy();
+    });
+    expect(screen.getByRole('switch').props.value).toBe(false);
+  });
+
+  it('privacy disclosure always visible regardless of enabled state', async () => {
+    mockLoadEnsSettings.mockResolvedValue({ enabled: false, rpcUrl: '' });
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/ENS lookups send reviewed Ethereum addresses/),
+      ).toBeTruthy();
+    });
+  });
+
+  it('Revert button appears when input is dirty, restores saved value', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    expect(screen.queryByText('Revert')).toBeNull();
+
+    fireEvent.changeText(
+      screen.getByDisplayValue('https://saved.rpc'),
+      'https://new.rpc',
+    );
+    expect(screen.getByText('Revert')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Revert'));
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+    expect(screen.queryByText('Revert')).toBeNull();
+    expect(mockSaveEnsRpcUrl).not.toHaveBeenCalled();
+  });
+
+  it('valid mainnet RPC saves and clears dirty state', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+    mockValidateRpcUrl.mockResolvedValue('ok');
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    fireEvent.changeText(
+      screen.getByDisplayValue('https://saved.rpc'),
+      'https://valid.rpc',
+    );
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(mockSaveEnsRpcUrl).toHaveBeenCalledWith('https://valid.rpc'),
+    );
+    expect(screen.queryByText('Revert')).toBeNull();
+  });
+
+  it('non-mainnet response shows error, does not save', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+    mockValidateRpcUrl.mockResolvedValue('non-mainnet');
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    fireEvent.changeText(
+      screen.getByDisplayValue('https://saved.rpc'),
+      'https://polygon.rpc',
+    );
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Not an Ethereum mainnet endpoint.'),
+      ).toBeTruthy();
+    });
+    expect(mockSaveEnsRpcUrl).not.toHaveBeenCalled();
+  });
+
+  it('unreachable/timeout shows error, does not save', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+    mockValidateRpcUrl.mockResolvedValue('unreachable');
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    fireEvent.changeText(
+      screen.getByDisplayValue('https://saved.rpc'),
+      'https://bad.rpc',
+    );
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Could not reach RPC endpoint — URL not saved.'),
+      ).toBeTruthy();
+    });
+    expect(mockSaveEnsRpcUrl).not.toHaveBeenCalled();
+  });
+
+  it('saving empty string calls saveEnsRpcUrl("")', async () => {
+    mockLoadEnsSettings.mockResolvedValue(settingsWithUrl('https://saved.rpc'));
+
+    render(<EnsSettingsSection />);
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('https://saved.rpc')).toBeTruthy(),
+    );
+
+    fireEvent.changeText(screen.getByDisplayValue('https://saved.rpc'), '');
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() => expect(mockSaveEnsRpcUrl).toHaveBeenCalledWith(''));
+  });
+});
+
+describe('EnsSettingsSection.offline', () => {
+  it('renders nothing', () => {
+    const { UNSAFE_root } = render(<EnsSettingsSectionOffline />);
+    expect(UNSAFE_root?.children.length).toBe(0);
+  });
+});

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -14,6 +14,22 @@ jest.mock('react-native-paper', () => {
   };
 });
 
+const mockEnsNames: Record<string, string> = {};
+jest.mock('../src/components/ens/AddressInfoRow.online', () => ({
+  __esModule: true,
+  default: ({ label, value }: { label: string; value: string }) => {
+    const { Text, View } = require('react-native');
+    const ensName = mockEnsNames[value];
+    return (
+      <View>
+        <Text>{label}</Text>
+        {ensName && <Text>{ensName}</Text>}
+        <Text>{value}</Text>
+      </View>
+    );
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -249,6 +265,48 @@ describe('EthSignRequestDetail — EIP-55 address display', () => {
     expect(
       screen.getByText('0xabCDEF1234567890ABcDEF1234567890aBCDeF12'),
     ).toBeTruthy();
+    expect(
+      screen.getByText('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef'),
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ENS address rows
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — ENS address display', () => {
+  beforeEach(() => {
+    Object.keys(mockEnsNames).forEach(k => delete mockEnsNames[k]);
+  });
+
+  it('shows ENS name and raw address for resolved recipient', () => {
+    mockEnsNames['0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef'] =
+      'recipient.eth';
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+      address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+    });
+
+    expect(screen.getByText('recipient.eth')).toBeTruthy();
+    expect(
+      screen.getByText('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef'),
+    ).toBeTruthy();
+  });
+
+  it('shows raw address only when ENS not resolved', () => {
+    renderDetail({
+      signData: legacyTxHex(),
+      dataType: 1,
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+      address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+    });
+
+    expect(screen.queryByText('recipient.eth')).toBeNull();
     expect(
       screen.getByText('0xD3CDa913deb6F4967B2eF3Aa68F5a843da74c4Ef'),
     ).toBeTruthy();

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -4,6 +4,20 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import TransactionDetailScreen from '../src/screens/TransactionDetailScreen';
 import type { EthSignRequest } from '../src/types';
 
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: { getItem: jest.fn(), setItem: jest.fn() },
+}));
+
+jest.mock('../src/hooks/ens/useEnsName.online', () => ({
+  useEnsName: () => ({
+    name: null,
+    loading: false,
+    error: false,
+    retry: jest.fn(),
+  }),
+}));
+
 // PSBT with one input and one output so inspectBtcPsbt can parse it fully
 const VALID_PSBT_HEX = (() => {
   const { Psbt, payments, networks } = require('bitcoinjs-lib');

--- a/__tests__/checkOfflineBundle.test.js
+++ b/__tests__/checkOfflineBundle.test.js
@@ -1,0 +1,90 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT = path.resolve(__dirname, '../scripts/check-offline-bundle.js');
+
+function writeFixture(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offline-bundle-'));
+  const filePath = path.join(dir, 'index.android.bundle');
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+function run(...args) {
+  return spawnSync('node', [SCRIPT, ...args], { encoding: 'utf8' });
+}
+
+describe('check-offline-bundle', () => {
+  it('passes on a fixture without forbidden markers', () => {
+    const filePath = writeFixture('var x=1;console.log("hello");');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('passed');
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a fixture containing the default RPC URL', () => {
+    const filePath = writeFixture('var url="ethereum-rpc.publicnode.com";');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a fixture containing EnsSettingsSection', () => {
+    const filePath = writeFixture('navigate("EnsSettingsSection");');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a fixture containing loadEnsRpcUrl', () => {
+    const filePath = writeFixture('loadEnsRpcUrl().then(console.log);');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a fixture containing ENS privacy disclosure', () => {
+    const filePath = writeFixture('"ENS lookups send reviewed Ethereum addresses"');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails on a fixture containing ENS RPC URL label', () => {
+    const filePath = writeFixture('"ENS RPC URL"');
+    try {
+      const result = run('--bundle', filePath);
+      expect(result.status).not.toBe(0);
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it('fails when --bundle argument is missing', () => {
+    const result = run();
+    expect(result.status).not.toBe(0);
+  });
+
+  it('fails when bundle file does not exist', () => {
+    const result = run('--bundle', '/tmp/nonexistent-bundle-12345');
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/__tests__/ensClient.test.ts
+++ b/__tests__/ensClient.test.ts
@@ -1,0 +1,137 @@
+import { createPublicClient, getAddress, http } from 'viem';
+
+import { resolveEnsName as resolveOffline } from '../src/utils/ens/client.offline';
+import { resolveEnsName, validateRpcUrl } from '../src/utils/ens/client.online';
+
+const mockGetEnsName = jest.fn();
+const mockGetEnsAddress = jest.fn();
+const mockGetChainId = jest.fn();
+const mockClient = {
+  getEnsName: mockGetEnsName,
+  getEnsAddress: mockGetEnsAddress,
+  getChainId: mockGetChainId,
+};
+
+jest.mock('viem', () => ({
+  getAddress: jest.fn((addr: string) => addr),
+  createPublicClient: jest.fn(() => mockClient),
+  http: jest.fn(),
+}));
+
+jest.mock('viem/chains', () => ({
+  mainnet: { id: 1, name: 'Mainnet' },
+}));
+
+const mockedGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
+const mockedCreatePublicClient = createPublicClient as jest.MockedFunction<
+  typeof createPublicClient
+>;
+const mockedHttp = http as jest.MockedFunction<typeof http>;
+
+describe('client.online', () => {
+  const address = '0x1234567890abcdef1234567890abcdef12345678';
+  const rpcUrl = 'https://rpc.example.com';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreatePublicClient.mockReturnValue(mockClient as any);
+  });
+
+  describe('resolveEnsName', () => {
+    it('checksums lowercase address before lookup', async () => {
+      const lowerAddress = address.toLowerCase();
+      mockedGetAddress.mockReturnValue(address);
+      mockGetEnsName.mockResolvedValue(null);
+
+      await resolveEnsName(lowerAddress, rpcUrl);
+
+      expect(mockedGetAddress).toHaveBeenCalledWith(lowerAddress);
+      expect(mockGetEnsName).toHaveBeenCalledWith({ address });
+    });
+
+    it('returns confirmed name on reverse + forward match', async () => {
+      mockedGetAddress.mockImplementation((addr: string) => addr);
+      mockGetEnsName.mockResolvedValue('vitalik.eth');
+      mockGetEnsAddress.mockResolvedValue(address);
+
+      const result = await resolveEnsName(address, rpcUrl);
+
+      expect(result).toEqual({ name: 'vitalik.eth' });
+    });
+
+    it('returns mismatch when forward resolves to different address', async () => {
+      mockedGetAddress.mockImplementation((addr: string) => addr);
+      mockGetEnsName.mockResolvedValue('vitalik.eth');
+      mockGetEnsAddress.mockResolvedValue(
+        '0xabcdef1234567890abcdef1234567890abcdef12',
+      );
+
+      const result = await resolveEnsName(address, rpcUrl);
+
+      expect(result).toEqual({ name: null, reason: 'mismatch' });
+    });
+
+    it('returns not-found when no reverse record', async () => {
+      mockedGetAddress.mockImplementation((addr: string) => addr);
+      mockGetEnsName.mockResolvedValue(null);
+
+      const result = await resolveEnsName(address, rpcUrl);
+
+      expect(result).toEqual({ name: null, reason: 'not-found' });
+    });
+
+    it('returns rpc-error on network failure', async () => {
+      mockedGetAddress.mockImplementation((addr: string) => addr);
+      mockGetEnsName.mockRejectedValue(new Error('network error'));
+
+      const result = await resolveEnsName(address, rpcUrl);
+
+      expect(result).toEqual({ name: null, reason: 'rpc-error' });
+    });
+  });
+
+  describe('validateRpcUrl', () => {
+    it('returns ok for mainnet chainId 1', async () => {
+      mockGetChainId.mockResolvedValue(1);
+
+      const result = await validateRpcUrl(rpcUrl);
+
+      expect(result).toBe('ok');
+      expect(mockedHttp).toHaveBeenCalledWith(rpcUrl, { timeout: 5000 });
+    });
+
+    it('returns non-mainnet for other chainIds', async () => {
+      mockGetChainId.mockResolvedValue(137);
+
+      const result = await validateRpcUrl(rpcUrl);
+
+      expect(result).toBe('non-mainnet');
+    });
+
+    it('returns timeout on timeout error', async () => {
+      const timeoutError = new Error('timeout');
+      timeoutError.name = 'TimeoutError';
+      mockGetChainId.mockRejectedValue(timeoutError);
+
+      const result = await validateRpcUrl(rpcUrl);
+
+      expect(result).toBe('timeout');
+    });
+
+    it('returns unreachable on other failures', async () => {
+      mockGetChainId.mockRejectedValue(new Error('network error'));
+
+      const result = await validateRpcUrl(rpcUrl);
+
+      expect(result).toBe('unreachable');
+    });
+  });
+});
+
+describe('client.offline', () => {
+  it('resolveEnsName returns not-found', async () => {
+    const result = await resolveOffline('0x123', 'https://rpc');
+
+    expect(result).toEqual({ name: null, reason: 'not-found' });
+  });
+});

--- a/__tests__/ensSettings.test.ts
+++ b/__tests__/ensSettings.test.ts
@@ -1,0 +1,157 @@
+import {
+  DEFAULT_ENS_RPC_URL,
+  loadEnsRpcUrl,
+  loadEnsSettings,
+  saveEnsEnabled,
+  saveEnsRpcUrl,
+} from '../src/storage/ensSettings.online';
+
+import {
+  DEFAULT_ENS_RPC_URL as DEFAULT_OFFLINE,
+  loadEnsRpcUrl as loadOffline,
+  loadEnsSettings as loadSettingsOffline,
+  saveEnsEnabled as saveEnabledOffline,
+  saveEnsRpcUrl as saveOffline,
+} from '../src/storage/ensSettings.offline';
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: any[]) => mockGetItem(...args),
+    setItem: (...args: any[]) => mockSetItem(...args),
+  },
+}));
+
+describe('ensSettings.online', () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
+  });
+
+  it('DEFAULT_ENS_RPC_URL is PublicNode', () => {
+    expect(DEFAULT_ENS_RPC_URL).toBe('https://ethereum-rpc.publicnode.com');
+  });
+
+  describe('loadEnsSettings', () => {
+    it('returns enabled=false and empty rpcUrl when nothing stored', async () => {
+      mockGetItem.mockResolvedValue(null);
+      expect(await loadEnsSettings()).toEqual({ enabled: false, rpcUrl: '' });
+    });
+
+    it('returns enabled=true and stored URL', async () => {
+      mockGetItem
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce('https://custom.rpc');
+      expect(await loadEnsSettings()).toEqual({
+        enabled: true,
+        rpcUrl: 'https://custom.rpc',
+      });
+    });
+
+    it('returns enabled=false when flag is not "true"', async () => {
+      mockGetItem
+        .mockResolvedValueOnce('false')
+        .mockResolvedValueOnce('https://custom.rpc');
+      expect(await loadEnsSettings()).toEqual({
+        enabled: false,
+        rpcUrl: 'https://custom.rpc',
+      });
+    });
+
+    it('returns defaults when storage throws', async () => {
+      mockGetItem.mockRejectedValue(new Error('storage failure'));
+      expect(await loadEnsSettings()).toEqual({ enabled: false, rpcUrl: '' });
+    });
+  });
+
+  describe('loadEnsRpcUrl', () => {
+    it('returns null when disabled', async () => {
+      mockGetItem
+        .mockResolvedValueOnce('false')
+        .mockResolvedValueOnce('https://custom.rpc');
+      expect(await loadEnsRpcUrl()).toBeNull();
+    });
+
+    it('returns null when enabled but no URL stored', async () => {
+      mockGetItem.mockResolvedValueOnce('true').mockResolvedValueOnce(null);
+      expect(await loadEnsRpcUrl()).toBeNull();
+    });
+
+    it('returns URL when enabled and URL stored', async () => {
+      mockGetItem
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce('https://custom.rpc');
+      expect(await loadEnsRpcUrl()).toBe('https://custom.rpc');
+    });
+
+    it('returns null when storage throws', async () => {
+      mockGetItem.mockRejectedValue(new Error('storage failure'));
+      expect(await loadEnsRpcUrl()).toBeNull();
+    });
+  });
+
+  describe('saveEnsEnabled', () => {
+    it('stores "true" when enabled', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveEnsEnabled(true);
+      expect(mockSetItem).toHaveBeenCalledWith('ens_enabled', 'true');
+    });
+
+    it('stores "false" when disabled', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveEnsEnabled(false);
+      expect(mockSetItem).toHaveBeenCalledWith('ens_enabled', 'false');
+    });
+  });
+
+  describe('saveEnsRpcUrl', () => {
+    it('stores the URL', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveEnsRpcUrl('https://custom.rpc');
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'ens_rpc_url',
+        'https://custom.rpc',
+      );
+    });
+
+    it('stores empty string', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveEnsRpcUrl('');
+      expect(mockSetItem).toHaveBeenCalledWith('ens_rpc_url', '');
+    });
+  });
+});
+
+describe('ensSettings.offline', () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
+  });
+
+  it('DEFAULT_ENS_RPC_URL is empty', () => {
+    expect(DEFAULT_OFFLINE).toBe('');
+  });
+
+  it('loadEnsSettings returns disabled with empty URL', async () => {
+    expect(await loadSettingsOffline()).toEqual({ enabled: false, rpcUrl: '' });
+    expect(mockGetItem).not.toHaveBeenCalled();
+  });
+
+  it('loadEnsRpcUrl returns null', async () => {
+    expect(await loadOffline()).toBeNull();
+    expect(mockGetItem).not.toHaveBeenCalled();
+  });
+
+  it('saveEnsEnabled is a no-op', async () => {
+    await saveEnabledOffline(true);
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('saveEnsRpcUrl is a no-op', async () => {
+    await saveOffline('https://any.rpc');
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/metro.resolveRequest.test.ts
+++ b/__tests__/metro.resolveRequest.test.ts
@@ -1,0 +1,131 @@
+import { resolve } from 'metro-resolver';
+
+const { createResolveRequest } = require('../metro.resolveRequest');
+
+jest.mock('metro-resolver', () => ({
+  resolve: jest.fn(),
+}));
+
+describe('metro.resolveRequest', () => {
+  const mockContext = {
+    originModulePath: '/project/src/App.tsx',
+    allowHaste: true,
+    disableHierarchicalLookup: false,
+    doesFileExist: () => true,
+    isAssetFile: () => false,
+    nodeModulesPaths: ['/project/node_modules'],
+    preferNativePlatform: true,
+    sourceExts: ['ts', 'tsx', 'js', 'jsx', 'json'],
+    unstable_conditionNames: ['require', 'import'],
+    unstable_conditionsByPlatform: {},
+    unstable_enablePackageExports: true,
+    getPackageMainPath: () => '/project/package.json',
+    redirectModulePath: (p: string) => p,
+    resolveRequest: undefined,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function assertNoResolveRequestRecursion() {
+    const calledContext = (resolve as jest.Mock).mock.calls[0][0];
+    expect(calledContext).not.toHaveProperty('resolveRequest');
+  }
+
+  describe('online build', () => {
+    const resolveRequest = createResolveRequest(true);
+
+    it('resolves .online imports normally', () => {
+      resolveRequest(mockContext as any, './foo.online', 'ios');
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        './foo.online',
+        'ios',
+      );
+    });
+
+    it('resolves non-.online imports unchanged', () => {
+      resolveRequest(mockContext as any, 'react-native', 'android');
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        'react-native',
+        'android',
+      );
+    });
+  });
+
+  describe('offline build', () => {
+    const resolveRequest = createResolveRequest(false);
+
+    it('rewrites .online imports to .offline', () => {
+      (resolve as jest.Mock).mockReturnValue('/project/src/foo.offline.ts');
+      const result = resolveRequest(
+        mockContext as any,
+        './foo.online',
+        'android',
+      );
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        './foo.offline',
+        'android',
+      );
+      expect(result).toBe('/project/src/foo.offline.ts');
+    });
+
+    it('rewrites .online.ts imports to .offline.ts', () => {
+      (resolve as jest.Mock).mockReturnValue('/project/src/foo.offline.ts');
+      resolveRequest(mockContext as any, './foo.online.ts', 'android');
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        './foo.offline.ts',
+        'android',
+      );
+    });
+
+    it('throws when .offline file does not exist', () => {
+      (resolve as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Module not found');
+      });
+
+      expect(() =>
+        resolveRequest(mockContext as any, './foo.online', 'android'),
+      ).toThrow('Module not found');
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        './foo.offline',
+        'android',
+      );
+    });
+
+    it('does not rewrite imports without .online suffix', () => {
+      resolveRequest(mockContext as any, 'react-native', 'android');
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        'react-native',
+        'android',
+      );
+    });
+
+    it('does not rewrite imports containing online as part of a larger word', () => {
+      resolveRequest(mockContext as any, './online-utils', 'android');
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.any(Object),
+        './online-utils',
+        'android',
+      );
+    });
+  });
+});

--- a/__tests__/useEnsName.test.ts
+++ b/__tests__/useEnsName.test.ts
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { getAddress } from 'viem';
+
+import {
+  clearEnsNameCache,
+  useEnsName,
+} from '../src/hooks/ens/useEnsName.online';
+import { useEnsName as useEnsNameOffline } from '../src/hooks/ens/useEnsName.offline';
+
+const mockLoadEnsRpcUrl = jest.fn();
+const mockResolveEnsName = jest.fn();
+
+jest.mock('../src/storage/ensSettings.online', () => ({
+  loadEnsRpcUrl: (...args: any[]) => mockLoadEnsRpcUrl(...args),
+}));
+
+jest.mock('../src/utils/ens/client.online', () => ({
+  resolveEnsName: (...args: any[]) => mockResolveEnsName(...args),
+}));
+
+jest.mock('viem', () => ({
+  getAddress: jest.fn((addr: string) => addr),
+}));
+
+const mockedGetAddress = getAddress as jest.MockedFunction<typeof getAddress>;
+
+describe('useEnsName.online', () => {
+  const address = '0x1234567890abcdef1234567890abcdef12345678';
+
+  beforeEach(() => {
+    clearEnsNameCache();
+    jest.clearAllMocks();
+    mockedGetAddress.mockImplementation((addr: string) => addr);
+  });
+
+  it('returns no name when URL is null; no resolver call', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useEnsName(address));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.name).toBeNull();
+    expect(result.current.error).toBe(false);
+    expect(mockResolveEnsName).not.toHaveBeenCalled();
+  });
+
+  it('confirmed name is cached and returned synchronously on second call', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue('https://rpc.example.com');
+    mockResolveEnsName.mockResolvedValue({ name: 'vitalik.eth' });
+
+    const { result, unmount } = renderHook(() => useEnsName(address));
+    await waitFor(() => expect(result.current.name).toBe('vitalik.eth'));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(false);
+
+    unmount();
+
+    const { result: result2 } = renderHook(() => useEnsName(address));
+    expect(result2.current.loading).toBe(false);
+    expect(result2.current.name).toBe('vitalik.eth');
+    expect(result2.current.error).toBe(false);
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it('not-found returns empty string name, error: false; retry is a no-op', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue('https://rpc.example.com');
+    mockResolveEnsName.mockResolvedValue({ name: null, reason: 'not-found' });
+
+    const { result } = renderHook(() => useEnsName(address));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBe(false);
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it('mismatch returns empty string name, error: false; retry is a no-op', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue('https://rpc.example.com');
+    mockResolveEnsName.mockResolvedValue({ name: null, reason: 'mismatch' });
+
+    const { result } = renderHook(() => useEnsName(address));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.name).toBe('');
+    expect(result.current.error).toBe(false);
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it('rpc-error returns error: true; calling retry triggers another resolver call', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue('https://rpc.example.com');
+    mockResolveEnsName
+      .mockResolvedValueOnce({ name: null, reason: 'rpc-error' })
+      .mockResolvedValueOnce({ name: 'vitalik.eth' });
+
+    const { result } = renderHook(() => useEnsName(address));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.name).toBeNull();
+    expect(result.current.error).toBe(true);
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.name).toBe('vitalik.eth'));
+    expect(result.current.error).toBe(false);
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(2);
+  });
+
+  it('retry is no-op when last failure is not rpc-error (success state)', async () => {
+    mockLoadEnsRpcUrl.mockResolvedValue('https://rpc.example.com');
+    mockResolveEnsName.mockResolvedValue({ name: 'vitalik.eth' });
+
+    const { result } = renderHook(() => useEnsName(address));
+    await waitFor(() => expect(result.current.name).toBe('vitalik.eth'));
+
+    act(() => {
+      result.current.retry();
+    });
+
+    expect(mockResolveEnsName).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useEnsName.online — invalid address', () => {
+  beforeEach(() => {
+    clearEnsNameCache();
+    mockResolveEnsName.mockReset();
+  });
+
+  it('returns no name, no loading, no error for invalid address', async () => {
+    mockedGetAddress.mockImplementationOnce(() => {
+      throw new Error('invalid address');
+    });
+
+    const { result } = renderHook(() => useEnsName('not-an-address'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.name).toBeNull();
+    expect(result.current.error).toBe(false);
+    expect(mockResolveEnsName).not.toHaveBeenCalled();
+  });
+});
+
+describe('useEnsName.offline', () => {
+  it('returns no name, no error, no loading', () => {
+    const { result } = renderHook(() => useEnsNameOffline('0x123'));
+
+    expect(result.current.name).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(false);
+    expect(result.current.retry).toBeInstanceOf(Function);
+  });
+});

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -160,6 +160,23 @@ android {
     }
 }
 
+afterEvaluate {
+    android.applicationVariants.all { variant ->
+        def isFull = variant.productFlavors.any { it.name == "full" }
+        def taskName = "createBundle${variant.name.capitalize()}JsAndAssets"
+        def bundleTask = tasks.findByName(taskName)
+        if (bundleTask != null) {
+            bundleTask.configure {
+                def originalArgs = nodeExecutableAndArgs.get().toList()
+                def envScript = file("${buildDir}/metro-env-${variant.name}.js")
+                envScript.parentFile.mkdirs()
+                envScript.text = "process.env.ONLINE_BUILD = '${isFull ? 'true' : 'false'}';\n"
+                nodeExecutableAndArgs.set(originalArgs + ["--require", envScript.absolutePath])
+            }
+        }
+    }
+}
+
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")

--- a/docs/adr/0001-camera-scanner.md
+++ b/docs/adr/0001-camera-scanner.md
@@ -1,0 +1,57 @@
+# 0001: Keep the QR scanner as a small native CameraX and ZXing module
+
+Date: 2026-05-06
+
+Status: Accepted
+
+## Context
+
+GapSign needs camera access only for QR scanning: inbound UR requests and SeedQR import. The scanner must fit the app's air-gapped posture, offline Android flavor, and small audit surface.
+
+The app previously used `react-native-camera-kit`, which brought ML Kit barcode scanning into the QR path. The main problem was the dependency chain: it added permissions such as `INTERNET` to the Android APK, which conflicts with the offline flavor's no-network packaging goal even if GapSign itself does not make network calls. Commit `76a1e13` replaced that stack with an internal React Native native view backed by Android CameraX and ZXing. That change removed `react-native-camera-kit` from `package.json`, declared CameraX explicitly in `android/app/build.gradle`, and added `com.google.zxing:core:3.5.3`. The changelog entry for v1.4.0 records the intended result: the offline flavor no longer declares `INTERNET` or storage permissions for scanning.
+
+VisionCamera is the main third-party alternative. As of VisionCamera 5.0.9, `react-native-vision-camera` has peer dependencies on `react`, `react-native`, `react-native-nitro-modules`, and `react-native-nitro-image`. Its Android manifest does not declare Android permissions directly; it declares optional camera and microphone hardware features. The Nitro peer packages' Android manifests are empty.
+
+Barcode scanning is split into a separate `react-native-vision-camera-barcode-scanner` 5.0.9 package with peer dependencies on `react`, `react-native`, `react-native-nitro-modules`, and `react-native-vision-camera`. Its own Android manifest declares only an optional camera hardware feature, but its Android Gradle dependency is `com.google.mlkit:barcode-scanning:17.3.0`. That ML Kit artifact depends on `com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1`, which depends on Google datatransport. The transitive `com.google.android.datatransport:transport-backend-cct:2.3.3` AAR declares `android.permission.INTERNET` and `android.permission.ACCESS_NETWORK_STATE`; `transport-runtime:2.2.6` declares `ACCESS_NETWORK_STATE`. Those permissions would be candidates for manifest merging if GapSign adopted VisionCamera's barcode scanner.
+
+Primary references:
+
+- VisionCamera releases: https://github.com/mrousavy/react-native-vision-camera/releases
+- VisionCamera getting started: https://visioncamera.margelo.com/docs
+- VisionCamera barcode scanner docs: https://visioncamera.margelo.com/docs/barcode-scanner
+- npm registry metadata checked with `npm view react-native-vision-camera react-native-vision-camera-barcode-scanner`
+- Published npm tarballs inspected with `npm pack react-native-vision-camera@5.0.9 react-native-vision-camera-barcode-scanner@5.0.9 react-native-nitro-modules react-native-nitro-image`
+- Google Maven AAR manifests inspected for `com.google.mlkit:barcode-scanning:17.3.0`, `com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1`, and their datatransport dependencies
+
+## Decision
+
+Keep GapSign's scanner as a small native CameraX + ZXing module instead of adopting VisionCamera for now.
+
+The React Native API remains `src/components/Camera/index.tsx`, exposing only the `Camera` component and `ReadCodeEvent`. The shared UI wrapper remains `src/components/CameraView.tsx`.
+
+## Rationale
+
+The current scanner is intentionally narrow: camera preview, QR-only frame analysis, and one event back to JavaScript. That matches GapSign's QR workflows without adding photo, video, frame processor, object detection, or barcode-format surface area.
+
+VisionCamera is well maintained and more feature-complete, but adopting it would add Nitro peer dependencies and, for scanning, a separate barcode scanner package. The scanner package still reaches ML Kit and Google datatransport dependencies that declare network-related permissions. That is a reasonable tradeoff for apps that need a general camera platform or ML Kit scanning, but GapSign currently needs only deterministic QR scanning in an offline wallet companion.
+
+ZXing keeps decoding local and inspectable. CameraX is already the Android camera layer we need. Avoiding the ML Kit camera/scanner dependency chain prevents unwanted Android permissions from being merged into the APK and keeps the offline flavor simpler to explain.
+
+## Consequences
+
+Positive:
+
+- Smaller JavaScript dependency graph for QR scanning.
+- Fewer native packages to track during React Native upgrades.
+- QR scanning remains local, narrow, and easy to audit.
+- Offline Android packaging stays easier to reason about.
+
+Negative:
+
+- We own the Android native camera bridge and its edge cases.
+- iOS still needs a matching native implementation.
+- VisionCamera's broader device handling and active maintenance are not available to us through a dependency.
+
+## Revisit
+
+Reconsider VisionCamera if GapSign needs cross-platform camera behavior beyond QR scanning, if maintaining the native scanner becomes costly, or if VisionCamera's Nitro dependency footprint becomes part of the app for another accepted reason.

--- a/docs/adr/0002-build-time-isolation-for-online-features.md
+++ b/docs/adr/0002-build-time-isolation-for-online-features.md
@@ -1,0 +1,48 @@
+# 0002: Build-time isolate online-only features
+
+Date: 2026-05-06
+
+Status: Accepted
+
+## Context
+
+GapSign has an offline Android flavor whose promise is stronger than "network code is not used": online-only features may exist in the repository, but they must be absent from the offline APK and its JavaScript bundle. This matters for network-backed features such as ENS resolution and WalletConnect because they introduce RPC clients, endpoint strings, settings screens, and sometimes optional packages that are inappropriate for the offline distribution.
+
+The existing `BuildConfig.INTERNET_ENABLED` flag is useful for small behavior differences in already-shared code. It is not sufficient for features whose code, dependencies, or endpoints should not be packaged into the offline artifact at all.
+
+Shared screens still need a stable way to render online enhancements in the online build while keeping the offline build raw-address-only or disconnected from online providers.
+
+## Decision
+
+Online-only features must be isolated at build time with explicit online/offline module boundaries. Shared code imports the online boundary module; offline builds resolve that import to an offline stub during Metro resolution.
+
+Online implementation files may live in the repository. The offline APK and JavaScript bundle must not include online feature modules, default RPC/project endpoint strings, settings routes for online-only features, or online-only dependencies.
+
+Runtime `INTERNET_ENABLED` checks remain acceptable for small choices inside code that is already shared by both builds, but they are not the boundary for network-backed features.
+
+## Rationale
+
+Build-time isolation keeps the offline flavor auditable. A reviewer should be able to inspect the offline artifact and see that ENS lookup code, WalletConnect clients, RPC endpoints, and related settings are not present.
+
+Runtime gating is easier to implement, but it still ships the online code and strings in the offline bundle. That weakens the offline flavor's packaging story and makes accidental reachability harder to reason about.
+
+The `.online` / `.offline` boundary pattern keeps shared screens from depending directly on online implementations. It also gives tests and CI a concrete artifact to verify: build the offline bundle and scan it for forbidden online-only markers.
+
+## Consequences
+
+Positive:
+
+- Offline APKs remain easier to audit for network-backed feature absence.
+- Online feature code can still live in the repo and be tested without maintaining a separate source tree.
+- Shared UI can call stable boundary modules while offline stubs preserve offline behavior.
+- CI can verify bundle reachability instead of relying on source grep.
+
+Negative:
+
+- Each online feature needs extra boundary modules and offline stubs.
+- Metro resolution and Gradle bundling need explicit build-mode wiring.
+- Bundle guard scripts must be maintained as online features add new symbols or endpoint strings.
+
+## Revisit
+
+Reconsider this pattern if GapSign stops shipping an offline Android flavor, if React Native/Metro offers a cleaner first-class flavor mechanism, or if online features move to a separate package that can be excluded from offline installs and bundles more directly.

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,6 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('path');
+const { createResolveRequest } = require('./metro.resolveRequest');
 
 /**
  * Metro configuration
@@ -23,6 +24,7 @@ const config = {
       ...nodeLibs,
       crypto: path.join(__dirname, 'src/shims/crypto.ts'),
     },
+    resolveRequest: createResolveRequest(process.env.ONLINE_BUILD === 'true'),
   },
 };
 

--- a/metro.resolveRequest.js
+++ b/metro.resolveRequest.js
@@ -1,0 +1,25 @@
+const { resolve } = require('metro-resolver');
+
+/**
+ * Creates a Metro resolveRequest hook that maps `.online` imports to `.offline`
+ * when the build is not online.
+ *
+ * @param {boolean} isOnlineBuild
+ * @returns {import('metro-resolver').CustomResolver}
+ */
+function createResolveRequest(isOnlineBuild) {
+  return function resolveRequest(context, moduleName, platform) {
+    const { resolveRequest: _, ...restContext } = context;
+
+    if (!isOnlineBuild) {
+      const offlineModuleName = moduleName.replace(/\.online\b/, '.offline');
+      if (offlineModuleName !== moduleName) {
+        return resolve(restContext, offlineModuleName, platform);
+      }
+    }
+
+    return resolve(restContext, moduleName, platform);
+  };
+}
+
+module.exports = { createResolveRequest };

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.5.0",
   "private": true,
   "scripts": {
-    "android": "react-native run-android --mode fullDebug",
+    "android": "ONLINE_BUILD=true react-native run-android --mode fullDebug",
     "android:offline": "react-native run-android --mode offlineDebug",
     "ios": "react-native run-ios",
     "lint": "eslint .",
-    "start": "react-native start",
+    "start": "ONLINE_BUILD=true react-native start",
+    "start:offline": "react-native start",
     "test": "jest",
     "postinstall": "npx react-native-asset",
     "bump": "node scripts/bump-version.js",
@@ -17,7 +18,8 @@
     "generate:chains": "node scripts/generate-chains.js",
     "generate:logos": "node scripts/generate-logos.js",
     "generate:logos:clean": "node scripts/generate-logos.js --clean",
-    "generate": "npm run generate:tokens && npm run generate:chains && npm run generate:abi && npm run generate:selectors"
+    "generate": "npm run generate:tokens && npm run generate:chains && npm run generate:abi && npm run generate:selectors",
+    "check:offline-bundle": "node scripts/check-offline-bundle.js"
   },
   "dependencies": {
     "@ethereumjs/rlp": "^10.1.1",

--- a/scripts/check-offline-bundle.js
+++ b/scripts/check-offline-bundle.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// These markers are string literals that only appear if our own ENS source
+// files are bundled. Avoid viem function names — viem is a shared dependency
+// and its barrel exports include ENS internals regardless of tree-shaking.
+const FORBIDDEN_MARKERS = [
+  'ethereum-rpc.publicnode.com',
+  'EnsSettingsSection',
+  'loadEnsRpcUrl',
+  'ENS RPC URL',
+  'ENS lookups send',
+];
+
+function parseArgs(argv) {
+  const idx = argv.indexOf('--bundle');
+  if (idx === -1 || idx + 1 >= argv.length) {
+    console.error('Usage: check-offline-bundle.js --bundle <path>');
+    process.exit(1);
+  }
+  return argv[idx + 1];
+}
+
+function main() {
+  const bundlePath = parseArgs(process.argv);
+  const resolved = path.resolve(bundlePath);
+
+  if (!fs.existsSync(resolved)) {
+    console.error(`Bundle not found: ${resolved}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(resolved, 'utf8');
+  const violations = [];
+
+  for (const marker of FORBIDDEN_MARKERS) {
+    if (content.includes(marker)) {
+      violations.push(marker);
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('Offline bundle contains forbidden online-only markers:');
+    for (const v of violations) {
+      console.error(`  - ${v}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Offline bundle check passed — no ENS/RPC markers found.');
+}
+
+main();

--- a/src/components/DecodedCallSection.tsx
+++ b/src/components/DecodedCallSection.tsx
@@ -3,6 +3,7 @@ import { Icon, Text } from 'react-native-paper';
 
 import theme from '../theme';
 
+import AddressInfoRow from './ens/AddressInfoRow.online';
 import InfoRow from './InfoRow';
 
 import { INTERNET_ENABLED } from '../utils/buildConfig';
@@ -57,11 +58,11 @@ export default function DecodedCallSection({
         )}
         {tokenContract && (
           <View style={styles.row}>
-            <InfoRow label="Token contract" value={tokenContract} />
+            <AddressInfoRow label="Token contract" value={tokenContract} />
           </View>
         )}
         <View style={styles.row}>
-          <InfoRow label="Recipient" value={call.to} />
+          <AddressInfoRow label="Recipient" value={call.to} />
         </View>
         <View style={styles.row}>
           <InfoRow
@@ -91,14 +92,14 @@ export default function DecodedCallSection({
         )}
         {tokenContract && (
           <View style={styles.row}>
-            <InfoRow label="Token contract" value={tokenContract} />
+            <AddressInfoRow label="Token contract" value={tokenContract} />
           </View>
         )}
         <View style={styles.row}>
-          <InfoRow label="From" value={call.from} />
+          <AddressInfoRow label="From" value={call.from} />
         </View>
         <View style={styles.row}>
-          <InfoRow label="Recipient" value={call.to} />
+          <AddressInfoRow label="Recipient" value={call.to} />
         </View>
         <View style={styles.row}>
           <InfoRow
@@ -129,11 +130,11 @@ export default function DecodedCallSection({
         )}
         {tokenContract && (
           <View style={styles.row}>
-            <InfoRow label="Token contract" value={tokenContract} />
+            <AddressInfoRow label="Token contract" value={tokenContract} />
           </View>
         )}
         <View style={styles.row}>
-          <InfoRow label="Spender" value={call.spender} />
+          <AddressInfoRow label="Spender" value={call.spender} />
         </View>
         <View style={styles.row}>
           <InfoRow
@@ -170,7 +171,10 @@ export default function DecodedCallSection({
         </View>
         {call.args.map((arg, index) => (
           <View key={`${arg.name}-${index}`} style={styles.row}>
-            <InfoRow label={`${arg.name} (${arg.type})`} value={arg.value} />
+            <AddressInfoRow
+              label={`${arg.name} (${arg.type})`}
+              value={arg.value}
+            />
           </View>
         ))}
         {call.highRisk && (
@@ -216,7 +220,7 @@ export default function DecodedCallSection({
               }`}
             />
             {command.args.map(arg => (
-              <InfoRow
+              <AddressInfoRow
                 key={`${command.index}-${arg.name}`}
                 label={`${arg.name} (${arg.type})`}
                 value={arg.value}

--- a/src/components/EthSignRequestDetail.tsx
+++ b/src/components/EthSignRequestDetail.tsx
@@ -4,6 +4,7 @@ import { Icon, Text } from 'react-native-paper';
 import theme from '../theme';
 import type { EthSignRequest } from '../types';
 
+import AddressInfoRow from './ens/AddressInfoRow.online';
 import DecodedCallSection from './DecodedCallSection';
 import InfoRow from './InfoRow';
 
@@ -56,11 +57,14 @@ function PermitReviewSection({
       <SectionHeader title="EIP-712 Permit" />
       {special.tokenContract && (
         <View style={styles.row}>
-          <InfoRow label="Token contract" value={special.tokenContract} />
+          <AddressInfoRow
+            label="Token contract"
+            value={special.tokenContract}
+          />
         </View>
       )}
       <View style={styles.row}>
-        <InfoRow label="Spender" value={special.spender} />
+        <AddressInfoRow label="Spender" value={special.spender} />
       </View>
       <View style={styles.row}>
         <InfoRow
@@ -102,11 +106,11 @@ function SafeTxReviewSection({
       <SectionHeader title="Safe Transaction" />
       {special.safeAddress && (
         <View style={styles.row}>
-          <InfoRow label="Safe" value={special.safeAddress} />
+          <AddressInfoRow label="Safe" value={special.safeAddress} />
         </View>
       )}
       <View style={styles.row}>
-        <InfoRow label="To" value={special.to} />
+        <AddressInfoRow label="To" value={special.to} />
       </View>
       <View style={styles.row}>
         <InfoRow label="Value" value={special.value} />
@@ -123,8 +127,11 @@ function SafeTxReviewSection({
         <InfoRow label="Gas price" value={special.gasPrice} />
       </View>
       <View style={styles.row}>
-        <InfoRow label="Gas token" value={special.gasToken} />
-        <InfoRow label="Refund receiver" value={special.refundReceiver} />
+        <AddressInfoRow label="Gas token" value={special.gasToken} />
+        <AddressInfoRow
+          label="Refund receiver"
+          value={special.refundReceiver}
+        />
       </View>
       {special.decodedCall ? (
         <DecodedCallSection
@@ -189,7 +196,7 @@ export default function EthSignRequestDetail({
       </View>
 
       <View style={styles.row}>
-        <InfoRow label="Signer" value={signer} />
+        <AddressInfoRow label="Signer" value={signer} />
       </View>
 
       {request.address && (
@@ -207,7 +214,7 @@ export default function EthSignRequestDetail({
       {tx?.to &&
         (!tx.decodedCall || tx.decodedCall.kind === 'contract-call') && (
           <View style={styles.row}>
-            <InfoRow label="To" value={tx.to} />
+            <AddressInfoRow label="To" value={tx.to} />
           </View>
         )}
 
@@ -261,7 +268,7 @@ export default function EthSignRequestDetail({
           </View>
           {Object.entries(eip712!.domain).map(([key, value]) => (
             <View key={`domain-${key}`} style={styles.row}>
-              <InfoRow label={key} value={value} />
+              <AddressInfoRow label={key} value={value} />
             </View>
           ))}
         </>
@@ -279,7 +286,7 @@ export default function EthSignRequestDetail({
           <SectionHeader title="Message Fields" />
           {Object.entries(eip712!.message).map(([key, value]) => (
             <View key={`message-${key}`} style={styles.row}>
-              <InfoRow label={key} value={value} />
+              <AddressInfoRow label={key} value={value} />
             </View>
           ))}
         </>

--- a/src/components/ens/AddressInfoRow.offline.tsx
+++ b/src/components/ens/AddressInfoRow.offline.tsx
@@ -1,0 +1,11 @@
+import InfoRow from '../InfoRow';
+
+export default function AddressInfoRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return <InfoRow label={label} value={value} />;
+}

--- a/src/components/ens/AddressInfoRow.online.tsx
+++ b/src/components/ens/AddressInfoRow.online.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import EnsAddressLabel from './EnsAddressLabel.online';
+import InfoRow from '../InfoRow';
+
+import { isDisplayAddress } from '../AddressText';
+import theme from '../../theme';
+
+export default function AddressInfoRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  if (isDisplayAddress(value)) {
+    return (
+      <View style={styles.infoRow}>
+        <Text variant="bodySmall" style={styles.infoLabel}>
+          {label}
+        </Text>
+        <EnsAddressLabel address={value} />
+      </View>
+    );
+  }
+
+  return <InfoRow label={label} value={value} />;
+}
+
+const styles = StyleSheet.create({
+  infoRow: {
+    gap: 4,
+  },
+  infoLabel: {
+    color: theme.colors.onSurfaceVariant,
+  },
+});

--- a/src/components/ens/EnsAddressLabel.offline.tsx
+++ b/src/components/ens/EnsAddressLabel.offline.tsx
@@ -1,0 +1,5 @@
+import AddressText from '../AddressText';
+
+export default function EnsAddressLabel({ address }: { address: string }) {
+  return <AddressText address={address} />;
+}

--- a/src/components/ens/EnsAddressLabel.online.tsx
+++ b/src/components/ens/EnsAddressLabel.online.tsx
@@ -1,0 +1,61 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import AddressText from '../AddressText';
+import EnsErrorRow from './EnsErrorRow';
+
+import { useEnsName } from '../../hooks/ens/useEnsName.online';
+import theme from '../../theme';
+
+export default function EnsAddressLabel({ address }: { address: string }) {
+  const { name, error, retry } = useEnsName(address);
+
+  if (name) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.ensName}>{name}</Text>
+        <AddressText address={address} style={styles.address} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <AddressText address={address} style={styles.address} />
+        <EnsErrorRow onRetry={retry} />
+      </View>
+    );
+  }
+
+  if (name === '') {
+    return (
+      <View style={styles.container}>
+        <AddressText address={address} style={styles.address} />
+        <Text style={styles.noEns}>no ens</Text>
+      </View>
+    );
+  }
+
+  return <AddressText address={address} style={styles.address} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 4,
+  },
+  ensName: {
+    fontFamily: 'Inter_18pt-Medium',
+    fontSize: 15,
+    color: theme.colors.onSurface,
+  },
+  address: {
+    fontFamily: 'monospace',
+    fontSize: 14,
+    color: theme.colors.onSurface,
+  },
+  noEns: {
+    fontFamily: 'Inter_18pt-Regular',
+    fontSize: 12,
+    color: theme.colors.onSurfaceVariant,
+  },
+});

--- a/src/components/ens/EnsErrorRow.tsx
+++ b/src/components/ens/EnsErrorRow.tsx
@@ -1,0 +1,40 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import theme from '../../theme';
+
+export default function EnsErrorRow({ onRetry }: { onRetry: () => void }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.errorText}>⚠ ENS unavailable</Text>
+      <Pressable
+        onPress={onRetry}
+        style={styles.refreshButton}
+        accessibilityLabel="Refresh ENS lookup"
+      >
+        <Text style={styles.refreshText}>Refresh</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  errorText: {
+    fontFamily: 'Inter_18pt-Regular',
+    fontSize: 12,
+    color: theme.colors.error,
+  },
+  refreshButton: {
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+  },
+  refreshText: {
+    fontFamily: 'Inter_18pt-Medium',
+    fontSize: 12,
+    color: theme.colors.primary,
+  },
+});

--- a/src/components/settings/EnsRpcUrlInput.tsx
+++ b/src/components/settings/EnsRpcUrlInput.tsx
@@ -1,0 +1,95 @@
+import { ActivityIndicator, StyleSheet, TextInput, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import theme from '../../theme';
+
+export default function EnsRpcUrlInput({
+  input,
+  dirty,
+  validating,
+  error,
+  onChangeText,
+  onRevert,
+  onSave,
+}: {
+  input: string;
+  dirty: boolean;
+  validating: boolean;
+  error: string | null;
+  onChangeText: (value: string) => void;
+  onRevert: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <>
+      <Text variant="bodySmall" style={styles.fieldLabel}>
+        RPC URL
+      </Text>
+      <TextInput
+        style={styles.input}
+        value={input}
+        onChangeText={onChangeText}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="url"
+        editable={!validating}
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      {(dirty || validating) && (
+        <View style={styles.buttonRow}>
+          {dirty && !validating && (
+            <Text style={styles.revertButton} onPress={onRevert}>
+              Revert
+            </Text>
+          )}
+          <Text
+            style={[styles.saveButton, validating && styles.saveButtonDisabled]}
+            onPress={validating ? undefined : onSave}
+          >
+            {validating ? (
+              <ActivityIndicator size="small" color={theme.colors.primary} />
+            ) : (
+              'Save'
+            )}
+          </Text>
+        </View>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  fieldLabel: {
+    color: theme.colors.onSurfaceVariant,
+  },
+  input: {
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: theme.colors.onSurface,
+    fontFamily: 'monospace',
+    fontSize: 14,
+  },
+  error: {
+    color: theme.colors.error,
+    fontSize: 12,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 12,
+  },
+  revertButton: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 14,
+  },
+  saveButton: {
+    color: theme.colors.primary,
+    fontSize: 14,
+  },
+  saveButtonDisabled: {
+    color: theme.colors.onSurfaceDisabled,
+  },
+});

--- a/src/components/settings/EnsSettingsSection.offline.tsx
+++ b/src/components/settings/EnsSettingsSection.offline.tsx
@@ -1,0 +1,3 @@
+export default function EnsSettingsSection() {
+  return null;
+}

--- a/src/components/settings/EnsSettingsSection.online.tsx
+++ b/src/components/settings/EnsSettingsSection.online.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import theme from '../../theme';
+
+import EnsRpcUrlInput from './EnsRpcUrlInput';
+import EnsToggleRow from './EnsToggleRow';
+
+import { clearEnsNameCache } from '../../hooks/ens/useEnsName.online';
+import { validateRpcUrl } from '../../utils/ens/client.online';
+import {
+  DEFAULT_ENS_RPC_URL,
+  loadEnsSettings,
+  saveEnsEnabled,
+  saveEnsRpcUrl,
+} from '../../storage/ensSettings.online';
+
+export default function EnsSettingsSection() {
+  const [input, setInput] = useState('');
+  const [savedUrl, setSavedUrl] = useState('');
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadEnsSettings()
+      .then(settings => {
+        if (!cancelled) {
+          setEnabled(settings.enabled);
+          setSavedUrl(settings.rpcUrl);
+          setInput(settings.rpcUrl);
+          setLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = useCallback(
+    async (value: boolean) => {
+      setEnabled(value);
+      setError(null);
+      if (value && !savedUrl) {
+        setSavedUrl(DEFAULT_ENS_RPC_URL);
+        setInput(DEFAULT_ENS_RPC_URL);
+        await Promise.all([
+          saveEnsEnabled(true),
+          saveEnsRpcUrl(DEFAULT_ENS_RPC_URL),
+        ]);
+      } else {
+        if (!value) clearEnsNameCache();
+        await saveEnsEnabled(value);
+      }
+    },
+    [savedUrl],
+  );
+
+  const dirty = loaded && input !== savedUrl;
+
+  const handleRevert = useCallback(() => {
+    setInput(savedUrl);
+    setError(null);
+  }, [savedUrl]);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      await saveEnsRpcUrl('');
+      setSavedUrl('');
+      setError(null);
+      return;
+    }
+
+    setValidating(true);
+    setError(null);
+
+    const result = await validateRpcUrl(trimmed);
+    setValidating(false);
+
+    if (result === 'ok') {
+      await saveEnsRpcUrl(trimmed);
+      setSavedUrl(trimmed);
+      setError(null);
+    } else if (result === 'non-mainnet') {
+      setError('Not an Ethereum mainnet endpoint.');
+    } else {
+      setError('Could not reach RPC endpoint — URL not saved.');
+    }
+  }, [input]);
+
+  if (!loaded) return null;
+
+  return (
+    <View style={styles.section}>
+      <EnsToggleRow enabled={enabled} onToggle={handleToggle} />
+      {enabled && (
+        <EnsRpcUrlInput
+          input={input}
+          dirty={dirty}
+          validating={validating}
+          error={error}
+          onChangeText={value => {
+            setInput(value);
+            setError(null);
+          }}
+          onRevert={handleRevert}
+          onSave={handleSave}
+        />
+      )}
+      <Text style={styles.privacy}>
+        ENS lookups send reviewed Ethereum addresses to the configured RPC
+        provider.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    gap: 8,
+  },
+  privacy: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 12,
+  },
+});

--- a/src/components/settings/EnsToggleRow.tsx
+++ b/src/components/settings/EnsToggleRow.tsx
@@ -1,0 +1,40 @@
+import { StyleSheet, Switch, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import theme from '../../theme';
+
+export default function EnsToggleRow({
+  enabled,
+  onToggle,
+}: {
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+}) {
+  return (
+    <View style={styles.toggleRow}>
+      <Text variant="bodyMedium" style={styles.label}>
+        ENS resolution
+      </Text>
+      <Switch
+        value={enabled}
+        onValueChange={onToggle}
+        trackColor={{
+          false: theme.colors.surfaceVariant,
+          true: theme.colors.primary,
+        }}
+        thumbColor={theme.colors.onSurface}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    color: theme.colors.onSurface,
+  },
+});

--- a/src/constants/ens.ts
+++ b/src/constants/ens.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ENS_RPC_URL = 'https://ethereum-rpc.publicnode.com';

--- a/src/data/licenses.ts
+++ b/src/data/licenses.ts
@@ -426,7 +426,6 @@ export const licenses: LicenseEntry[] = [
   { package: 'react', licenseType: 'MIT' },
   { package: 'react-native', licenseType: 'MIT' },
   { package: 'react-native-animated-ur-qr', licenseType: 'MIT' },
-  { package: 'react-native-camera-kit', licenseType: 'MIT' },
   { package: 'react-native-encrypted-storage', licenseType: 'MIT' },
   { package: 'react-native-get-random-values', licenseType: 'MIT' },
   { package: 'react-native-keycard', licenseType: 'MIT' },

--- a/src/hooks/ens/useEnsName.offline.ts
+++ b/src/hooks/ens/useEnsName.offline.ts
@@ -1,0 +1,12 @@
+export interface UseEnsNameResult {
+  name: string | null;
+  loading: boolean;
+  error: boolean;
+  retry: () => void;
+}
+
+function noop() {}
+
+export function useEnsName(_address: string): UseEnsNameResult {
+  return { name: null, loading: false, error: false, retry: noop };
+}

--- a/src/hooks/ens/useEnsName.online.ts
+++ b/src/hooks/ens/useEnsName.online.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getAddress } from 'viem';
+
+import { loadEnsRpcUrl } from '../../storage/ensSettings.online';
+import { resolveEnsName } from '../../utils/ens/client.online';
+
+const cache = new Map<string, string>();
+
+export interface UseEnsNameResult {
+  name: string | null;
+  loading: boolean;
+  error: boolean;
+  retry: () => void;
+}
+
+function normalizeAddress(address: string): string | null {
+  try {
+    return getAddress(address);
+  } catch {
+    return null;
+  }
+}
+
+export function useEnsName(address: string): UseEnsNameResult {
+  const normalized = normalizeAddress(address);
+
+  const [name, setName] = useState<string | null>(() => {
+    if (!normalized) return null;
+    return cache.get(normalized) ?? null;
+  });
+  const [loading, setLoading] = useState(() => {
+    if (!normalized) return false;
+    return !cache.has(normalized);
+  });
+  const [error, setError] = useState(false);
+  const [retryTrigger, setRetryTrigger] = useState(0);
+  const lastFailureRef = useRef<'rpc-error' | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      if (!normalized) {
+        setName(null);
+        setLoading(false);
+        setError(false);
+        lastFailureRef.current = null;
+        return;
+      }
+
+      if (cache.has(normalized)) {
+        setName(cache.get(normalized)!);
+        setLoading(false);
+        setError(false);
+        lastFailureRef.current = null;
+        return;
+      }
+
+      setLoading(true);
+      setError(false);
+      lastFailureRef.current = null;
+
+      const rpcUrl = await loadEnsRpcUrl();
+      if (!rpcUrl) {
+        if (!cancelled) {
+          setLoading(false);
+          setName(null);
+          setError(false);
+        }
+        return;
+      }
+
+      const result = await resolveEnsName(normalized, rpcUrl);
+      if (cancelled) return;
+
+      if ('name' in result && result.name !== null) {
+        cache.set(normalized, result.name);
+        setName(result.name);
+        setLoading(false);
+        setError(false);
+        lastFailureRef.current = null;
+      } else if (result.reason === 'rpc-error') {
+        setName(null);
+        setLoading(false);
+        setError(true);
+        lastFailureRef.current = 'rpc-error';
+      } else {
+        cache.set(normalized, '');
+        setName('');
+        setLoading(false);
+        setError(false);
+        lastFailureRef.current = null;
+      }
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalized, retryTrigger]);
+
+  const retry = useCallback(() => {
+    if (!normalized) return;
+    if (lastFailureRef.current !== 'rpc-error') return;
+    setRetryTrigger(t => t + 1);
+  }, [normalized]);
+
+  return { name, loading, error, retry };
+}
+
+export function clearEnsNameCache(): void {
+  cache.clear();
+}

--- a/src/navigation/dashboardActions.ts
+++ b/src/navigation/dashboardActions.ts
@@ -2,12 +2,14 @@ import { DashboardAction } from './types';
 
 import { dashboardEntry as aboutEntry } from '../screens/AboutScreen';
 import { dashboardEntry as exportKeyEntry } from '../screens/ExportKeyScreen';
-import { dashboardEntry as keycardMenu } from '../screens/KeycardMenuScreen';
-import { dashboardEntry as addressMenu } from '../screens/address/AddressMenuScreen';
+import { dashboardEntry as keycardMenuEntry } from '../screens/KeycardMenuScreen';
+import { dashboardEntry as settingsEntry } from '../screens/SettingsScreen';
+import { dashboardEntry as addressMenuEntry } from '../screens/address/AddressMenuScreen';
 
 export const dashboardActions: DashboardAction[] = [
   exportKeyEntry,
-  addressMenu,
-  keycardMenu,
+  addressMenuEntry,
+  keycardMenuEntry,
+  settingsEntry,
   aboutEntry,
 ];

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -19,6 +19,7 @@ import QRScannerScreen from '../screens/QRScannerScreen';
 import SetCardNameScreen from '../screens/SetCardNameScreen';
 import TransactionDetailScreen from '../screens/TransactionDetailScreen';
 import UrlQRScreen from '../screens/UrlQRScreen';
+import SettingsScreen from '../screens/SettingsScreen';
 
 // Address screens
 import AddressDetailScreen from '../screens/address/AddressDetailScreen';
@@ -184,5 +185,10 @@ export const routes: Route[] = [
     name: 'UrlQR',
     component: UrlQRScreen,
     options: defaultHeaderOptions,
+  },
+  {
+    name: 'Settings',
+    component: SettingsScreen,
+    options: { ...defaultHeaderOptions, title: 'Settings' },
   },
 ];

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -71,6 +71,7 @@ export type RootStackParamList = {
     url: string;
     title?: string;
   };
+  Settings: undefined;
 };
 
 export type DashboardScreenProps = NativeStackScreenProps<
@@ -196,6 +197,11 @@ export type LicenseDetailScreenProps = NativeStackScreenProps<
 export type UrlQRScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'UrlQR'
+>;
+
+export type SettingsScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'Settings'
 >;
 
 export type DashboardAction = {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,47 @@
+import React, { useLayoutEffect } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { DashboardAction, SettingsScreenProps } from '../navigation/types';
+import theme from '../theme';
+
+import EnsSettingsSection from '../components/settings/EnsSettingsSection.online';
+
+export const dashboardEntry: DashboardAction = {
+  label: 'Settings',
+  navigate: nav => nav.navigate('Settings'),
+};
+
+export default function SettingsScreen({ navigation }: SettingsScreenProps) {
+  const insets = useSafeAreaInsets();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'Settings' });
+  }, [navigation]);
+
+  return (
+    <ScrollView
+      style={[styles.container, { paddingBottom: insets.bottom + 16 }]}
+      contentContainerStyle={styles.content}
+    >
+      <View style={styles.section}>
+        <EnsSettingsSection />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    gap: 24,
+  },
+  section: {
+    gap: 16,
+  },
+});

--- a/src/screens/address/AddressDetailScreen.tsx
+++ b/src/screens/address/AddressDetailScreen.tsx
@@ -8,7 +8,7 @@ import type { AddressDetailScreenProps } from '../../navigation/types';
 import theme from '../../theme';
 
 import { Icons } from '../../assets/icons';
-import AddressText from '../../components/AddressText';
+import EnsAddressLabel from '../../components/ens/EnsAddressLabel.online';
 import PrimaryButton from '../../components/PrimaryButton';
 
 export default function AddressDetailScreen({
@@ -37,7 +37,7 @@ export default function AddressDetailScreen({
             backgroundColor="#ffffff"
           />
         </View>
-        <AddressText address={address} selectable style={styles.address} />
+        <EnsAddressLabel address={address} />
       </View>
       <PrimaryButton
         label="Copy Address"
@@ -66,11 +66,5 @@ const styles = StyleSheet.create({
     padding: 16,
     backgroundColor: '#ffffff',
     borderRadius: 8,
-  },
-  address: {
-    color: theme.colors.onSurface,
-    fontFamily: 'monospace',
-    textAlign: 'center',
-    paddingHorizontal: 8,
   },
 });

--- a/src/shims.ts
+++ b/src/shims.ts
@@ -1,3 +1,12 @@
 import 'node-libs-react-native/globals';
 import { Buffer } from 'buffer';
+import { TextDecoder, TextEncoder } from 'text-encoding';
+
 global.Buffer = global.Buffer || Buffer;
+
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder as any;
+}
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder as any;
+}

--- a/src/storage/ensSettings.offline.ts
+++ b/src/storage/ensSettings.offline.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_ENS_RPC_URL = '';
+
+export interface EnsSettings {
+  enabled: boolean;
+  rpcUrl: string;
+}
+
+export async function loadEnsSettings(): Promise<EnsSettings> {
+  return { enabled: false, rpcUrl: '' };
+}
+
+export async function loadEnsRpcUrl(): Promise<string | null> {
+  return null;
+}
+
+export async function saveEnsEnabled(_enabled: boolean): Promise<void> {}
+
+export async function saveEnsRpcUrl(_url: string): Promise<void> {}

--- a/src/storage/ensSettings.online.ts
+++ b/src/storage/ensSettings.online.ts
@@ -1,0 +1,47 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export { DEFAULT_ENS_RPC_URL } from '../constants/ens';
+
+const ENS_ENABLED_KEY = 'ens_enabled';
+const ENS_RPC_URL_KEY = 'ens_rpc_url';
+
+export interface EnsSettings {
+  enabled: boolean;
+  rpcUrl: string;
+}
+
+export async function loadEnsSettings(): Promise<EnsSettings> {
+  try {
+    const [enabled, url] = await Promise.all([
+      AsyncStorage.getItem(ENS_ENABLED_KEY),
+      AsyncStorage.getItem(ENS_RPC_URL_KEY),
+    ]);
+    return {
+      enabled: enabled === 'true',
+      rpcUrl: url?.trim() ?? '',
+    };
+  } catch {
+    return { enabled: false, rpcUrl: '' };
+  }
+}
+
+export async function loadEnsRpcUrl(): Promise<string | null> {
+  try {
+    const [enabled, url] = await Promise.all([
+      AsyncStorage.getItem(ENS_ENABLED_KEY),
+      AsyncStorage.getItem(ENS_RPC_URL_KEY),
+    ]);
+    if (enabled !== 'true') return null;
+    return url?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveEnsEnabled(enabled: boolean): Promise<void> {
+  await AsyncStorage.setItem(ENS_ENABLED_KEY, enabled ? 'true' : 'false');
+}
+
+export async function saveEnsRpcUrl(url: string): Promise<void> {
+  await AsyncStorage.setItem(ENS_RPC_URL_KEY, url);
+}

--- a/src/utils/ens/client.offline.ts
+++ b/src/utils/ens/client.offline.ts
@@ -1,0 +1,10 @@
+export type ResolveEnsNameResult =
+  | { name: string }
+  | { name: null; reason: 'not-found' | 'mismatch' | 'rpc-error' };
+
+export async function resolveEnsName(
+  _address: string,
+  _rpcUrl: string,
+): Promise<ResolveEnsNameResult> {
+  return { name: null, reason: 'not-found' };
+}

--- a/src/utils/ens/client.online.ts
+++ b/src/utils/ens/client.online.ts
@@ -1,0 +1,65 @@
+import { createPublicClient, getAddress, http } from 'viem';
+import { mainnet } from 'viem/chains';
+
+export type ResolveEnsNameResult =
+  | { name: string }
+  | { name: null; reason: 'not-found' | 'mismatch' | 'rpc-error' };
+
+export async function resolveEnsName(
+  address: string,
+  rpcUrl: string,
+): Promise<ResolveEnsNameResult> {
+  try {
+    const checksummedAddress = getAddress(address);
+
+    const client = createPublicClient({
+      chain: mainnet,
+      transport: http(rpcUrl),
+    });
+    const name = await client.getEnsName({ address: checksummedAddress });
+    if (!name) {
+      return { name: null, reason: 'not-found' };
+    }
+
+    const resolvedAddress = await client.getEnsAddress({ name });
+    if (
+      !resolvedAddress ||
+      getAddress(resolvedAddress) !== checksummedAddress
+    ) {
+      return { name: null, reason: 'mismatch' };
+    }
+
+    return { name };
+  } catch {
+    return { name: null, reason: 'rpc-error' };
+  }
+}
+
+export async function validateRpcUrl(
+  url: string,
+): Promise<'ok' | 'non-mainnet' | 'timeout' | 'unreachable'> {
+  try {
+    const client = createPublicClient({
+      chain: mainnet,
+      transport: http(url, { timeout: 5000 }),
+    });
+
+    const chainId = await client.getChainId();
+
+    if (chainId === 1) {
+      return 'ok';
+    }
+
+    return 'non-mainnet';
+  } catch (error: any) {
+    if (
+      error?.name === 'TimeoutError' ||
+      error?.code === 'TIMEOUT' ||
+      error?.message?.toLowerCase().includes('timeout')
+    ) {
+      return 'timeout';
+    }
+
+    return 'unreachable';
+  }
+}


### PR DESCRIPTION
## Summary

- Add opt-in ENS reverse resolution for Ethereum addresses. Disabled by default, enabled via a toggle in Settings with a configurable RPC URL (defaults to publicnode.com)
- Display resolved ENS names above raw addresses in transaction review, EIP-712 review, decoded calldata, and address detail screens; show "no ens" for addresses with no registered name; show an inline retry on RPC errors
- Isolate all ENS code behind the existing online/offline Metro build boundary — offline builds bundle no ENS code, RPC strings, or network clients; enforced by `scripts/check-offline-bundle.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in ENS reverse resolution with a Settings toggle
  * Settings screen to enable ENS, configure custom RPC URL, validate/save/revert changes
  * Resolved ENS names shown alongside raw addresses across the app (address lists, details, request screens)
  * Explicit “no ens” indicator and “ENS unavailable” error with a Refresh action when resolution fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->