### PR TITLE
refactor: extract usePinPadScramble hook from PinPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Extract `usePinPadScramble` hook from `PinPad`; preference loading is no longer inlined in the component
+
 ## [1.6.2] - 2026-05-13
 
 ### Fixed

--- a/__tests__/InitCardScreen.test.tsx
+++ b/__tests__/InitCardScreen.test.tsx
@@ -69,7 +69,9 @@ function hookMock(phase: string) {
 
 async function renderScreen(phase = 'idle') {
   mockUseInitCard.mockReturnValue(hookMock(phase));
-  const result = render(<InitCardScreen navigation={navigation} route={route} />);
+  const result = render(
+    <InitCardScreen navigation={navigation} route={route} />,
+  );
   await act(async () => {});
   return result;
 }

--- a/__tests__/PinPad.test.tsx
+++ b/__tests__/PinPad.test.tsx
@@ -290,9 +290,6 @@ describe('PinPad', () => {
     });
 
     it('does not reshuffle on error when scramble is disabled', async () => {
-      jest
-        .requireMock('../src/storage/preferencesStorage')
-        .loadBooleanPreference.mockResolvedValue(false);
       const { rerender, toJSON } = render(<PinPad onComplete={onComplete} />);
       await act(async () => {});
       const before = getDigitOrder(toJSON());

--- a/__tests__/usePinPadScramble.test.ts
+++ b/__tests__/usePinPadScramble.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { usePinPadScramble } from '../src/hooks/usePinPadScramble';
+
+jest.mock('../src/storage/preferencesStorage', () => ({
+  loadBooleanPreference: jest.fn().mockResolvedValue(false),
+  preferenceKeys: { pinPadScramble: 'preference_pinpad_scramble' },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .requireMock('../src/storage/preferencesStorage')
+    .loadBooleanPreference.mockResolvedValue(false);
+});
+
+it('returns false by default', async () => {
+  const { result } = renderHook(() => usePinPadScramble());
+  await act(async () => {});
+  expect(result.current).toBe(false);
+});
+
+it('returns true when preference is enabled', async () => {
+  jest
+    .requireMock('../src/storage/preferencesStorage')
+    .loadBooleanPreference.mockResolvedValue(true);
+  const { result } = renderHook(() => usePinPadScramble());
+  await act(async () => {});
+  expect(result.current).toBe(true);
+});
+
+it('falls back to false when storage throws', async () => {
+  jest
+    .requireMock('../src/storage/preferencesStorage')
+    .loadBooleanPreference.mockRejectedValue(new Error('storage error'));
+  const { result } = renderHook(() => usePinPadScramble());
+  await act(async () => {});
+  expect(result.current).toBe(false);
+});
+
+it('does not update state after unmount', async () => {
+  let resolve!: (v: boolean) => void;
+  jest
+    .requireMock('../src/storage/preferencesStorage')
+    .loadBooleanPreference.mockReturnValue(new Promise(r => { resolve = r; }));
+  const { result, unmount } = renderHook(() => usePinPadScramble());
+  unmount();
+  await act(async () => { resolve(true); });
+  expect(result.current).toBe(false);
+});

--- a/src/components/PinPad/index.tsx
+++ b/src/components/PinPad/index.tsx
@@ -1,12 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import {
-  loadBooleanPreference,
-  preferenceKeys,
-} from '../../storage/preferencesStorage';
 import theme from '../../theme';
 
+import { usePinPadScramble } from '../../hooks/usePinPadScramble';
 import Keypad from './Keypad';
 import PinInput from './PinInput';
 
@@ -57,19 +54,15 @@ export default function PinPad({
   onType,
   length = PIN_LENGTH,
 }: PinPadProps) {
+  const scramble = usePinPadScramble();
   const normalizedLength = normalizePinLength(length);
   const [pin, setPin] = useState('');
-  const [scramble, setScramble] = useState(false);
   const [padKeys, setPadKeys] = useState(fixedKeys);
   const prevError = useRef(error);
   const pinRef = useRef('');
   const lengthRef = useRef(length);
   const onCompleteRef = useRef(onComplete);
   const onTypeRef = useRef(onType);
-
-  useEffect(() => {
-    loadBooleanPreference(preferenceKeys.pinPadScramble).then(setScramble);
-  }, []);
 
   useEffect(() => {
     if (scramble) {

--- a/src/hooks/usePinPadScramble.ts
+++ b/src/hooks/usePinPadScramble.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+import {
+  loadBooleanPreference,
+  preferenceKeys,
+} from '../storage/preferencesStorage';
+
+export function usePinPadScramble(): boolean {
+  const [scramble, setScramble] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    loadBooleanPreference(preferenceKeys.pinPadScramble)
+      .then(value => { if (mounted) setScramble(value); })
+      .catch(() => { if (mounted) setScramble(false); });
+    return () => { mounted = false; };
+  }, []);
+
+  return scramble;
+}


### PR DESCRIPTION
## Summary

- Moves the `preference_pinpad_scramble` AsyncStorage load out of `PinPad` into a dedicated `usePinPadScramble` hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * PIN pad scramble preference handling moved out of the component into a dedicated module for cleaner separation.

* **Tests**
  * Added tests covering scramble preference behavior (true/false/error) and ensured state is stable after unmount.
  * Updated existing tests for setup/formatting consistency.

* **Documentation**
  * Changelog updated to note the preference handling change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/180)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->