### PR TITLE
fix: write Metro env script in doFirst to survive clean task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Metro env script deleted by preceding `clean` task before the bundle task executes; move file write to `doFirst` so it runs at execution time
+
 ## [1.6.1] - 2026-05-12
 
 ### Changed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -172,11 +172,14 @@ afterEvaluate {
         def isFull = variant.productFlavors.any { it.name == "full" }
         def taskName = "createBundle${variant.name.capitalize()}JsAndAssets"
         tasks.matching { it.name == taskName }.configureEach {
-            def originalArgs = nodeExecutableAndArgs.get().toList()
             def envScript = file("${buildDir}/metro-env-${variant.name}.js")
-            envScript.parentFile.mkdirs()
-            envScript.text = "process.env.ONLINE_BUILD = '${isFull ? 'true' : 'false'}';\n"
-            nodeExecutableAndArgs.set(originalArgs + ["--require", envScript.absolutePath])
+            // Set --require at configuration time; write the file in doFirst so
+            // it survives a preceding `clean` task that would delete build/.
+            nodeExecutableAndArgs.set(nodeExecutableAndArgs.get().toList() + ["--require", envScript.absolutePath])
+            doFirst {
+                envScript.parentFile.mkdirs()
+                envScript.text = "process.env.ONLINE_BUILD = '${isFull ? 'true' : 'false'}';\n"
+            }
         }
     }
 }


### PR DESCRIPTION
The script was written during Gradle configuration phase, then deleted by the preceding `clean` task before the bundle task executed. Moving the write to `doFirst` ensures it runs at execution time, after clean completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the build process would fail due to temporary build files being incorrectly removed during cleanup operations, preventing successful app bundling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->