### PR TITLE
refactor: rename DonationSection/DonationList to SupportSection/SupportList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add opt-in PIN pad scramble toggle in Settings (default: fixed layout)
 - Add opt-in ENS reverse resolution: toggle + custom RPC URL in Settings, ENS name display on address rows, "no ens" indicator for unregistered addresses
 
+### Changed
+
+- Rename "Support development" section to "Buy me a coffee" with updated copy; rename `DonationSection`/`DonationList` components to `SupportSection`/`SupportList`
+
 ### Fixed
 
 - Fix system UI dark theme: navigation bar, status bar, and safe area background now match app background on all screens

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ npm test      # Jest test suite
 npm run lint  # ESLint
 ```
 
-## Support development
+## Buy me a coffee
 
-If GapSign is useful to you, voluntary donations help support ongoing open-source development.
+If GapSign keeps your funds safe, you can send a coffee my way.
 
 - Ethereum: `0xF665E3D58DABa87d741A347674DCc4C4b794cAc9`
 - Bitcoin: `bc1qpncfjnresszndse506zmvjya05xcs6493cm8xf`

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -66,13 +66,13 @@ describe('AboutScreen', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders the app, icon, project link, Keycard, donations, contributors, and license sections', () => {
+  it('renders the app, icon, project link, Keycard, support, contributors, and license sections', () => {
     renderScreen();
     expect(screen.getAllByText('GapSign').length).toBeGreaterThan(0);
     expect(screen.getByLabelText('GapSign app icon')).toBeTruthy();
     expect(screen.getByText('GitHub project')).toBeTruthy();
     expect(screen.getByText(/Keycard required/)).toBeTruthy();
-    expect(screen.getByText('Support development')).toBeTruthy();
+    expect(screen.getByText('Buy me a coffee')).toBeTruthy();
     expect(screen.getByText(bitcoinAddress)).toBeTruthy();
     expect(screen.getByText(ethereumAddress)).toBeTruthy();
     const labels = screen
@@ -91,29 +91,29 @@ describe('AboutScreen', () => {
     );
   });
 
-  it('copies donation addresses', () => {
+  it('copies support addresses', () => {
     renderScreen();
-    fireEvent.press(screen.getByLabelText('Copy Bitcoin donation address'));
+    fireEvent.press(screen.getByLabelText('Copy Bitcoin address'));
     expect(mockSetString).toHaveBeenCalledWith(bitcoinAddress);
 
-    fireEvent.press(screen.getByLabelText('Copy Ethereum donation address'));
+    fireEvent.press(screen.getByLabelText('Copy Ethereum address'));
     expect(mockSetString).toHaveBeenCalledWith(ethereumAddress);
   });
 
-  it('opens donation addresses as QR codes', () => {
+  it('opens support addresses as QR codes', () => {
     renderScreen();
-    fireEvent.press(screen.getByLabelText('Show Bitcoin donation QR code'));
+    fireEvent.press(screen.getByLabelText('Show Bitcoin QR code'));
     expect(navigation.navigate).toHaveBeenCalledWith('AddressDetail', {
       address: bitcoinAddress,
       index: 0,
-      title: 'Bitcoin donation',
+      title: 'Bitcoin address',
     });
 
-    fireEvent.press(screen.getByLabelText('Show Ethereum donation QR code'));
+    fireEvent.press(screen.getByLabelText('Show Ethereum QR code'));
     expect(navigation.navigate).toHaveBeenCalledWith('AddressDetail', {
       address: ethereumAddress,
       index: 0,
-      title: 'Ethereum donation',
+      title: 'Ethereum address',
     });
   });
 

--- a/__tests__/AddressDetailScreen.test.tsx
+++ b/__tests__/AddressDetailScreen.test.tsx
@@ -137,14 +137,14 @@ describe('AddressDetailScreen', () => {
               params: {
                 address: ETH_ADDRESS,
                 index: 0,
-                title: 'Ethereum donation',
+                title: 'Ethereum address',
               },
             } as any
           }
         />,
       );
       expect(navigation.setOptions).toHaveBeenCalledWith({
-        title: 'Ethereum donation',
+        title: 'Ethereum address',
       });
     });
   });

--- a/src/components/about/SupportList.tsx
+++ b/src/components/about/SupportList.tsx
@@ -7,7 +7,7 @@ import theme from '../../theme';
 import { Icons } from '../../assets/icons';
 import AddressText from '../AddressText';
 
-const DONATION_ADDRESSES = [
+const SUPPORT_ADDRESSES = [
   {
     label: 'Ethereum',
     address: '0xF665E3D58DABa87d741A347674DCc4C4b794cAc9',
@@ -18,14 +18,14 @@ const DONATION_ADDRESSES = [
   },
 ];
 
-interface DonationListProps {
+interface SupportListProps {
   onShowQR: (label: string, address: string) => void;
 }
 
-export default function DonationList({ onShowQR }: DonationListProps) {
+export default function SupportList({ onShowQR }: SupportListProps) {
   return (
     <View style={styles.list}>
-      {DONATION_ADDRESSES.map(({ label, address }) => (
+      {SUPPORT_ADDRESSES.map(({ label, address }) => (
         <View key={label} style={styles.row}>
           <View style={styles.text}>
             <Text style={styles.label}>{label}</Text>
@@ -36,7 +36,7 @@ export default function DonationList({ onShowQR }: DonationListProps) {
               style={styles.iconButton}
               onPress={() => Clipboard.setString(address)}
               accessibilityRole="button"
-              accessibilityLabel={`Copy ${label} donation address`}
+              accessibilityLabel={`Copy ${label} address`}
             >
               <Icons.copy
                 width={20}
@@ -48,7 +48,7 @@ export default function DonationList({ onShowQR }: DonationListProps) {
               style={styles.iconButton}
               onPress={() => onShowQR(label, address)}
               accessibilityRole="button"
-              accessibilityLabel={`Show ${label} donation QR code`}
+              accessibilityLabel={`Show ${label} QR code`}
             >
               <Icons.qr width={20} height={20} color={theme.colors.onSurface} />
             </Pressable>

--- a/src/components/about/SupportSection.tsx
+++ b/src/components/about/SupportSection.tsx
@@ -2,21 +2,21 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import theme from '../../theme';
 
-import DonationList from './DonationList';
+import SupportList from './SupportList';
 
-type DonationSectionProps = {
+type SupportSectionProps = {
   onShowQR: (label: string, address: string) => void;
 };
 
-export default function DonationSection({ onShowQR }: DonationSectionProps) {
+export default function SupportSection({ onShowQR }: SupportSectionProps) {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Support development</Text>
+      <Text style={styles.title}>Buy me a coffee</Text>
       <Text style={styles.description}>
-        Donations help keep GapSign maintained and available as open-source
-        software.
+        If GapSign keeps your funds safe, you can send a coffee my way. It helps
+        keep the project maintained and open-source.
       </Text>
-      <DonationList onShowQR={onShowQR} />
+      <SupportList onShowQR={onShowQR} />
     </View>
   );
 }

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -15,7 +15,7 @@ import theme from '../theme';
 
 import AppIdentityHeader from '../components/about/AppIdentityHeader';
 import ContributorsList from '../components/about/ContributorsList';
-import DonationSection from '../components/about/DonationSection';
+import SupportSection from '../components/about/SupportSection';
 import KeycardPurchaseCard from '../components/KeycardPurchaseCard';
 import LicenseList from '../components/about/LicenseList';
 
@@ -97,12 +97,12 @@ export default function AboutScreen({ navigation }: AboutScreenProps) {
         }
       />
 
-      <DonationSection
+      <SupportSection
         onShowQR={(label, address) =>
           navigation.navigate('AddressDetail', {
             address,
             index: 0,
-            title: `${label} donation`,
+            title: `${label} address`,
           })
         }
       />


### PR DESCRIPTION
## Summary

- Rename `DonationSection` → `SupportSection`, `DonationList` → `SupportList`, `DONATION_ADDRESSES` → `SUPPORT_ADDRESSES`, and all associated types
- Update About screen section title to "Buy me a coffee" with new copy
- Strip "donation" from accessibility labels and nav titles
- Update README section header and blurb
- Update tests to match new labels and copy

## Test plan

- [x] `npx jest --no-coverage` passes (79 suites, 928 tests)
- [x] About screen shows "Buy me a coffee" heading
- [x] Copy and QR buttons on support addresses still work
- [x] No `Donation`/`donation`/`DONATION` identifiers remain in `src/` or `__tests__/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Rebranded the donation support section to "Buy me a coffee" with updated messaging and terminology throughout the app.

* **Documentation**
  * Updated README and CHANGELOG to reflect the rebranded support section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->