### PR TITLE
refactor: extract keycardTlv module from btcMessage, btcPsbt, cryptoMultiAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Extract `usePinPadScramble` hook from `PinPad`; preference loading is no longer inlined in the component
+- Extract `keycardTlv.ts` with shared DER/TLV constants and `parseDerSignature`; removes duplication across `btcMessage`, `btcPsbt`, and `cryptoMultiAccounts`
 
 ## [1.6.2] - 2026-05-13
 

--- a/__tests__/keycardTlv.test.ts
+++ b/__tests__/keycardTlv.test.ts
@@ -1,0 +1,34 @@
+import { SCALAR_BYTES, derIntTo32 } from '../src/utils/keycardTlv';
+
+describe('derIntTo32', () => {
+  it('returns a 32-byte value unchanged', () => {
+    const input = new Uint8Array(SCALAR_BYTES).fill(0xab);
+    expect(derIntTo32(input)).toBe(input);
+  });
+
+  it('strips a leading 0x00 padding byte', () => {
+    const value = new Uint8Array(SCALAR_BYTES).fill(0x01);
+    const input = new Uint8Array([0x00, ...value]);
+    const result = derIntTo32(input);
+    expect(result).toEqual(value);
+    expect(result.length).toBe(SCALAR_BYTES);
+  });
+
+  it('left-pads a short integer to 32 bytes', () => {
+    const input = new Uint8Array([0x01]);
+    const result = derIntTo32(input);
+    expect(result.length).toBe(SCALAR_BYTES);
+    expect(result[SCALAR_BYTES - 1]).toBe(0x01);
+    expect(result.slice(0, SCALAR_BYTES - 1).every(b => b === 0)).toBe(true);
+  });
+
+  it('throws RangeError for empty input after stripping', () => {
+    expect(() => derIntTo32(new Uint8Array([0x00]))).toThrow(RangeError);
+  });
+
+  it('throws RangeError for oversized input', () => {
+    expect(() =>
+      derIntTo32(new Uint8Array(SCALAR_BYTES + 1).fill(0x01)),
+    ).toThrow(RangeError);
+  });
+});

--- a/src/utils/btcMessage.ts
+++ b/src/utils/btcMessage.ts
@@ -9,16 +9,13 @@ import { UR, UREncoder } from '@ngraveio/bc-ur';
 import { sha256 } from '@noble/hashes/sha2.js';
 import Keycard from 'keycard-sdk';
 
+import { parseDerSignature } from './keycardTlv';
+
 const BTC_MESSAGE_SIGNATURE_TYPE = 'btc-signature';
 const BTC_SIGN_REQUEST_UUID_TAG = RegistryTypes.UUID.getTag();
 const BTC_SIGN_REQUEST_KEYPATH_TAG = RegistryTypes.CRYPTO_KEYPATH.getTag();
 const BTC_MESSAGE_DATA_TYPE = 1;
 const BTC_MESSAGE_SIGNATURE_HEADER = 27 + 4;
-const TLV_SIGNATURE_TEMPLATE = 0xa0;
-const TLV_PUB_KEY = 0x80;
-const TLV_ECDSA_TEMPLATE = 0x30;
-const TLV_INTEGER = 0x02;
-const SCALAR_BYTES = 32;
 
 enum BtcSignRequestKeys {
   requestId = 1,
@@ -43,17 +40,6 @@ export type BtcSignRequest = {
   address?: string;
   origin?: string;
 };
-
-function derIntTo32(bytes: Uint8Array): Uint8Array {
-  const stripped = bytes[0] === 0x00 ? bytes.slice(1) : bytes;
-  if (stripped.length === SCALAR_BYTES) {
-    return stripped;
-  }
-
-  const padded = new Uint8Array(SCALAR_BYTES);
-  padded.set(stripped, SCALAR_BYTES - stripped.length);
-  return padded;
-}
 
 function formatRequestId(requestId: DataItem | Buffer | string): string {
   if (requestId instanceof DataItem) {
@@ -174,14 +160,7 @@ export function parseKeycardBtcMessageSignature(
     hash,
     tlvData: data,
   });
-  const tlv = new Keycard.BERTLV(data);
-  tlv.enterConstructed(TLV_SIGNATURE_TEMPLATE);
-  const publicKey = Buffer.from(
-    Keycard.CryptoUtils.compressPublicKey(tlv.readPrimitive(TLV_PUB_KEY)),
-  );
-  tlv.enterConstructed(TLV_ECDSA_TEMPLATE);
-  const r = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
-  const s = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
+  const { publicKey, r, s } = parseDerSignature(data);
 
   return {
     signature: Buffer.concat([

--- a/src/utils/btcPsbt.ts
+++ b/src/utils/btcPsbt.ts
@@ -4,13 +4,7 @@ import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
 import { pubKeyFingerprint } from './cryptoAccount';
-
-const TLV_SIGNATURE_TEMPLATE = 0xa0;
-const TLV_PUB_KEY = 0x80;
-const TLV_ECDSA_TEMPLATE = 0x30;
-const TLV_INTEGER = 0x02;
-const TLV_KEY_TEMPLATE = 0xa1;
-const SCALAR_BYTES = 32;
+import { TLV_KEY_TEMPLATE, TLV_PUB_KEY, parseDerSignature } from './keycardTlv';
 
 type NetworkName = 'mainnet' | 'testnet' | 'unknown';
 
@@ -42,17 +36,6 @@ type SignableInput = {
   pubkey: Buffer;
   sighashType?: number;
 };
-
-function derIntTo32(bytes: Uint8Array): Uint8Array {
-  const stripped = bytes[0] === 0x00 ? bytes.slice(1) : bytes;
-  if (stripped.length === SCALAR_BYTES) {
-    return stripped;
-  }
-
-  const padded = new Uint8Array(SCALAR_BYTES);
-  padded.set(stripped, SCALAR_BYTES - stripped.length);
-  return padded;
-}
 
 function toPsbt(psbtHex: string): Psbt {
   return Psbt.fromBuffer(Buffer.from(psbtHex, 'hex'));
@@ -169,15 +152,7 @@ function isChangeOutput(output: Psbt['data']['outputs'][number]): boolean {
 }
 
 function parseKeycardSignature(data: Uint8Array): KeycardSignature {
-  const tlv = new Keycard.BERTLV(data);
-  tlv.enterConstructed(TLV_SIGNATURE_TEMPLATE);
-  const publicKey = Buffer.from(
-    Keycard.CryptoUtils.compressPublicKey(tlv.readPrimitive(TLV_PUB_KEY)),
-  );
-  tlv.enterConstructed(TLV_ECDSA_TEMPLATE);
-  const r = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
-  const s = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
-
+  const { publicKey, r, s } = parseDerSignature(data);
   return {
     publicKey,
     signature: Buffer.concat([Buffer.from(r), Buffer.from(s)]),

--- a/src/utils/cryptoMultiAccounts.ts
+++ b/src/utils/cryptoMultiAccounts.ts
@@ -10,6 +10,7 @@ import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
 import { pubKeyFingerprint } from './cryptoAccount';
+import { TLV_KEY_TEMPLATE, TLV_PUB_KEY } from './keycardTlv';
 import {
   derivationPathToKeypath,
   numberToFingerprintBuffer,
@@ -56,9 +57,6 @@ const BITGET_KEYS: MultiAccountKey[] = [
     source: EIP4527_STANDARD,
   },
 ];
-
-const TLV_KEY_TEMPLATE = 0xa1;
-const TLV_PUB_KEY = 0x80;
 
 export type BitgetExportResult = {
   masterFingerprint: number;

--- a/src/utils/keycardTlv.ts
+++ b/src/utils/keycardTlv.ts
@@ -1,0 +1,41 @@
+import Keycard from 'keycard-sdk';
+
+export const TLV_SIGNATURE_TEMPLATE = 0xa0;
+export const TLV_KEY_TEMPLATE = 0xa1;
+export const TLV_PUB_KEY = 0x80;
+export const TLV_ECDSA_TEMPLATE = 0x30;
+export const TLV_INTEGER = 0x02;
+export const SCALAR_BYTES = 32;
+
+export function derIntTo32(bytes: Uint8Array): Uint8Array {
+  const stripped = bytes[0] === 0x00 ? bytes.slice(1) : bytes;
+  if (stripped.length === 0 || stripped.length > SCALAR_BYTES) {
+    throw new RangeError(
+      `DER integer has invalid length ${stripped.length} (expected 1–${SCALAR_BYTES})`,
+    );
+  }
+  if (stripped.length === SCALAR_BYTES) {
+    return stripped;
+  }
+  const padded = new Uint8Array(SCALAR_BYTES);
+  padded.set(stripped, SCALAR_BYTES - stripped.length);
+  return padded;
+}
+
+export type ParsedDerSignature = {
+  publicKey: Buffer;
+  r: Uint8Array;
+  s: Uint8Array;
+};
+
+export function parseDerSignature(data: Uint8Array): ParsedDerSignature {
+  const tlv = new Keycard.BERTLV(data);
+  tlv.enterConstructed(TLV_SIGNATURE_TEMPLATE);
+  const publicKey = Buffer.from(
+    Keycard.CryptoUtils.compressPublicKey(tlv.readPrimitive(TLV_PUB_KEY)),
+  );
+  tlv.enterConstructed(TLV_ECDSA_TEMPLATE);
+  const r = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
+  const s = derIntTo32(tlv.readPrimitive(TLV_INTEGER));
+  return { publicKey, r, s };
+}


### PR DESCRIPTION
## Summary

- `TLV_SIGNATURE_TEMPLATE`, `TLV_KEY_TEMPLATE`, `TLV_PUB_KEY`, `TLV_ECDSA_TEMPLATE`, `TLV_INTEGER`, `SCALAR_BYTES`, and `derIntTo32` were defined identically in `btcMessage.ts` and `btcPsbt.ts`; `TLV_KEY_TEMPLATE` and `TLV_PUB_KEY` were also duplicated in `cryptoMultiAccounts.ts`
- Extracts `src/utils/keycardTlv.ts` with all shared constants, `derIntTo32`, and `parseDerSignature` (the common BERTLV parse pattern for Keycard ECDSA responses)
- All three files now import from `keycardTlv`; no behaviour change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to enhance maintainability.

* **Tests**
  * Added new test coverage for signature processing utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/181)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->