### PR TITLE
fix: use tasks.matching to generate Metro env script for lazy Gradle tasks

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch commits since previous release tag
         run: |
@@ -39,15 +39,15 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install Node dependencies
@@ -147,7 +147,7 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install fdroidserver
         run: pip install fdroidserver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Bump GitHub Actions: `checkout@v6`, `setup-node@v6`, `setup-java@v5`; use Node 22 in CI and release workflows
+
+### Fixed
+
+- Fix `createBundle*JsAndAssets` Metro env script not being generated when React Native Gradle plugin registers bundle tasks lazily; switch from `tasks.findByName` to `tasks.matching { }.configureEach`
+
 ## [1.6.0] - 2026-05-12
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -171,15 +171,12 @@ afterEvaluate {
     android.applicationVariants.all { variant ->
         def isFull = variant.productFlavors.any { it.name == "full" }
         def taskName = "createBundle${variant.name.capitalize()}JsAndAssets"
-        def bundleTask = tasks.findByName(taskName)
-        if (bundleTask != null) {
-            bundleTask.configure {
-                def originalArgs = nodeExecutableAndArgs.get().toList()
-                def envScript = file("${buildDir}/metro-env-${variant.name}.js")
-                envScript.parentFile.mkdirs()
-                envScript.text = "process.env.ONLINE_BUILD = '${isFull ? 'true' : 'false'}';\n"
-                nodeExecutableAndArgs.set(originalArgs + ["--require", envScript.absolutePath])
-            }
+        tasks.matching { it.name == taskName }.configureEach {
+            def originalArgs = nodeExecutableAndArgs.get().toList()
+            def envScript = file("${buildDir}/metro-env-${variant.name}.js")
+            envScript.parentFile.mkdirs()
+            envScript.text = "process.env.ONLINE_BUILD = '${isFull ? 'true' : 'false'}';\n"
+            nodeExecutableAndArgs.set(originalArgs + ["--require", envScript.absolutePath])
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix release build failing with `Cannot find module '.../metro-env-fullRelease.js'`: the env script was never created because `tasks.findByName` returns `null` for lazily-registered tasks; replaced with `tasks.matching { }.configureEach` which fires when the task is eventually registered
- Bump GitHub Actions to Node.js 24-compatible versions: `checkout@v4` -> `v6`, `setup-node@v4` -> `v6`, `setup-java@v4` -> `v5`; pin `node-version` to `22` (active LTS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across CI and release workflows
  * Upgraded Node.js runtime from version 20 to 22 in automated builds

* **Bug Fixes**
  * Fixed issue with bundle task initialization in Gradle-based builds

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->