### PR TITLE
refactor: consolidate UR encoding into a shared encodeToUR helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Extract `usePinPadScramble` hook from `PinPad`; preference loading is no longer inlined in the component
 - Extract `keycardTlv.ts` with shared DER/TLV constants and `parseDerSignature`; removes duplication across `btcMessage`, `btcPsbt`, and `cryptoMultiAccounts`
 - Support `@/` import alias for `src/` to eliminate deep relative paths across the codebase
+- Extract `encodeToUR` helper to `ur.ts`; consolidate repeated `new UREncoder(new UR(...))` pattern across `btcMessage`, `cryptoAccount`, `cryptoHdKey`, `cryptoMultiAccounts`, and `btcPsbt`; move `buildBtcResultUR` out of `KeycardScreen` into `btcPsbt` as `buildCryptoPsbtUR`
 
 ## [1.6.2] - 2026-05-13
 

--- a/__tests__/DataTabPanel.test.tsx
+++ b/__tests__/DataTabPanel.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import EthDataTabPanel from '../src/components/SignRequestDetail/eth/DataTabPanel';
+import type { EthSignRequest } from '../src/types';
+import type { ParsedTx } from '../src/utils/txParser';
+
+jest.mock('react-native-paper', () => {
+  const { Text, TouchableOpacity, View } = require('react-native');
+  return {
+    Text: ({ children, ...props }: any) => <Text {...props}>{children}</Text>,
+    SegmentedButtons: ({
+      buttons,
+      onValueChange,
+    }: {
+      value: string;
+      onValueChange: (v: string) => void;
+      buttons: { value: string; label: string }[];
+    }) => (
+      <View>
+        {buttons.map((b: any) => (
+          <TouchableOpacity
+            key={b.value}
+            onPress={() => onValueChange(b.value)}
+          >
+            <Text>{b.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    ),
+  };
+});
+
+jest.mock('../src/theme', () => ({
+  __esModule: true,
+  default: { colors: { onSurfaceVariant: '#aaa', negative: '#f00' } },
+}));
+
+jest.mock('../src/components/InfoRow', () => {
+  const { Text } = require('react-native');
+  return ({ label, value }: { label: string; value: string }) => (
+    <Text>{`${label}: ${value}`}</Text>
+  );
+});
+
+jest.mock('../src/components/ens/AddressInfoRow.online', () => {
+  const { Text } = require('react-native');
+  return ({ label, value }: { label: string; value: string }) => (
+    <Text>{`${label}: ${value}`}</Text>
+  );
+});
+
+jest.mock(
+  '../src/components/SignRequestDetail/eth/DataTabPanel/DecodedCallSection',
+  () => {
+    const { Text } = require('react-native');
+    return () => <Text>DecodedCallSection</Text>;
+  },
+);
+
+jest.mock(
+  '../src/components/SignRequestDetail/eth/DataTabPanel/SpecialEip712Section',
+  () => {
+    const { Text } = require('react-native');
+    return () => <Text>SpecialEip712Section</Text>;
+  },
+);
+
+jest.mock('../src/utils/erc8213', () => ({
+  computeCalldataDigest: () => '0x' + 'ab'.repeat(32),
+  computeEip712DigestFromJson: () => '0x' + 'cd'.repeat(32),
+  computeEip712DigestFromPrehashed: () => '0x' + 'ef'.repeat(32),
+}));
+
+const LEGACY_TX_HEX =
+  'e9018504a817c80082520894d3cda913deb6f4967b2ef3aa68f5a843da74c4ef8806f05b59d3b2000080018080';
+
+const request: EthSignRequest = {
+  signData: LEGACY_TX_HEX,
+  dataType: 1,
+  derivationPath: "m/44'/60'/0'/0",
+};
+
+describe('EthDataTabPanel dispatch', () => {
+  it('renders TxDataPanel (Digests tab) for a pure ETH transfer with no calldata', () => {
+    const tx: ParsedTx = {
+      to: '0xd3CdA913deB6f4967b2Ef3aa68f5A843dA74C4ef',
+      fees: { kind: 'unknown' },
+    };
+    render(
+      <EthDataTabPanel
+        request={request}
+        tx={tx}
+        eip712={null}
+        eip712Prehashed={null}
+        chainId={1}
+      />,
+    );
+    expect(screen.getByText('Digests')).toBeTruthy();
+    expect(screen.getByText('Raw')).toBeTruthy();
+  });
+
+  it('falls back to raw InfoRow when tx is null and no eip712', () => {
+    render(
+      <EthDataTabPanel
+        request={request}
+        tx={null}
+        eip712={null}
+        eip712Prehashed={null}
+        chainId={1}
+      />,
+    );
+    expect(screen.getByText(new RegExp(LEGACY_TX_HEX))).toBeTruthy();
+  });
+});

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -40,6 +40,7 @@ jest.mock('../src/utils/btcPsbt', () => ({
   BtcSigningSession: jest.fn().mockImplementation(() => ({
     signWithKeycard: jest.fn().mockResolvedValue({ psbtHex: 'deadbeef' }),
   })),
+  buildCryptoPsbtUR: jest.fn(() => 'ur:crypto-psbt/mock'),
   inspectBtcPsbt: jest.fn(),
 }));
 

--- a/__tests__/btcPsbt.test.ts
+++ b/__tests__/btcPsbt.test.ts
@@ -1,7 +1,10 @@
 import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
 
+import { URDecoder } from '@ngraveio/bc-ur';
+
 import {
   BtcSigningSession,
+  buildCryptoPsbtUR,
   inspectBtcPsbt,
   parseCryptoPsbtRequest,
 } from '../src/utils/btcPsbt';
@@ -330,5 +333,25 @@ describe('BtcSigningSession', () => {
       'Taproot inputs are not supported yet.',
     );
     expect(cmdSet.signWithPath).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCryptoPsbtUR
+// ---------------------------------------------------------------------------
+
+describe('buildCryptoPsbtUR', () => {
+  it('returns a UR string with crypto-psbt type prefix', () => {
+    const result = buildCryptoPsbtUR(MINIMAL_PSBT_HEX);
+    expect(result).toMatch(/^ur:crypto-psbt\//i);
+  });
+
+  it('produces output decodable back to the same PSBT bytes', () => {
+    const result = buildCryptoPsbtUR(MINIMAL_PSBT_HEX);
+    const decoder = new URDecoder();
+    decoder.receivePart(result);
+    expect(decoder.isComplete()).toBe(true);
+    const decoded = CryptoPSBT.fromCBOR(decoder.resultUR().cbor);
+    expect(decoded.getPSBT().toString('hex')).toBe(MINIMAL_PSBT_HEX);
   });
 });

--- a/__tests__/erc8213.test.ts
+++ b/__tests__/erc8213.test.ts
@@ -37,8 +37,6 @@ describe('computeCalldataDigest', () => {
   it('returns null for odd-length calldata', () => {
     expect(computeCalldataDigest('0xabc')).toBeNull();
   });
-
-
 });
 
 describe('computeEip712DigestFromJson', () => {

--- a/__tests__/ur.test.ts
+++ b/__tests__/ur.test.ts
@@ -9,7 +9,7 @@ import {
 import { EthSignRequest } from '@keystonehq/bc-ur-registry-eth';
 import { URDecoder } from '@ngraveio/bc-ur';
 
-import { handleUR } from '../src/utils/ur';
+import { encodeToUR, handleUR } from '../src/utils/ur';
 import { DATA_TYPE_LABELS } from '../src/types';
 
 const VALID_EIP1559_TX_HEX =
@@ -299,6 +299,31 @@ describe('handleUR – btc-sign-request', () => {
     if (result.kind === 'error') {
       expect(result.message).toMatch(/Unsupported btc-sign-request data type/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// encodeToUR
+// ---------------------------------------------------------------------------
+
+describe('encodeToUR', () => {
+  it('returns a UR string with the given type prefix', () => {
+    const cbor = new CryptoPSBT(
+      Buffer.from('70736274ff01000a0200000000000000000000', 'hex'),
+    ).toCBOR();
+    const result = encodeToUR('crypto-psbt', cbor);
+    expect(result).toMatch(/^ur:crypto-psbt\//i);
+  });
+
+  it('produces output decodable by URDecoder', () => {
+    const cbor = new CryptoPSBT(
+      Buffer.from('70736274ff01000a0200000000000000000000', 'hex'),
+    ).toCBOR();
+    const encoded = encodeToUR('crypto-psbt', cbor);
+    const decoder = new URDecoder();
+    decoder.receivePart(encoded);
+    expect(decoder.isComplete()).toBe(true);
+    expect(decoder.resultUR().type).toBe('crypto-psbt');
   });
 });
 

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { CryptoPSBT } from '@keystonehq/bc-ur-registry';
-import { UR, UREncoder } from '@ngraveio/bc-ur';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { KeycardScreenProps } from '../navigation/types';
@@ -16,7 +14,7 @@ import {
   hashBitcoinMessage,
   parseKeycardBtcMessageSignature,
 } from '../utils/btcMessage';
-import { BtcSigningSession } from '../utils/btcPsbt';
+import { BtcSigningSession, buildCryptoPsbtUR } from '../utils/btcPsbt';
 import { buildEthSignatureUR } from '../utils/ethSignature';
 import {
   buildExportUr,
@@ -50,16 +48,6 @@ function buildEthResultUR(
     params.requestId,
     txType,
   );
-}
-
-function buildBtcResultUR(psbtHex: string): string {
-  const psbt = new CryptoPSBT(Buffer.from(psbtHex, 'hex'));
-  const cbor = psbt.toCBOR();
-  const type = psbt.getRegistryType().getType();
-  return new UREncoder(
-    new UR(cbor, type),
-    Math.max(cbor.length, 100),
-  ).nextPart();
 }
 
 export default function KeycardScreen({
@@ -205,7 +193,7 @@ export default function KeycardScreen({
     ) {
       return;
     }
-    navigateToSignResult(buildBtcResultUR(result.psbtHex));
+    navigateToSignResult(buildCryptoPsbtUR(result.psbtHex));
   }, [result, navigateToSignResult]);
 
   const handleBtcMessageSignDone = useCallback(() => {

--- a/src/utils/btcMessage.ts
+++ b/src/utils/btcMessage.ts
@@ -5,7 +5,7 @@ import {
   decodeToDataItem,
   encodeDataItem,
 } from '@keystonehq/bc-ur-registry';
-import { UR, UREncoder } from '@ngraveio/bc-ur';
+import { encodeToUR } from './ur';
 import { sha256 } from '@noble/hashes/sha2.js';
 import Keycard from 'keycard-sdk';
 
@@ -188,8 +188,5 @@ export function buildBtcSignatureUR(args: {
     }),
   );
 
-  return new UREncoder(
-    new UR(cbor, BTC_MESSAGE_SIGNATURE_TYPE),
-    Math.max(cbor.length, 100),
-  ).nextPart();
+  return encodeToUR(BTC_MESSAGE_SIGNATURE_TYPE, cbor);
 }

--- a/src/utils/btcPsbt.ts
+++ b/src/utils/btcPsbt.ts
@@ -5,6 +5,7 @@ import type { Commandset } from 'keycard-sdk/dist/commandset';
 
 import { pubKeyFingerprint } from './cryptoAccount';
 import { TLV_KEY_TEMPLATE, TLV_PUB_KEY, parseDerSignature } from './keycardTlv';
+import { encodeToUR } from './ur';
 
 type NetworkName = 'mainnet' | 'testnet' | 'unknown';
 
@@ -324,4 +325,11 @@ export class BtcSigningSession {
       totalInputs: signableInputs.length,
     };
   }
+}
+
+export function buildCryptoPsbtUR(psbtHex: string): string {
+  const psbt = new CryptoPSBT(Buffer.from(psbtHex, 'hex'));
+  const cbor = psbt.toCBOR();
+  const type = psbt.getRegistryType().getType();
+  return encodeToUR(type, cbor);
 }

--- a/src/utils/cryptoAccount.ts
+++ b/src/utils/cryptoAccount.ts
@@ -8,7 +8,7 @@ import {
   CryptoOutput,
   ScriptExpressions,
 } from '@keystonehq/bc-ur-registry';
-import { UR, UREncoder } from '@ngraveio/bc-ur';
+import { encodeToUR } from './ur';
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import Keycard from 'keycard-sdk';
@@ -115,8 +115,5 @@ export function buildCryptoAccountUR(account: BitcoinCryptoAccount): string {
 
   const cbor = cryptoAccount.toCBOR();
   const type = cryptoAccount.getRegistryType().getType();
-  return new UREncoder(
-    new UR(cbor, type),
-    Math.max(cbor.length, 100),
-  ).nextPart();
+  return encodeToUR(type, cbor);
 }

--- a/src/utils/cryptoHdKey.ts
+++ b/src/utils/cryptoHdKey.ts
@@ -3,7 +3,7 @@ import {
   CryptoKeypath,
   PathComponent,
 } from '@keystonehq/bc-ur-registry';
-import { UR, UREncoder } from '@ngraveio/bc-ur';
+import { encodeToUR } from './ur';
 import Keycard from 'keycard-sdk';
 
 import {
@@ -51,8 +51,5 @@ export function buildCryptoHdKeyUR(
 
   const cbor = hdKey.toCBOR();
   const type = hdKey.getRegistryType().getType();
-  return new UREncoder(
-    new UR(cbor, type),
-    Math.max(cbor.length, 100),
-  ).nextPart();
+  return encodeToUR(type, cbor);
 }

--- a/src/utils/cryptoMultiAccounts.ts
+++ b/src/utils/cryptoMultiAccounts.ts
@@ -5,7 +5,7 @@ import {
   CryptoHDKey,
   CryptoMultiAccounts,
 } from '@keystonehq/bc-ur-registry';
-import { UR, UREncoder } from '@ngraveio/bc-ur';
+import { encodeToUR } from './ur';
 import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
@@ -140,8 +140,5 @@ export function buildCryptoMultiAccountsUR(result: BitgetExportResult): string {
 
   const cbor = cryptoMultiAccounts.toCBOR();
   const type = cryptoMultiAccounts.getRegistryType().getType();
-  return new UREncoder(
-    new UR(cbor, type),
-    Math.max(cbor.length, 100),
-  ).nextPart();
+  return encodeToUR(type, cbor);
 }

--- a/src/utils/ur.ts
+++ b/src/utils/ur.ts
@@ -1,4 +1,5 @@
 import { EthSignRequest } from '@keystonehq/bc-ur-registry-eth';
+import { UR, UREncoder } from '@ngraveio/bc-ur';
 
 import type {
   EthSignRequest as EthSignRequestType,
@@ -40,6 +41,13 @@ function parseEthSignRequest(cbor: Buffer): EthSignRequestType {
       : undefined,
     origin: parsed.getOrigin(),
   };
+}
+
+export function encodeToUR(type: string, cbor: Buffer): string {
+  return new UREncoder(
+    new UR(cbor, type),
+    Math.max(cbor.length, 100),
+  ).nextPart();
 }
 
 export function handleUR(type: string, cbor: Buffer): ScanResult {


### PR DESCRIPTION
## Summary

- Add `encodeToUR(type, cbor)` to `ur.ts`: the `new UREncoder(new UR(cbor, type), Math.max(cbor.length, 100)).nextPart()` pattern was repeated in five places with no variation
- Remove `UR` / `UREncoder` imports from `btcMessage`, `cryptoAccount`, `cryptoHdKey`, `cryptoMultiAccounts`, all now call `encodeToUR`
- Move `buildBtcResultUR` out of `KeycardScreen` (it was an inline private function with no tests) into `btcPsbt.ts` as `buildCryptoPsbtUR`
- `KeycardScreen` now imports `buildCryptoPsbtUR` from `btcPsbt` and has no direct UR dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated and centralized UR encoding helpers to improve code maintainability and reduce duplication across modules.

* **Tests**
  * Added comprehensive test coverage for UR encoding, ETH data panel rendering, PSBT handling, and edge cases in digest computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->