### PR TITLE
refactor: fix NFC layer seam and add useKeycardOp factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Extract `encodeToUR` helper to `ur.ts`; consolidate repeated `new UREncoder(new UR(...))` pattern across `btcMessage`, `cryptoAccount`, `cryptoHdKey`, `cryptoMultiAccounts`, and `btcPsbt`; move `buildBtcResultUR` out of `KeycardScreen` into `btcPsbt` as `buildCryptoPsbtUR`
 - Extract `buildSignKeycardParams` to `src/utils/signNavigation.ts`; remove result-kind dispatch from `TransactionDetailScreen.handleSign`
 - Replace generic `preferenceKeys` + `loadBooleanPreference` with typed per-preference helpers; drop `loadEnsRpcUrl` in favour of `loadEnsSettings`
+- `useKeycardOperation` composes with `useNFCOperation` instead of bypassing it to `useNFCSession`
+- Add `useKeycardOp` factory; remove `keycard.execute` boilerplate from six operation hooks
 
 ## [1.6.2] - 2026-05-13
 

--- a/__tests__/DashboardScreen.test.tsx
+++ b/__tests__/DashboardScreen.test.tsx
@@ -39,11 +39,12 @@ jest.mock('../src/assets/icons', () => {
 
 // Capture the useFocusEffect callback so tests can fire focus events.
 let focusCallback: (() => void) | null = null;
+const mockUseNavigationNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: (cb: () => void) => {
     focusCallback = cb;
   },
-  useNavigation: () => ({ navigate: jest.fn() }),
+  useNavigation: () => ({ navigate: mockUseNavigationNavigate }),
 }));
 
 const mockDashboardActions: { label: string; navigate: (nav: any) => void }[] =
@@ -92,6 +93,7 @@ describe('DashboardScreen', () => {
   beforeEach(() => {
     navigation.navigate.mockClear();
     navigation.setParams.mockClear();
+    mockUseNavigationNavigate.mockClear();
     mockDashboardActions.length = 0;
     mockLoadBooleanPreference.mockReset();
     mockSaveBooleanPreference.mockReset();
@@ -256,6 +258,18 @@ describe('DashboardScreen', () => {
       });
 
       expect(screen.queryByText('Keycard required')).toBeNull();
+    });
+
+    it('navigates to UrlQR when the QR icon button is pressed', async () => {
+      mockLoadBooleanPreference.mockResolvedValue(false);
+      await renderScreen();
+
+      fireEvent.press(screen.getByTestId('dashboard-keycard-qr-button'));
+
+      expect(mockUseNavigationNavigate).toHaveBeenCalledWith('UrlQR', {
+        url: 'https://get.keycard.tech/vuxxnf',
+        title: 'Buy a Keycard',
+      });
     });
   });
 });

--- a/__tests__/useAddresses.test.ts
+++ b/__tests__/useAddresses.test.ts
@@ -10,23 +10,22 @@ type OperationFn = (cmdSet: any) => Promise<any>;
 let capturedOperation: OperationFn | null = null;
 let capturedOptions: { requiresPin?: boolean } | null = null;
 
-const mockExecute = jest.fn(
-  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
-    capturedOperation = fn;
-    capturedOptions = opts;
-  },
-);
+const mockStart = jest.fn();
 
 jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
+  useKeycardOp: (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -53,7 +52,7 @@ jest.mock('../src/utils/hdAddress', () => ({
 
 describe('useAddresses', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     mockExtendedKey.mockClear();
     capturedOperation = null;
     capturedOptions = null;
@@ -65,7 +64,7 @@ describe('useAddresses', () => {
       await act(async () => {
         result.current.start();
       });
-      expect(mockExecute).toHaveBeenCalledTimes(1);
+      expect(mockStart).toHaveBeenCalledTimes(1);
       expect(capturedOptions).toEqual({ requiresPin: true });
     });
   });

--- a/__tests__/useGenerateKey.test.ts
+++ b/__tests__/useGenerateKey.test.ts
@@ -10,26 +10,25 @@ let capturedOptions: {
   requiresMasterKey?: boolean;
 } | null = null;
 
-const mockExecute = jest.fn(
-  (
+const mockStart = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: (
     fn: OperationFn,
     opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
   ) => {
     capturedOperation = fn;
     capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
   },
-);
-
-jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
 }));
 
 jest.mock('keycard-sdk/dist/constants', () => ({
@@ -54,7 +53,7 @@ jest.mock('@scure/bip39/wordlists/english.js', () => ({
 
 describe('useGenerateKey', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     capturedOperation = null;
     capturedOptions = null;
   });

--- a/__tests__/useGenerateSlip39Shares.test.ts
+++ b/__tests__/useGenerateSlip39Shares.test.ts
@@ -10,31 +10,30 @@ let capturedOptions: {
   requiresMasterKey?: boolean;
 } | null = null;
 
-const mockExecute = jest.fn(
-  (
+const mockStart = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: (
     fn: OperationFn,
     opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
   ) => {
     capturedOperation = fn;
     capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
   },
-);
-
-jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
 }));
 
 describe('useGenerateSlip39Shares', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     capturedOperation = null;
     capturedOptions = null;
   });
@@ -45,7 +44,7 @@ describe('useGenerateSlip39Shares', () => {
       result.current.start();
     });
 
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockStart).toHaveBeenCalledTimes(1);
     expect(capturedOptions).toEqual({
       requiresPin: false,
       requiresMasterKey: false,
@@ -73,6 +72,6 @@ describe('useGenerateSlip39Shares', () => {
     const { result } = renderHook(() => useGenerateSlip39Shares(3, 1));
 
     expect(() => result.current.start()).toThrow(/at least 2/);
-    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable no-bitwise */
 
 import { act, renderHook } from '@testing-library/react-native';
-import { useKeycardOperation } from '../src/hooks/keycard/useKeycardOperation';
+import {
+  useKeycardOp,
+  useKeycardOperation,
+} from '../src/hooks/keycard/useKeycardOperation';
 import type { UseKeycardOperation } from '../src/hooks/keycard/useKeycardOperation';
 import { checkGenuine } from '../src/utils/genuineCheck';
 import { loadPairing } from '../src/storage/pairingStorage';
@@ -68,6 +71,33 @@ const mockCheckGenuine = checkGenuine as jest.MockedFunction<
   typeof checkGenuine
 >;
 const mockLoadPairing = loadPairing as jest.MockedFunction<typeof loadPairing>;
+
+// ---------------------------------------------------------------------------
+// Shared mock Commandset factory
+// ---------------------------------------------------------------------------
+
+const makeMockCmdSet = () => ({
+  applicationInfo: {
+    instanceUID: new Uint8Array([0xaa, 0xbb]),
+    initializedCard: true,
+    freePairingSlots: 5,
+    hasMasterKey: () => true,
+  },
+  select: jest.fn().mockResolvedValue({ sw: 0x9000 }),
+  identifyCard: jest.fn(),
+  autoPair: jest.fn().mockResolvedValue(undefined),
+  getPairing: jest.fn().mockReturnValue({ pairingIndex: 0 }),
+  setPairing: jest.fn(),
+  autoOpenSecureChannel: jest.fn().mockResolvedValue(undefined),
+  getData: jest.fn().mockResolvedValue({
+    sw: 0x9000,
+    data: new Uint8Array([0x20 | 9, ...Buffer.from('Main card')]),
+  }),
+  verifyPIN: jest.fn().mockResolvedValue({
+    sw: 0x9000,
+    checkAuthOK: jest.fn(),
+  }),
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -256,31 +286,6 @@ describe('useKeycardOperation', () => {
   // -------------------------------------------------------------------------
 
   describe('genuine check', () => {
-    // A minimal Commandset whose select() returns 0x9000 so useNFCSession
-    // proceeds to call our handleCardConnected.
-    const makeMockCmdSet = () => ({
-      applicationInfo: {
-        instanceUID: new Uint8Array([0xaa, 0xbb]),
-        initializedCard: true,
-        freePairingSlots: 5,
-        hasMasterKey: () => true,
-      },
-      select: jest.fn().mockResolvedValue({ sw: 0x9000 }),
-      identifyCard: jest.fn(),
-      autoPair: jest.fn().mockResolvedValue(undefined),
-      getPairing: jest.fn().mockReturnValue({ pairingIndex: 0 }),
-      setPairing: jest.fn(),
-      autoOpenSecureChannel: jest.fn().mockResolvedValue(undefined),
-      getData: jest.fn().mockResolvedValue({
-        sw: 0x9000,
-        data: new Uint8Array([0x20 | 9, ...Buffer.from('Main card')]),
-      }),
-      verifyPIN: jest.fn().mockResolvedValue({
-        sw: 0x9000,
-        checkAuthOK: jest.fn(),
-      }),
-    });
-
     beforeEach(() => {
       // Default: no existing pairing, genuine check passes
       mockLoadPairing.mockResolvedValue(null);
@@ -472,5 +477,132 @@ describe('useKeycardOperation', () => {
       await triggerCardConnect(result.current);
       expect(mockOp).toHaveBeenCalledTimes(1);
     });
+
+    it('enters error phase when applicationInfo is missing from SELECT response', async () => {
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        applicationInfo: null,
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: false });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'No application info in SELECT response',
+      );
+    });
+  });
+
+  describe('clearPinError', () => {
+    it('is exposed and callable without side effects when no error exists', async () => {
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.clearPinError();
+      });
+      expect(result.current.pinError).toBeNull();
+    });
+  });
+
+  describe('PIN verification', () => {
+    beforeEach(() => {
+      mockLoadPairing.mockResolvedValue({ pairingIndex: 0 } as any);
+      mockCheckGenuine.mockResolvedValue(true);
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => makeMockCmdSet());
+    });
+
+    it('sets pinError and returns to pin_entry on wrong PIN', async () => {
+      const { WrongPINException } = require('keycard-sdk/dist/apdu-exception');
+      const err = new WrongPINException(2);
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        verifyPIN: jest.fn().mockResolvedValue({
+          sw: 0x63c2,
+          checkAuthOK: () => {
+            throw err;
+          },
+        }),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      await act(async () => {
+        result.current.submitPin('wrong');
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.pinError).toBe(
+        'PIN is not valid. 2 attempts left.',
+      );
+      expect(result.current.phase).toBe('pin_entry');
+    });
+
+    it('enters error phase with locked message when no attempts remain', async () => {
+      const { WrongPINException } = require('keycard-sdk/dist/apdu-exception');
+      const err = new WrongPINException(0);
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        verifyPIN: jest.fn().mockResolvedValue({
+          sw: 0x6300,
+          checkAuthOK: () => {
+            throw err;
+          },
+        }),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      await act(async () => {
+        result.current.submitPin('wrong');
+      });
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'Card is locked. Use Unblock Card option.',
+      );
+      expect(result.current.pinError).toBeNull();
+    });
+  });
+});
+
+describe('useKeycardOp', () => {
+  beforeEach(() => {
+    mockStartNFC.mockResolvedValue(undefined);
+    mockStartNFC.mockClear();
+  });
+
+  it('start() transitions to nfc when requiresPin is false', async () => {
+    const { result } = renderHook(() =>
+      useKeycardOp(jest.fn(), { requiresPin: false }),
+    );
+    await act(async () => {
+      result.current.start();
+    });
+    expect(result.current.phase).toBe('nfc');
+    expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+  });
+
+  it('start() transitions to pin_entry when requiresPin is true (default)', async () => {
+    const { result } = renderHook(() => useKeycardOp(jest.fn()));
+    await act(async () => {
+      result.current.start();
+    });
+    expect(result.current.phase).toBe('pin_entry');
+    expect(mockStartNFC).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/useLoadKey.test.ts
+++ b/__tests__/useLoadKey.test.ts
@@ -16,26 +16,25 @@ let capturedOptions: {
   requiresMasterKey?: boolean;
 } | null = null;
 
-const mockExecute = jest.fn(
-  (
+const mockStart = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: (
     fn: OperationFn,
     opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
   ) => {
     capturedOperation = fn;
     capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
   },
-);
-
-jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
 }));
 
 jest.mock('keycard-sdk/dist/mnemonic', () => ({
@@ -66,7 +65,7 @@ const preparedKeyPair = { type: 'keypair' } as unknown as BIP32KeyPair;
 
 describe('deriveMnemonicKeyPair', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     mockToBinarySeed.mockClear();
     mockFromBinarySeed.mockClear();
     mockFromBinarySeed.mockReturnValue({ type: 'keypair' });
@@ -100,7 +99,7 @@ describe('deriveMnemonicKeyPair', () => {
 
 describe('useLoadKey', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     capturedOperation = null;
     capturedOptions = null;
   });
@@ -111,7 +110,7 @@ describe('useLoadKey', () => {
       result.current.start(preparedKeyPair);
     });
 
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockStart).toHaveBeenCalledTimes(1);
     expect(capturedOptions).toEqual({
       requiresPin: true,
       requiresMasterKey: false,

--- a/__tests__/useSetCardName.test.ts
+++ b/__tests__/useSetCardName.test.ts
@@ -12,32 +12,31 @@ let capturedOptions: {
   requiresMasterKey?: boolean;
 } | null = null;
 
-const mockExecute = jest.fn(
-  (
+const mockStart = jest.fn();
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: (
     fn: OperationFn,
     opts: { requiresPin?: boolean; requiresMasterKey?: boolean },
   ) => {
     capturedOperation = fn;
     capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      cardName: null,
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
   },
-);
-
-jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    cardName: null,
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
 }));
 
 describe('useSetCardName', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     capturedOperation = null;
     capturedOptions = null;
   });
@@ -117,6 +116,6 @@ describe('useSetCardName', () => {
     expect(() => result.current.start('x'.repeat(21))).toThrow(
       'Card name must be 20 bytes or fewer.',
     );
-    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/useVerifyFingerprint.test.ts
+++ b/__tests__/useVerifyFingerprint.test.ts
@@ -7,25 +7,24 @@ type OperationFn = (cmdSet: any) => Promise<any>;
 let capturedOperation: OperationFn | null = null;
 let capturedOptions: { requiresPin?: boolean } | null = null;
 
-const mockExecute = jest.fn(
-  (fn: OperationFn, opts: { requiresPin?: boolean }) => {
-    capturedOperation = fn;
-    capturedOptions = opts;
-  },
-);
+const mockStart = jest.fn();
 const mockPubKeyFingerprint = jest.fn();
 const mockFromTLV = jest.fn();
 
 jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
-  useKeycardOperation: () => ({
-    phase: 'idle',
-    status: '',
-    result: null,
-    execute: mockExecute,
-    cancel: jest.fn(),
-    reset: jest.fn(),
-    submitPin: jest.fn(),
-  }),
+  useKeycardOp: (fn: OperationFn, opts: { requiresPin?: boolean }) => {
+    capturedOperation = fn;
+    capturedOptions = opts;
+    return {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: mockStart,
+      cancel: jest.fn(),
+      reset: jest.fn(),
+      submitPin: jest.fn(),
+    };
+  },
 }));
 
 jest.mock('../src/utils/cryptoAccount', () => ({
@@ -40,7 +39,7 @@ const expectedFingerprint = 0xdeadbeef;
 
 describe('useVerifyFingerprint', () => {
   beforeEach(() => {
-    mockExecute.mockClear();
+    mockStart.mockClear();
     mockPubKeyFingerprint.mockClear();
     mockFromTLV.mockClear();
     capturedOperation = null;

--- a/src/components/DashboardKeycardNotice.tsx
+++ b/src/components/DashboardKeycardNotice.tsx
@@ -1,17 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import type { NavigationProp } from '@react-navigation/native';
+import { type NavigationProp, useNavigation } from '@react-navigation/native';
 
 import type { RootStackParamList } from '../navigation/types';
-import {
-  loadDashboardKeycardNoticeDismissed,
-  saveDashboardKeycardNoticeDismissed,
-} from '../storage/preferencesStorage';
 
 import KeycardPurchaseCard from './KeycardPurchaseCard';
 
 import { KEYCARD_PURCHASE_URL } from '../constants/keycard';
+import {
+  loadDashboardKeycardNoticeDismissed,
+  saveDashboardKeycardNoticeDismissed,
+} from '../storage/preferencesStorage';
 
 export default function DashboardKeycardNotice() {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -58,6 +57,7 @@ export default function DashboardKeycardNotice() {
         }
         buttonTestID="dashboard-keycard-purchase-link"
         closeButtonTestID="dashboard-keycard-notice-close"
+        qrButtonTestID="dashboard-keycard-qr-button"
       />
     </View>
   );

--- a/src/components/KeycardPurchaseCard.tsx
+++ b/src/components/KeycardPurchaseCard.tsx
@@ -15,6 +15,7 @@ import PrimaryButton from './PrimaryButton';
 type KeycardPurchaseCardProps = {
   buttonTestID?: string;
   closeButtonTestID?: string;
+  qrButtonTestID?: string;
   onClose?: () => void;
   onShowQR?: () => void;
 };
@@ -26,6 +27,7 @@ const keycardPurchaseDescription =
 export default function KeycardPurchaseCard({
   buttonTestID,
   closeButtonTestID,
+  qrButtonTestID,
   onClose,
   onShowQR,
 }: KeycardPurchaseCardProps) {
@@ -69,7 +71,11 @@ export default function KeycardPurchaseCard({
           testID={buttonTestID}
         />
         {onShowQR ? (
-          <Pressable style={styles.qrIconButton} onPress={onShowQR}>
+          <Pressable
+            style={styles.qrIconButton}
+            onPress={onShowQR}
+            testID={qrButtonTestID}
+          >
             <Icons.qr
               width={22}
               height={22}

--- a/src/hooks/keycard/useAddresses.ts
+++ b/src/hooks/keycard/useAddresses.ts
@@ -2,7 +2,7 @@ import { HDKey } from '@scure/bip32';
 import Keycard from 'keycard-sdk';
 import { useCallback } from 'react';
 
-import { useKeycardOperation } from './useKeycardOperation';
+import { useKeycardOp } from './useKeycardOperation';
 
 const COIN_CONFIG = {
   eth: { path: "m/44'/60'/0'" },
@@ -10,19 +10,17 @@ const COIN_CONFIG = {
 };
 
 export function useAddresses(coin: 'eth' | 'btc') {
-  const keycard = useKeycardOperation<HDKey>();
   const { path } = COIN_CONFIG[coin];
 
-  const start = useCallback(() => {
-    keycard.execute(
+  return useKeycardOp<HDKey>(
+    useCallback(
       async cmdSet => {
         const resp = await cmdSet.exportExtendedKey(0, path, false);
         resp.checkOK();
         return Keycard.BIP32KeyPair.extendedKey(resp.data);
       },
-      { requiresPin: true },
-    );
-  }, [keycard, path]);
-
-  return { ...keycard, start };
+      [path],
+    ),
+    { requiresPin: true },
+  );
 }

--- a/src/hooks/keycard/useGenerateKey.ts
+++ b/src/hooks/keycard/useGenerateKey.ts
@@ -1,18 +1,18 @@
 import { useCallback } from 'react';
-import { useKeycardOperation } from './useKeycardOperation';
 import { Constants } from 'keycard-sdk/dist/constants';
 import { Mnemonic } from 'keycard-sdk/dist/mnemonic';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 
-export function useGenerateKey(size: 12 | 24) {
-  const keycard = useKeycardOperation<string[]>();
+import { useKeycardOp } from './useKeycardOperation';
 
-  const start = useCallback(() => {
-    const checksum =
-      size === 12
-        ? Constants.GENERATE_MNEMONIC_12_WORDS
-        : Constants.GENERATE_MNEMONIC_24_WORDS;
-    keycard.execute(
+export function useGenerateKey(size: 12 | 24) {
+  const checksum =
+    size === 12
+      ? Constants.GENERATE_MNEMONIC_12_WORDS
+      : Constants.GENERATE_MNEMONIC_24_WORDS;
+
+  return useKeycardOp<string[]>(
+    useCallback(
       async cmdSet => {
         const response = await cmdSet.generateMnemonic(checksum);
         response.checkOK();
@@ -20,9 +20,8 @@ export function useGenerateKey(size: 12 | 24) {
         mnemonic.setWordlist(wordlist);
         return mnemonic.getWords();
       },
-      { requiresPin: false, requiresMasterKey: false },
-    );
-  }, [keycard, size]);
-
-  return { ...keycard, start };
+      [checksum],
+    ),
+    { requiresPin: false, requiresMasterKey: false },
+  );
 }

--- a/src/hooks/keycard/useGenerateSlip39Shares.ts
+++ b/src/hooks/keycard/useGenerateSlip39Shares.ts
@@ -3,27 +3,27 @@ import { useCallback } from 'react';
 import { Constants } from 'keycard-sdk/dist/constants';
 
 import { validateSlip39GenerationArgs } from '../../utils/slip39';
-import { useKeycardOperation } from './useKeycardOperation';
+import { useKeycardOp } from './useKeycardOperation';
 
 const SHELL_SLIP39_ENTROPY_WORD_COUNT = Constants.GENERATE_MNEMONIC_18_WORDS;
 
 export function useGenerateSlip39Shares(shareCount: number, threshold: number) {
-  const keycard = useKeycardOperation<Uint8Array>();
+  const { start: startOp, ...rest } = useKeycardOp<Uint8Array>(
+    useCallback(async (cmdSet, { setStatus }) => {
+      setStatus('Reading Keycard entropy...');
+      const response = await cmdSet.generateMnemonic(
+        SHELL_SLIP39_ENTROPY_WORD_COUNT,
+      );
+      response.checkOK();
+      return response.data;
+    }, []),
+    { requiresPin: false, requiresMasterKey: false },
+  );
 
   const start = useCallback(() => {
     validateSlip39GenerationArgs({ shareCount, threshold });
-    keycard.execute(
-      async (cmdSet, { setStatus }) => {
-        setStatus('Reading Keycard entropy...');
-        const response = await cmdSet.generateMnemonic(
-          SHELL_SLIP39_ENTROPY_WORD_COUNT,
-        );
-        response.checkOK();
-        return response.data;
-      },
-      { requiresPin: false, requiresMasterKey: false },
-    );
-  }, [keycard, shareCount, threshold]);
+    startOp();
+  }, [startOp, shareCount, threshold]);
 
-  return { ...keycard, start };
+  return { ...rest, start };
 }

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -8,7 +8,7 @@ import { loadPairing, savePairing } from '../../storage/pairingStorage';
 import { checkGenuine } from '../../utils/genuineCheck';
 import { toHex } from '../../utils/hex';
 import { displayKeycardName, parseKeycardName } from '../../utils/keycardName';
-import useNFCSession from './useNFCSession';
+import { useNFCOperation } from './useNFCOperation';
 
 export type Phase =
   | 'idle'
@@ -44,7 +44,6 @@ export interface UseKeycardOperation<T> {
 }
 
 export function useKeycardOperation<T>(): UseKeycardOperation<T> {
-  const [result, setResult] = useState<T | null>(null);
   const [waitingForPin, setWaitingForPin] = useState(false);
   const [pinError, setPinError] = useState<string | null>(null);
   const [cardName, setCardName] = useState<string | null>(null);
@@ -58,10 +57,12 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const approvedNonGenuineUidsRef = useRef<Set<string>>(new Set());
   const pendingUidRef = useRef<string | null>(null);
 
-  const handleCardDisconnected = useCallback(async () => {}, []);
-
   const doPairAndExecute = useCallback(
-    async (cmdSet: Commandset, uid: string, setStatus: (s: string) => void) => {
+    async (
+      cmdSet: Commandset,
+      uid: string,
+      setStatus: (s: string) => void,
+    ): Promise<T | null> => {
       const existingPairing = await loadPairing(uid);
       if (existingPairing) {
         console.log(
@@ -106,13 +107,12 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       }
 
       if (operationRunningRef.current || !operationRef.current) {
-        return;
+        return null;
       }
       operationRunningRef.current = true;
       setStatus('Processing...');
       try {
-        const opResult = await operationRef.current(cmdSet, { setStatus });
-        setResult(opResult);
+        return await operationRef.current(cmdSet, { setStatus });
       } finally {
         operationRunningRef.current = false;
       }
@@ -121,7 +121,10 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   );
 
   const handleCardConnected = useCallback(
-    async (cmdSet: Commandset, setStatus: (status: string) => void) => {
+    async (
+      cmdSet: Commandset,
+      setStatus: (status: string) => void,
+    ): Promise<T | null> => {
       const appInfo = cmdSet.applicationInfo;
       if (!appInfo) {
         throw new Error('No application info in SELECT response');
@@ -159,14 +162,14 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
           console.log('[Keycard] Genuine check failed — showing warning');
           pendingUidRef.current = uid;
           setShowGenuineWarning(true);
-          // Return without throwing: useNFCSession will set nfcPhase='done',
+          // Return null: useNFCSession will set nfcPhase='done',
           // but our phase computation overrides it to 'genuine_warning'.
-          return;
+          return null;
         }
         console.log('[Keycard] Genuine check passed');
       }
 
-      await doPairAndExecute(cmdSet, uid, setStatus);
+      return await doPairAndExecute(cmdSet, uid, setStatus);
     },
     [doPairAndExecute],
   );
@@ -174,9 +177,11 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const {
     phase: nfcPhase,
     status,
-    startNFC,
-    reset: resetNFC,
-  } = useNFCSession(handleCardConnected, handleCardDisconnected);
+    result,
+    start: startNFC,
+    cancel: nfcCancel,
+    reset: nfcReset,
+  } = useNFCOperation<T | null>(handleCardConnected);
 
   // 'genuine_warning' takes priority over all other phase overrides.
   const phase: Phase = showGenuineWarning
@@ -223,7 +228,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       pendingUidRef.current = null;
     }
     setShowGenuineWarning(false);
-    startNFC(); // Re-enter nfc phase; user taps card again
+    startNFC();
   }, [startNFC]);
 
   // Re-starts NFC without PIN re-entry — uses the cached PIN from the previous attempt.
@@ -232,8 +237,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     startNFC();
   }, [startNFC]);
 
-  const cancel = useCallback(() => {
-    resetNFC();
+  const clearKeycardState = useCallback(() => {
     setWaitingForPin(false);
     setPinError(null);
     setCardName(null);
@@ -242,20 +246,17 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     pinRef.current = '';
     operationRef.current = null;
     operationRunningRef.current = false;
-  }, [resetNFC]);
+  }, []);
+
+  const cancel = useCallback(() => {
+    nfcCancel();
+    clearKeycardState();
+  }, [nfcCancel, clearKeycardState]);
 
   const reset = useCallback(() => {
-    resetNFC();
-    setWaitingForPin(false);
-    setPinError(null);
-    setCardName(null);
-    setShowGenuineWarning(false);
-    pendingUidRef.current = null;
-    pinRef.current = '';
-    operationRef.current = null;
-    operationRunningRef.current = false;
-    setResult(null);
-  }, [resetNFC]);
+    nfcReset();
+    clearKeycardState();
+  }, [nfcReset, clearKeycardState]);
 
   return {
     phase,
@@ -271,4 +272,21 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     retry,
     proceedWithNonGenuine,
   };
+}
+
+export function useKeycardOp<T>(
+  op: KeycardOperationFn<T>,
+  options: ExecuteOptions = {},
+): Omit<UseKeycardOperation<T>, 'execute'> & { start: () => void } {
+  const { execute, ...rest } = useKeycardOperation<T>();
+  const opRef = useRef(op);
+  opRef.current = op;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const start = useCallback(() => {
+    execute(opRef.current, optionsRef.current);
+  }, [execute]);
+
+  return { ...rest, start };
 }

--- a/src/hooks/keycard/useLoadKey.ts
+++ b/src/hooks/keycard/useLoadKey.ts
@@ -1,31 +1,56 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { BIP32KeyPair } from 'keycard-sdk/dist/bip32key';
 import { Mnemonic } from 'keycard-sdk/dist/mnemonic';
 
-import { useKeycardOperation } from './useKeycardOperation';
+import { useKeycardOp } from './useKeycardOperation';
 
 export function useLoadKey() {
-  const keycard = useKeycardOperation<void>();
+  const keyPairRef = useRef<BIP32KeyPair | null>(null);
+
+  const clearKeyPair = useCallback(() => {
+    keyPairRef.current = null;
+  }, []);
+
+  const {
+    start: startOp,
+    cancel: cancelOp,
+    reset: resetOp,
+    ...rest
+  } = useKeycardOp<void>(
+    useCallback(async cmdSet => {
+      const appInfo = cmdSet.applicationInfo;
+      if (appInfo?.hasMasterKey()) {
+        throw new Error('Card already has a key. Factory reset required.');
+      }
+      try {
+        const response = await cmdSet.loadBIP32KeyPair(keyPairRef.current!);
+        response.checkOK();
+      } finally {
+        keyPairRef.current = null;
+      }
+    }, []),
+    { requiresPin: true, requiresMasterKey: false },
+  );
 
   const start = useCallback(
     (keyPair: BIP32KeyPair) => {
-      keycard.execute(
-        async cmdSet => {
-          const appInfo = cmdSet.applicationInfo;
-          if (appInfo?.hasMasterKey()) {
-            throw new Error('Card already has a key. Factory reset required.');
-          }
-
-          const response = await cmdSet.loadBIP32KeyPair(keyPair);
-          response.checkOK();
-        },
-        { requiresPin: true, requiresMasterKey: false },
-      );
+      keyPairRef.current = keyPair;
+      startOp();
     },
-    [keycard],
+    [startOp],
   );
 
-  return { ...keycard, start };
+  const cancel = useCallback(() => {
+    clearKeyPair();
+    cancelOp();
+  }, [clearKeyPair, cancelOp]);
+
+  const reset = useCallback(() => {
+    clearKeyPair();
+    resetOp();
+  }, [clearKeyPair, resetOp]);
+
+  return { ...rest, start, cancel, reset };
 }
 
 export function deriveMnemonicKeyPair(

--- a/src/hooks/keycard/useNFCOperation.ts
+++ b/src/hooks/keycard/useNFCOperation.ts
@@ -1,7 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Commandset } from 'keycard-sdk/dist/commandset';
-import useNFCSession from './useNFCSession';
-import { Phase } from './useNFCSession';
+import useNFCSession, { Phase } from './useNFCSession';
 
 export type { Phase };
 
@@ -15,14 +14,21 @@ export interface UseNFCOperation<T> {
 }
 
 export function useNFCOperation<T>(
-  onConnected: (cmdSet: Commandset) => Promise<T>,
+  onConnected: (
+    cmdSet: Commandset,
+    setStatus: (status: string) => void,
+  ) => Promise<T>,
 ): UseNFCOperation<T> {
   const [result, setResult] = useState<T | null>(null);
+  const runIdRef = useRef(0);
 
   const handleCardConnected = useCallback(
-    async (cmdSet: Commandset) => {
-      const value = await onConnected(cmdSet);
-      setResult(value);
+    async (cmdSet: Commandset, setStatus: (status: string) => void) => {
+      const runId = ++runIdRef.current;
+      const value = await onConnected(cmdSet, setStatus);
+      if (runId === runIdRef.current) {
+        setResult(value);
+      }
     },
     [onConnected],
   );
@@ -37,10 +43,12 @@ export function useNFCOperation<T>(
   } = useNFCSession(handleCardConnected, handleCardDisconnected);
 
   const cancel = useCallback(() => {
+    runIdRef.current++;
     nfcReset();
   }, [nfcReset]);
 
   const reset = useCallback(() => {
+    runIdRef.current++;
     nfcReset();
     setResult(null);
   }, [nfcReset]);

--- a/src/hooks/keycard/useSetCardName.ts
+++ b/src/hooks/keycard/useSetCardName.ts
@@ -1,40 +1,42 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import {
   mergeKeycardNameMetadata,
   validateKeycardName,
 } from '../../utils/keycardName';
-import { useKeycardOperation } from './useKeycardOperation';
+import { useKeycardOp } from './useKeycardOperation';
 
 export function useSetCardName() {
-  const keycard = useKeycardOperation<void>();
+  const nameRef = useRef('');
+
+  const { start: startOp, ...rest } = useKeycardOp<void>(
+    useCallback(async (cmdSet, { setStatus }) => {
+      const dataResp = await cmdSet.getData(0x00);
+      if (dataResp.sw !== 0x9000) {
+        throw new Error(
+          `GET DATA failed: 0x${dataResp.sw.toString(16).toUpperCase()}`,
+        );
+      }
+      setStatus('Writing card name...');
+      const metadata = mergeKeycardNameMetadata(nameRef.current, dataResp.data);
+      const resp = await cmdSet.storeData(metadata, 0x00);
+      if (resp.sw !== 0x9000) {
+        throw new Error(
+          `STORE DATA failed: 0x${resp.sw.toString(16).toUpperCase()}`,
+        );
+      }
+    }, []),
+    { requiresPin: true, requiresMasterKey: false },
+  );
 
   const start = useCallback(
     (name: string) => {
       validateKeycardName(name);
-      keycard.execute(
-        async (cmdSet, { setStatus }) => {
-          const dataResp = await cmdSet.getData(0x00);
-          if (dataResp.sw !== 0x9000) {
-            throw new Error(
-              `GET DATA failed: 0x${dataResp.sw.toString(16).toUpperCase()}`,
-            );
-          }
-
-          setStatus('Writing card name...');
-          const metadata = mergeKeycardNameMetadata(name, dataResp.data);
-          const resp = await cmdSet.storeData(metadata, 0x00);
-          if (resp.sw !== 0x9000) {
-            throw new Error(
-              `STORE DATA failed: 0x${resp.sw.toString(16).toUpperCase()}`,
-            );
-          }
-        },
-        { requiresPin: true, requiresMasterKey: false },
-      );
+      nameRef.current = name;
+      startOp();
     },
-    [keycard],
+    [startOp],
   );
 
-  return { ...keycard, start };
+  return { ...rest, start };
 }

--- a/src/hooks/keycard/useVerifyFingerprint.ts
+++ b/src/hooks/keycard/useVerifyFingerprint.ts
@@ -1,31 +1,33 @@
 import Keycard from 'keycard-sdk';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { pubKeyFingerprint } from '../../utils/cryptoAccount';
-import { useKeycardOperation } from './useKeycardOperation';
+import { useKeycardOp } from './useKeycardOperation';
 
 export type VerifyFingerprintResult = 'match' | 'mismatch';
 
 export function useVerifyFingerprint() {
-  const keycard = useKeycardOperation<VerifyFingerprintResult>();
+  const expectedRef = useRef(0);
+
+  const { start: startOp, ...rest } = useKeycardOp<VerifyFingerprintResult>(
+    useCallback(async cmdSet => {
+      const resp = await cmdSet.exportKey(0, true, 'm', false);
+      resp.checkOK();
+      const cardFingerprint = pubKeyFingerprint(
+        Keycard.BIP32KeyPair.fromTLV(resp.data).publicKey,
+      );
+      return expectedRef.current === cardFingerprint ? 'match' : 'mismatch';
+    }, []),
+    { requiresPin: true },
+  );
 
   const start = useCallback(
     (expectedFingerprint: number) => {
-      keycard.execute(
-        async cmdSet => {
-          const resp = await cmdSet.exportKey(0, true, 'm', false);
-          resp.checkOK();
-          const cardFingerprint = pubKeyFingerprint(
-            Keycard.BIP32KeyPair.fromTLV(resp.data).publicKey,
-          );
-
-          return expectedFingerprint === cardFingerprint ? 'match' : 'mismatch';
-        },
-        { requiresPin: true },
-      );
+      expectedRef.current = expectedFingerprint;
+      startOp();
     },
-    [keycard],
+    [startOp],
   );
 
-  return { ...keycard, start };
+  return { ...rest, start };
 }


### PR DESCRIPTION
## Summary

- Fix NFC layer seam: `useKeycardOperation` now composes with `useNFCOperation` instead of reaching past it into `useNFCSession` directly. Phase state and disconnect handling are no longer split across two layers.
- Add `useKeycardOp<T>(op, options)` factory to `useKeycardOperation.ts`. Eliminates the `execute()` wrapper boilerplate from six operation hooks and fixes the whole-object dep-array violation in each one.
- Extract `clearKeycardState` from `cancel` and `reset` (DRY).
- Fix unhandled rejections in `DashboardKeycardNotice`: storage load failure now hides the notice; save failure on dismiss is swallowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keycard notice now includes a QR button to view the purchase URL as a QR screen.

* **Refactor**
  * Improved internal keycard operation handling by consolidating and composing operation flows for more consistent NFC/operation behavior.

* **Tests**
  * Expanded test coverage for keycard operations and navigation, including QR-button navigation assertions.

* **Documentation**
  * Changelog updated to reflect the architectural improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->