### PR TITLE
chore: bump version to 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-05-13
+
 ### Fixed
 
 - Fix Metro env script deleted by preceding `clean` task before the bundle task executes; move file write to `doFirst` so it runs at execution time
@@ -230,7 +232,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Signing transaction with Keycard
 - Scan back result QR code into the compatible Ethereum wallet
 
-[Unreleased]: https://github.com/mmlado/GapSign/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/mmlado/GapSign/compare/v1.6.2...HEAD
+[1.6.2]: https://github.com/mmlado/GapSign/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/mmlado/GapSign/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/mmlado/GapSign/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/mmlado/GapSign/compare/v1.4.0...v1.5.0

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "tech.gapsign"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10601
-        versionName "1.6.1"
+        versionCode 10602
+        versionName "1.6.2"
     }
     flavorDimensions "distribution"
     productFlavors {

--- a/fastlane/metadata/android/en-US/changelogs/10602.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10602.txt
@@ -1,0 +1,1 @@
+Fix Metro env script deleted by preceding `clean` task before the bundle task executes; move file write to `doFirst` so it runs at execution time

--- a/fdroiddata-tech.gapsign.yml
+++ b/fdroiddata-tech.gapsign.yml
@@ -39,9 +39,9 @@ RepoType: git
 Repo: https://github.com/mmlado/GapSign
 
 Builds:
-  - versionName: 1.6.1
-    versionCode: 10601
-    commit: v1.6.1
+  - versionName: 1.6.2
+    versionCode: 10602
+    commit: v1.6.2
     subdir: android/app
     sudo:
       - apt-get install -y openjdk-17-jdk
@@ -60,5 +60,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.6.1
-CurrentVersionCode: 10601
+CurrentVersion: 1.6.2
+CurrentVersionCode: 10602

--- a/ios/GapSign.xcodeproj/project.pbxproj
+++ b/ios/GapSign.xcodeproj/project.pbxproj
@@ -288,7 +288,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GapSign/GapSign.entitlements;
-				CURRENT_PROJECT_VERSION = 10601;
+				CURRENT_PROJECT_VERSION = 10602;
 				DEVELOPMENT_TEAM = 53Q5365S97;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = GapSign/Info.plist;
@@ -297,7 +297,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -324,7 +324,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GapSign/GapSign.entitlements;
-				CURRENT_PROJECT_VERSION = 10601;
+				CURRENT_PROJECT_VERSION = 10602;
 				DEVELOPMENT_TEAM = 53Q5365S97;
 				INFOPLIST_FILE = GapSign/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -332,7 +332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "GapSign",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "GapSign",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ethereumjs/rlp": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GapSign",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "scripts": {
     "android": "ONLINE_BUILD=true react-native run-android --mode fullDebug",


### PR DESCRIPTION
- bump version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Metro environment script handling in the Android build pipeline.

* **Chores**
  * Updated application version to 1.6.2 across Android, iOS, and package distributions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->