### PR TITLE
feat: add opt-in token image toggle; fix CHANGELOG order; ADR for opt-in network features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Show ERC-8213 verification digests (Calldata Digest for transactions, EIP-712 Digest for typed data) so you can independently verify what you're signing
-
-### Fixed
-
-- Contributors missing from the About screen; release build now merges the GitHub contributors API
+- Add opt-in toggle in Settings to enable remote token image downloads (online build only); preference persisted via `preferencesStorage`, default off
 
 ### Changed
 
@@ -24,6 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Replace generic `preferenceKeys` + `loadBooleanPreference` with typed per-preference helpers; drop `loadEnsRpcUrl` in favour of `loadEnsSettings`
 - `useKeycardOperation` composes with `useNFCOperation` instead of bypassing it to `useNFCSession`
 - Add `useKeycardOp` factory; remove `keycard.execute` boilerplate from six operation hooks
+- Reorder Settings screen: PIN pad scramble first, token images second, ENS last
+
+### Fixed
+
+- Contributors missing from the About screen; release build now merges the GitHub contributors API
 
 ## [1.6.2] - 2026-05-13
 

--- a/__tests__/DecodedCallSection.test.tsx
+++ b/__tests__/DecodedCallSection.test.tsx
@@ -36,6 +36,11 @@ jest.mock('../src/utils/buildConfig', () => ({
   INTERNET_ENABLED: false,
 }));
 
+jest.mock('../src/hooks/useTokenImagesEnabled.online', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
 jest.mock('../src/data/token-logos-index.json', () => ({
   '1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 'png',
 }));

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -49,6 +49,11 @@ jest.mock('../src/components/ens/AddressInfoRow.online', () => ({
   },
 }));
 
+jest.mock('../src/hooks/useTokenImagesEnabled.online', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/__tests__/TokenImagesSettingsSection.test.tsx
+++ b/__tests__/TokenImagesSettingsSection.test.tsx
@@ -1,0 +1,103 @@
+import React, { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import TokenImagesSettingsSection from '../src/components/settings/TokenImagesSettingsSection.online';
+
+const mockLoad = jest.fn();
+const mockSave = jest.fn();
+
+jest.mock('../src/storage/preferencesStorage', () => ({
+  loadTokenImagesEnabled: (...args: any[]) => mockLoad(...args),
+  saveTokenImagesEnabled: (...args: any[]) => mockSave(...args),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text, Switch } = require('react-native');
+  return {
+    MD3DarkTheme: { colors: {} },
+    Text,
+    Switch,
+  };
+});
+
+async function renderSection() {
+  render(<TokenImagesSettingsSection />);
+  await act(async () => {});
+}
+
+describe('TokenImagesSettingsSection', () => {
+  beforeEach(() => {
+    mockLoad.mockReset();
+    mockSave.mockReset();
+    mockLoad.mockResolvedValue(false);
+    mockSave.mockResolvedValue(undefined);
+  });
+
+  it('renders the toggle with label', async () => {
+    await renderSection();
+    expect(screen.getByText('Load token images')).toBeTruthy();
+  });
+
+  it('toggle is off by default (opt-in)', async () => {
+    await renderSection();
+    expect(screen.getByRole('switch').props.value).toBe(false);
+  });
+
+  it('reflects stored preference when enabled', async () => {
+    mockLoad.mockResolvedValue(true);
+    await renderSection();
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+
+  it('saves and updates state when toggled on', async () => {
+    await renderSection();
+    await act(async () => {
+      fireEvent(screen.getByRole('switch'), 'valueChange', true);
+    });
+    expect(mockSave).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+
+  it('reverts state when save rejects', async () => {
+    mockLoad.mockResolvedValue(true);
+    mockSave.mockRejectedValue(new Error('storage error'));
+    await renderSection();
+    await act(async () => {
+      fireEvent(screen.getByRole('switch'), 'valueChange', false);
+    });
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+
+  it('does not revert when state already changed before catch runs', async () => {
+    mockLoad.mockResolvedValue(true);
+    let rejectFirstSave!: (e: Error) => void;
+    mockSave.mockReturnValueOnce(
+      new Promise<void>((_, rej) => (rejectFirstSave = rej)),
+    );
+    mockSave.mockResolvedValueOnce(undefined);
+    await renderSection();
+    await act(async () => {
+      fireEvent(screen.getByRole('switch'), 'valueChange', false);
+    });
+    await act(async () => {
+      fireEvent(screen.getByRole('switch'), 'valueChange', true);
+    });
+    await act(async () => {
+      rejectFirstSave(new Error('storage error'));
+    });
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+
+  it('stale storage load does not override user interaction', async () => {
+    let resolveLoad!: (v: boolean) => void;
+    mockLoad.mockReturnValue(new Promise(res => (resolveLoad = res)));
+    render(<TokenImagesSettingsSection />);
+    await act(async () => {
+      fireEvent(screen.getByRole('switch'), 'valueChange', true);
+    });
+    await act(async () => {
+      resolveLoad(false);
+    });
+    expect(screen.getByRole('switch').props.value).toBe(true);
+  });
+});

--- a/__tests__/TokenSymbolRow.test.tsx
+++ b/__tests__/TokenSymbolRow.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+
+import TokenSymbolRow from '../src/components/SignRequestDetail/eth/DataTabPanel/DecodedCallSection/TokenSymbolRow';
+
+import type { TokenMetadata } from '../src/utils/tokenMetadata';
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return { Text: ({ children, ...p }: any) => <Text {...p}>{children}</Text> };
+});
+
+jest.mock('../src/theme', () => ({
+  __esModule: true,
+  default: { colors: { onSurfaceVariant: '#aaa' } },
+}));
+
+let mockImagesEnabled = false;
+jest.mock('../src/hooks/useTokenImagesEnabled.online', () => ({
+  __esModule: true,
+  default: () => mockImagesEnabled,
+}));
+
+jest.mock('../src/utils/buildConfig', () => ({
+  INTERNET_ENABLED: true,
+}));
+
+const remoteToken: TokenMetadata = {
+  symbol: 'USDC',
+  decimals: 6,
+  logoURI: 'https://example.com/usdc.png',
+};
+
+const localToken: TokenMetadata = {
+  symbol: 'USDC',
+  decimals: 6,
+  logoURI: 'asset:/token-logos/1-0xabc.png',
+};
+
+const noLogoToken: TokenMetadata = { symbol: 'USDC', decimals: 6 };
+
+describe('TokenSymbolRow', () => {
+  beforeEach(() => {
+    mockImagesEnabled = false;
+  });
+
+  it('always renders the token symbol', () => {
+    render(<TokenSymbolRow token={noLogoToken} />);
+    expect(screen.getByText('USDC')).toBeTruthy();
+  });
+
+  it('hides remote logo when token images are disabled', () => {
+    mockImagesEnabled = false;
+    render(<TokenSymbolRow token={remoteToken} />);
+    expect(screen.queryByTestId('token-logo')).toBeNull();
+  });
+
+  it('shows remote logo when token images are enabled', () => {
+    mockImagesEnabled = true;
+    render(<TokenSymbolRow token={remoteToken} />);
+    expect(screen.getByTestId('token-logo').props.source).toEqual({
+      uri: 'https://example.com/usdc.png',
+    });
+  });
+
+  it('shows local asset logo regardless of images-enabled preference', () => {
+    mockImagesEnabled = false;
+    render(<TokenSymbolRow token={localToken} />);
+    expect(screen.getByTestId('token-logo').props.source).toEqual({
+      uri: 'asset:/token-logos/1-0xabc.png',
+    });
+  });
+
+  it('renders nothing for logoURI when token has no logo', () => {
+    mockImagesEnabled = true;
+    render(<TokenSymbolRow token={noLogoToken} />);
+    expect(screen.queryByTestId('token-logo')).toBeNull();
+  });
+});

--- a/__tests__/preferencesStorage.test.ts
+++ b/__tests__/preferencesStorage.test.ts
@@ -1,8 +1,10 @@
 import {
   loadDashboardKeycardNoticeDismissed,
   loadPinPadScramble,
+  loadTokenImagesEnabled,
   saveDashboardKeycardNoticeDismissed,
   savePinPadScramble,
+  saveTokenImagesEnabled,
 } from '../src/storage/preferencesStorage';
 
 const mockGetItem = jest.fn();
@@ -105,6 +107,56 @@ describe('preferencesStorage', () => {
       await savePinPadScramble(false);
       expect(mockSetItem).toHaveBeenCalledWith(
         'preference_pinpad_scramble',
+        '0',
+      );
+    });
+  });
+
+  describe('loadTokenImagesEnabled', () => {
+    it('reads the correct storage key', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await loadTokenImagesEnabled();
+      expect(mockGetItem).toHaveBeenCalledWith(
+        'preference_token_images_enabled',
+      );
+    });
+
+    it('returns false when nothing stored (opt-in default)', async () => {
+      mockGetItem.mockResolvedValue(null);
+      expect(await loadTokenImagesEnabled()).toBe(false);
+    });
+
+    it('returns true when stored value is "1"', async () => {
+      mockGetItem.mockResolvedValue('1');
+      expect(await loadTokenImagesEnabled()).toBe(true);
+    });
+
+    it('returns false when stored value is "0"', async () => {
+      mockGetItem.mockResolvedValue('0');
+      expect(await loadTokenImagesEnabled()).toBe(false);
+    });
+
+    it('returns false when storage throws', async () => {
+      mockGetItem.mockRejectedValue(new Error('storage failure'));
+      expect(await loadTokenImagesEnabled()).toBe(false);
+    });
+  });
+
+  describe('saveTokenImagesEnabled', () => {
+    it('stores true as "1"', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveTokenImagesEnabled(true);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'preference_token_images_enabled',
+        '1',
+      );
+    });
+
+    it('stores false as "0"', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveTokenImagesEnabled(false);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'preference_token_images_enabled',
         '0',
       );
     });

--- a/__tests__/useTokenImagesEnabled.test.ts
+++ b/__tests__/useTokenImagesEnabled.test.ts
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import useTokenImagesEnabled from '../src/hooks/useTokenImagesEnabled.online';
+
+const mockLoad = jest.fn();
+
+jest.mock('../src/storage/preferencesStorage', () => ({
+  loadTokenImagesEnabled: (...args: any[]) => mockLoad(...args),
+}));
+
+describe('useTokenImagesEnabled', () => {
+  beforeEach(() => {
+    mockLoad.mockReset();
+    mockLoad.mockResolvedValue(false);
+  });
+
+  it('returns false before storage resolves', () => {
+    mockLoad.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useTokenImagesEnabled());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when storage resolves false', async () => {
+    mockLoad.mockResolvedValue(false);
+    const { result } = renderHook(() => useTokenImagesEnabled());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when storage resolves true', async () => {
+    mockLoad.mockResolvedValue(true);
+    const { result } = renderHook(() => useTokenImagesEnabled());
+    await act(async () => {});
+    expect(result.current).toBe(true);
+  });
+});

--- a/docs/adr/0003-network-features-are-opt-in.md
+++ b/docs/adr/0003-network-features-are-opt-in.md
@@ -1,0 +1,38 @@
+# 0003: Network-touching features are opt-in
+
+Date: 2026-05-16
+
+Status: Accepted
+
+## Context
+
+GapSign's core promise is air-gapped operation. The online build adds network-backed features (ENS resolution, remote token images) to serve users who want those enhancements without switching to the offline flavor. However, enabling these features by default contradicts the air-gapped ethos and makes outbound requests on behalf of users who may not expect them.
+
+ENS resolution was already opt-in at launch. Token image fetching was opt-out (remote URLs were fetched by default in the online build), which is inconsistent.
+
+## Decision
+
+Every network-touching feature in the online build must be **opt-in**: disabled by default, enabled explicitly by the user in Settings. Preferences are persisted via `preferencesStorage`. Storage keys for opt-in features use an `_enabled` suffix so that the unset state (no stored value) maps to `false` via the existing `loadBoolean` helper, which defaults to `false`.
+
+Features covered by this decision:
+
+- ENS reverse resolution — opt-in toggle in Settings (already compliant)
+- Remote token image downloads — opt-in toggle in Settings (added in 1.7.0)
+
+Any future network-touching feature added to the online build must follow the same pattern.
+
+## Rationale
+
+- **Consistency with the air-gapped promise**: users who install the online build for its RPC features should not have unrelated network requests made without their knowledge.
+- **Metered connections**: cosmetic network requests (token logos) are a poor tradeoff on metered or slow connections.
+- **Storage key convention**: the `_enabled` suffix lets all opt-in preferences share the same `loadBoolean` / `saveBoolean` helpers; unset keys return `false` (disabled), which is the correct default for opt-in features.
+
+## Consequences
+
+- New network-touching features require a Settings toggle before shipping.
+- Token images are disabled by default; users must opt in via Settings.
+- The `preferencesStorage` module grows one load/save pair per opt-in feature.
+
+## Revisit if
+
+- A feature is so fundamental to the online build that opt-out is a better UX (e.g., a future WalletConnect integration that is the reason a user installs the online build at all).

--- a/src/components/SignRequestDetail/eth/DataTabPanel/DecodedCallSection/TokenSymbolRow.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/DecodedCallSection/TokenSymbolRow.tsx
@@ -3,20 +3,31 @@ import { Text } from 'react-native-paper';
 
 import theme from '@/theme';
 
+import useTokenImagesEnabled from '@/hooks/useTokenImagesEnabled.online';
 import { INTERNET_ENABLED } from '@/utils/buildConfig';
 import type { TokenMetadata } from '@/utils/tokenMetadata';
 
-function TokenLogo({ uri }: { uri: string }) {
+function TokenLogo({
+  uri,
+  imagesEnabled,
+}: {
+  uri: string;
+  imagesEnabled: boolean;
+}) {
   if (!INTERNET_ENABLED && !uri.startsWith('asset:/')) return null;
+  if (!imagesEnabled && !uri.startsWith('asset:/')) return null;
   return (
     <Image source={{ uri }} style={styles.tokenLogo} testID="token-logo" />
   );
 }
 
 export default function TokenSymbolRow({ token }: { token: TokenMetadata }) {
+  const imagesEnabled = useTokenImagesEnabled();
   return (
     <View style={styles.tokenRow}>
-      {token.logoURI && <TokenLogo uri={token.logoURI} />}
+      {token.logoURI && (
+        <TokenLogo uri={token.logoURI} imagesEnabled={imagesEnabled} />
+      )}
       <Text variant="labelMedium" style={styles.tokenSymbol}>
         {token.symbol}
       </Text>

--- a/src/components/settings/TokenImagesSettingsSection.offline.tsx
+++ b/src/components/settings/TokenImagesSettingsSection.offline.tsx
@@ -1,0 +1,3 @@
+export default function TokenImagesSettingsSection() {
+  return null;
+}

--- a/src/components/settings/TokenImagesSettingsSection.online.tsx
+++ b/src/components/settings/TokenImagesSettingsSection.online.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  loadTokenImagesEnabled,
+  saveTokenImagesEnabled,
+} from '@/storage/preferencesStorage';
+
+import SettingsToggleRow from './SettingsToggleRow';
+
+export default function TokenImagesSettingsSection() {
+  const [enabled, setEnabled] = useState(false);
+  const didInteractRef = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    loadTokenImagesEnabled().then(value => {
+      if (active && !didInteractRef.current) {
+        setEnabled(value);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleToggle = useCallback((value: boolean) => {
+    didInteractRef.current = true;
+    setEnabled(value);
+    saveTokenImagesEnabled(value).catch(() => {
+      setEnabled(current => (current === value ? !value : current));
+    });
+  }, []);
+
+  return (
+    <SettingsToggleRow
+      label="Load token images"
+      value={enabled}
+      onValueChange={handleToggle}
+    />
+  );
+}

--- a/src/hooks/useTokenImagesEnabled.offline.ts
+++ b/src/hooks/useTokenImagesEnabled.offline.ts
@@ -1,0 +1,3 @@
+export default function useTokenImagesEnabled(): boolean {
+  return false;
+}

--- a/src/hooks/useTokenImagesEnabled.online.ts
+++ b/src/hooks/useTokenImagesEnabled.online.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+import { loadTokenImagesEnabled } from '@/storage/preferencesStorage';
+
+export default function useTokenImagesEnabled(): boolean {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    loadTokenImagesEnabled().then(setEnabled);
+  }, []);
+
+  return enabled;
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import theme from '../theme';
 
 import EnsSettingsSection from '../components/settings/ens/EnsSettingsSection.online';
 import PinPadSettingsSection from '../components/settings/PinPadSettingsSection';
+import TokenImagesSettingsSection from '../components/settings/TokenImagesSettingsSection.online';
 
 export const dashboardEntry: DashboardAction = {
   label: 'Settings',
@@ -26,8 +27,9 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
       contentContainerStyle={styles.content}
     >
       <View style={styles.section}>
-        <EnsSettingsSection />
         <PinPadSettingsSection />
+        <TokenImagesSettingsSection />
+        <EnsSettingsSection />
       </View>
     </ScrollView>
   );

--- a/src/storage/preferencesStorage.ts
+++ b/src/storage/preferencesStorage.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const DASHBOARD_KEYCARD_NOTICE_DISMISSED =
   'preference_dashboard_keycard_notice_dismissed';
 const PIN_PAD_SCRAMBLE = 'preference_pinpad_scramble';
+const TOKEN_IMAGES_ENABLED = 'preference_token_images_enabled';
 
 async function loadBoolean(key: string): Promise<boolean> {
   try {
@@ -32,4 +33,12 @@ export async function loadPinPadScramble(): Promise<boolean> {
 
 export async function savePinPadScramble(value: boolean): Promise<void> {
   return saveBoolean(PIN_PAD_SCRAMBLE, value);
+}
+
+export async function loadTokenImagesEnabled(): Promise<boolean> {
+  return loadBoolean(TOKEN_IMAGES_ENABLED);
+}
+
+export async function saveTokenImagesEnabled(value: boolean): Promise<void> {
+  return saveBoolean(TOKEN_IMAGES_ENABLED, value);
 }


### PR DESCRIPTION
## Summary

- Add opt-in toggle in Settings to enable remote token image downloads (online build only, `TokenImagesSettingsSection.online/offline`). Disabled by default — no outbound requests for token logos until the
  user explicitly enables the feature.
- `useTokenImagesEnabled.online/offline` boundary hook; `TokenSymbolRow` reads the preference and skips remote URIs when disabled.
- `preferencesStorage`: `loadTokenImagesEnabled` / `saveTokenImagesEnabled` using the `_enabled` key convention so the unset default is `false`.
- Settings order: PIN pad scramble, token images, ENS.
- CHANGELOG section order fixed to follow Keep a Changelog (Added, Changed, Fixed).
- ADR 0003: all network-touching features in the online build must be opt-in, disabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Settings toggle to enable remote token image downloads (opt-in, off by default); preference persisted and resilient to save/load issues.

* **Changed**
  * Settings screen reordered: PIN pad → Token images → ENS
  * Token images now respect the opt-in setting (remote images hidden when disabled)

* **Documentation**
  * Added ADR requiring network-touching features be opt-in via Settings

* **Tests**
  * Added/expanded tests covering toggle behavior, persistence, race/error handling, and logo rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->