### PR TITLE
refactor: extract buildSignKeycardParams from TransactionDetailScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Extract `keycardTlv.ts` with shared DER/TLV constants and `parseDerSignature`; removes duplication across `btcMessage`, `btcPsbt`, and `cryptoMultiAccounts`
 - Support `@/` import alias for `src/` to eliminate deep relative paths across the codebase
 - Extract `encodeToUR` helper to `ur.ts`; consolidate repeated `new UREncoder(new UR(...))` pattern across `btcMessage`, `cryptoAccount`, `cryptoHdKey`, `cryptoMultiAccounts`, and `btcPsbt`; move `buildBtcResultUR` out of `KeycardScreen` into `btcPsbt` as `buildCryptoPsbtUR`
+- Extract `buildSignKeycardParams` to `src/utils/signNavigation.ts`; remove result-kind dispatch from `TransactionDetailScreen.handleSign`
 
 ## [1.6.2] - 2026-05-13
 

--- a/__tests__/signNavigation.test.ts
+++ b/__tests__/signNavigation.test.ts
@@ -1,0 +1,71 @@
+import { buildSignKeycardParams } from '../src/utils/signNavigation';
+import type { ScanResult } from '../src/types';
+
+describe('buildSignKeycardParams', () => {
+  it('returns eth params for eth-sign-request', () => {
+    const result: ScanResult = {
+      kind: 'eth-sign-request',
+      request: {
+        signData: 'aabbccdd',
+        dataType: 1,
+        derivationPath: "m/44'/60'/0'/0",
+        chainId: 1,
+        requestId: 'req-1',
+      },
+    };
+    expect(buildSignKeycardParams(result)).toEqual({
+      operation: 'sign',
+      signMode: 'eth',
+      signData: 'aabbccdd',
+      derivationPath: "m/44'/60'/0'/0",
+      chainId: 1,
+      requestId: 'req-1',
+      dataType: 1,
+    });
+  });
+
+  it('returns btc params for crypto-psbt', () => {
+    const result: ScanResult = {
+      kind: 'crypto-psbt',
+      request: { psbtHex: 'deadbeef' },
+    };
+    expect(buildSignKeycardParams(result)).toEqual({
+      operation: 'sign',
+      signMode: 'btc',
+      psbtHex: 'deadbeef',
+    });
+  });
+
+  it('returns btc-message params for btc-sign-request', () => {
+    const result: ScanResult = {
+      kind: 'btc-sign-request',
+      request: {
+        requestId: 'req-2',
+        signDataHex: 'cafebabe',
+        dataType: 1,
+        derivationPath: "m/84'/0'/0'/0/0",
+        address: 'bc1qexample',
+        origin: 'Sparrow',
+      },
+    };
+    expect(buildSignKeycardParams(result)).toEqual({
+      operation: 'sign',
+      signMode: 'btc-message',
+      requestId: 'req-2',
+      signDataHex: 'cafebabe',
+      derivationPath: "m/84'/0'/0'/0/0",
+      address: 'bc1qexample',
+      origin: 'Sparrow',
+    });
+  });
+
+  it('returns null for unsupported result', () => {
+    const result: ScanResult = { kind: 'unsupported', type: 'something' };
+    expect(buildSignKeycardParams(result)).toBeNull();
+  });
+
+  it('returns null for error result', () => {
+    const result: ScanResult = { kind: 'error', message: 'oops' };
+    expect(buildSignKeycardParams(result)).toBeNull();
+  });
+});

--- a/src/screens/TransactionDetailScreen.tsx
+++ b/src/screens/TransactionDetailScreen.tsx
@@ -7,6 +7,7 @@ import theme from '../theme';
 import SignRequestDetail from '../components/SignRequestDetail';
 import PrimaryButton from '../components/PrimaryButton';
 import { inspectBtcPsbt } from '../utils/btcPsbt';
+import { buildSignKeycardParams } from '../utils/signNavigation';
 
 export default function TransactionDetailScreen({
   route,
@@ -27,37 +28,13 @@ export default function TransactionDetailScreen({
       }
     })();
 
+  const keycardParams = buildSignKeycardParams(result);
+
   const handleSign = useCallback(() => {
-    if (result.kind === 'eth-sign-request') {
-      const request = result.request;
-      navigation.navigate('Keycard', {
-        operation: 'sign',
-        signMode: 'eth',
-        signData: request.signData,
-        derivationPath: request.derivationPath,
-        chainId: request.chainId,
-        requestId: request.requestId,
-        dataType: request.dataType,
-      });
-    } else if (result.kind === 'crypto-psbt') {
-      navigation.navigate('Keycard', {
-        operation: 'sign',
-        signMode: 'btc',
-        psbtHex: result.request.psbtHex,
-      });
-    } else if (result.kind === 'btc-sign-request') {
-      const request = result.request;
-      navigation.navigate('Keycard', {
-        operation: 'sign',
-        signMode: 'btc-message',
-        requestId: request.requestId,
-        signDataHex: request.signDataHex,
-        derivationPath: request.derivationPath,
-        address: request.address,
-        origin: request.origin,
-      });
+    if (keycardParams) {
+      navigation.navigate('Keycard', keycardParams);
     }
-  }, [result, navigation]);
+  }, [keycardParams, navigation]);
 
   return (
     <View style={styles.container}>
@@ -68,9 +45,7 @@ export default function TransactionDetailScreen({
         <SignRequestDetail result={result} />
       </ScrollView>
 
-      {(result.kind === 'eth-sign-request' ||
-        result.kind === 'crypto-psbt' ||
-        result.kind === 'btc-sign-request') && (
+      {keycardParams !== null && (
         <View style={[styles.actions, { paddingBottom: insets.bottom + 16 }]}>
           <PrimaryButton
             label={

--- a/src/utils/signNavigation.ts
+++ b/src/utils/signNavigation.ts
@@ -1,0 +1,41 @@
+import type { KeycardParams } from '@/navigation/types';
+import type { ScanResult } from '@/types';
+
+export function buildSignKeycardParams(
+  result: ScanResult,
+): KeycardParams | null {
+  if (result.kind === 'eth-sign-request') {
+    const { signData, derivationPath, chainId, requestId, dataType } =
+      result.request;
+    return {
+      operation: 'sign',
+      signMode: 'eth',
+      signData,
+      derivationPath,
+      chainId,
+      requestId,
+      dataType,
+    };
+  }
+  if (result.kind === 'crypto-psbt') {
+    return {
+      operation: 'sign',
+      signMode: 'btc',
+      psbtHex: result.request.psbtHex,
+    };
+  }
+  if (result.kind === 'btc-sign-request') {
+    const { requestId, signDataHex, derivationPath, address, origin } =
+      result.request;
+    return {
+      operation: 'sign',
+      signMode: 'btc-message',
+      requestId,
+      signDataHex,
+      derivationPath,
+      address,
+      origin,
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Extract `buildSignKeycardParams(result: ScanResult): KeycardParams | null`  to `src/utils/signNavigation.ts`
- `TransactionDetailScreen.handleSign` reduced from a 30-line if-chain to a single `navigation.navigate` call
- Button visibility replaced: `result.kind === 'eth-sign-request' || ...`  -> `keycardParams !== null`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for transaction signing functionality across multiple transaction types.

* **Bug Fixes**
  * Improved consistency and reliability of the signing flow for transactions and messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->