### PR TITLE
ci: remove Kotlin lint step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-
       - name: Lint
         run: npm run lint
-
-      - name: Kotlin lint
-        working-directory: android
-        run: ./gradlew ktlintCheck
 
       - name: Run tests with coverage
         run: npm test -- --watchAll=false --coverage --coverageReporters=lcov --coverageReporters=text-summary


### PR DESCRIPTION
- remove Kotlin lint step from CI workflow. There's a local script to run it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI workflow configuration for the code quality and linting process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->