### PR TITLE
feat: add WalletConnect v2 signing support via Keycard NFC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 ETHERSCAN_API_KEY=your_etherscan_api_key_here
+WC_PROJECT_ID=your_walletconnect_project_id_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- (online) WalletConnect v2: connect a dApp via QR, sign `personal_sign` and `eth_signTypedData_v4` with Keycard, configure project ID in Settings
 - Show ERC-8213 verification digests (Calldata Digest for transactions, EIP-712 Digest for typed data) so you can independently verify what you're signing
-- Add opt-in toggle in Settings to enable remote token image downloads (online build only); preference persisted via `preferencesStorage`, default off
+- (online) Add opt-in toggle in Settings to enable remote token image downloads; preference persisted via `preferencesStorage`, default off
 
 ### Changed
 

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { Linking } from 'react-native';
-import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import AboutScreen from '../src/screens/AboutScreen';
 
@@ -57,6 +57,7 @@ function renderScreen() {
 
 describe('AboutScreen', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     navigation.navigate.mockClear();
     mockUseNavigationNavigate.mockClear();
     mockSetString.mockClear();
@@ -64,6 +65,8 @@ describe('AboutScreen', () => {
   });
 
   afterEach(() => {
+    act(() => jest.runAllTimers());
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -102,17 +105,11 @@ describe('AboutScreen', () => {
   });
 
   it('clears pending copy timer when copy is pressed again', () => {
-    jest.useFakeTimers();
-    try {
-      renderScreen();
-      fireEvent.press(screen.getByLabelText('Copy Bitcoin address'));
-      fireEvent.press(screen.getByLabelText('Copy Bitcoin address'));
-      expect(mockSetString).toHaveBeenCalledTimes(2);
-      // Advance past the reset delay — copied should still be false (timer was cleared and restarted)
-      jest.runAllTimers();
-    } finally {
-      jest.useRealTimers();
-    }
+    renderScreen();
+    fireEvent.press(screen.getByLabelText('Copy Bitcoin address'));
+    fireEvent.press(screen.getByLabelText('Copy Bitcoin address'));
+    expect(mockSetString).toHaveBeenCalledTimes(2);
+    // afterEach drains timers via act — copied resets to false after the delay
   });
 
   it('opens support addresses as QR codes', () => {

--- a/__tests__/ChangeSecretScreen.test.tsx
+++ b/__tests__/ChangeSecretScreen.test.tsx
@@ -32,6 +32,10 @@ jest.mock('../src/storage/preferencesStorage', () => ({
   savePinPadScramble: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('../src/hooks/usePinPadScramble', () => ({
+  usePinPadScramble: () => false,
+}));
+
 const mockStart = jest.fn();
 const mockCancel = jest.fn();
 const mockReset = jest.fn();

--- a/__tests__/DashboardScreen.test.tsx
+++ b/__tests__/DashboardScreen.test.tsx
@@ -59,6 +59,11 @@ jest.mock('../src/navigation/dashboardActions', () => ({
 const mockLoadBooleanPreference = jest.fn();
 const mockSaveBooleanPreference = jest.fn();
 
+jest.mock(
+  '../src/components/walletConnect/DashboardCard.online',
+  () => () => null,
+);
+
 jest.mock('../src/storage/preferencesStorage', () => ({
   loadDashboardKeycardNoticeDismissed: (...args: any[]) =>
     mockLoadBooleanPreference(...args),
@@ -108,9 +113,9 @@ describe('DashboardScreen', () => {
   });
 
   describe('static layout', () => {
-    it('renders the Scan transaction button', async () => {
+    it('renders the Scan button', async () => {
       await renderScreen();
-      expect(screen.getByText('Scan transaction')).toBeTruthy();
+      expect(screen.getByText('Scan')).toBeTruthy();
     });
 
     it('renders one fewer pressable when action list is empty', async () => {
@@ -163,9 +168,9 @@ describe('DashboardScreen', () => {
   });
 
   describe('navigation', () => {
-    it('navigates to QRScanner when Scan transaction is pressed', async () => {
+    it('navigates to QRScanner when Scan is pressed', async () => {
       await renderScreen();
-      fireEvent.press(screen.getByText('Scan transaction'));
+      fireEvent.press(screen.getByText('Scan'));
       expect(navigation.navigate).toHaveBeenCalledWith('QRScanner');
     });
 

--- a/__tests__/Eip712JsonPanel.test.tsx
+++ b/__tests__/Eip712JsonPanel.test.tsx
@@ -108,4 +108,47 @@ describe('Eip712JsonPanel', () => {
       screen.getByText('from: 0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'),
     ).toBeTruthy();
   });
+
+  it('shows pre-hashed digest on Digests tab when signData is already a 32-byte hex hash (dataType=0 WC path)', () => {
+    const digest =
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+    const prehashedRequest: EthSignRequest = {
+      signData: digest,
+      dataType: 0,
+      derivationPath: "m/44'/60'/0'/0",
+    };
+    render(
+      <Eip712JsonPanel
+        request={prehashedRequest}
+        eip712={eip712}
+        chainId={1}
+      />,
+    );
+    fireEvent.press(screen.getByText('Digests'));
+    expect(screen.getByText(`EIP-712 Digest: ${digest}`)).toBeTruthy();
+  });
+
+  it('renders special EIP-712 review section when available', () => {
+    render(
+      <Eip712JsonPanel
+        request={request}
+        eip712={{ ...eip712, special: { kind: 'permit' } as any }}
+        chainId={1}
+      />,
+    );
+    expect(screen.getByText('SpecialEip712Section')).toBeTruthy();
+  });
+
+  it('omits digest row when signData cannot be parsed or treated as a digest', () => {
+    const invalidRequest: EthSignRequest = {
+      signData: 'not-eip712-json-or-digest',
+      dataType: 2,
+      derivationPath: "m/44'/60'/0'/0",
+    };
+    render(
+      <Eip712JsonPanel request={invalidRequest} eip712={eip712} chainId={1} />,
+    );
+    fireEvent.press(screen.getByText('Digests'));
+    expect(screen.queryByText(/EIP-712 Digest:/)).toBeNull();
+  });
 });

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -20,6 +20,8 @@ const MockNFCBottomSheet = NFCBottomSheet as jest.MockedFunction<
 
 jest.mock('../src/utils/ethSignature', () => ({
   buildEthSignatureUR: jest.fn(),
+  buildEthSignatureURFromResult: jest.fn(),
+  buildRawEthHexSignature: jest.fn(),
 }));
 
 jest.mock('../src/utils/cryptoAccount', () => ({
@@ -58,6 +60,15 @@ jest.mock('../src/utils/btcMessage', () => ({
   })),
 }));
 
+jest.mock('../src/utils/keycardExport', () => {
+  const actual = jest.requireActual('../src/utils/keycardExport');
+  return {
+    ...actual,
+    exportKeyForWallet: jest.fn(),
+    prepareSignHash: jest.fn(() => new Uint8Array(32)),
+  };
+});
+
 const mockSubmitPin = jest.fn();
 const mockCancel = jest.fn();
 const mockExecute = jest.fn();
@@ -65,6 +76,16 @@ const mockUseKeycardOperation = jest.fn();
 
 jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
   useKeycardOperation: () => mockUseKeycardOperation(),
+}));
+
+const mockRespondSuccess = jest.fn().mockResolvedValue(undefined);
+const mockRespondError = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../src/hooks/useWalletConnectSession.online', () => ({
+  useWalletConnectSession: () => ({
+    respondSuccess: mockRespondSuccess,
+    respondError: mockRespondError,
+  }),
 }));
 
 const navigation = {
@@ -245,10 +266,11 @@ describe('KeycardScreen', () => {
     });
 
     it('navigates after the 800ms timer fires', async () => {
-      const { buildEthSignatureUR } = require('../src/utils/ethSignature') as {
-        buildEthSignatureUR: jest.Mock;
-      };
-      buildEthSignatureUR.mockReturnValue('UR:ETH-SIGN/...');
+      const { buildEthSignatureURFromResult } =
+        require('../src/utils/ethSignature') as {
+          buildEthSignatureURFromResult: jest.Mock;
+        };
+      buildEthSignatureURFromResult.mockReturnValue('UR:ETH-SIGN/...');
 
       mockUseKeycardOperation.mockReturnValue({
         ...hookMock('done'),
@@ -439,6 +461,244 @@ describe('KeycardScreen', () => {
       const resetCall = navigation.reset.mock.calls[0][0];
       expect(resetCall.routes[1].name).toBe('QRResult');
       expect(resetCall.routes[1].params.urString).toBe('ur:btc-signature/mock');
+    });
+
+    it('does not navigate when result is not a Uint8Array (handleBtcMessageSignDone guard)', async () => {
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: { psbtHex: 'unexpected' },
+      });
+      await renderWithMockedHook(btcMessageSignRoute);
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+      expect(navigation.reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCancel', () => {
+    function lastOnCancel() {
+      const calls = MockNFCBottomSheet.mock.calls;
+      return calls[calls.length - 1][0].onCancel as () => Promise<void>;
+    }
+
+    it('calls cancel and resets to Dashboard', async () => {
+      await renderScreen('nfc');
+      await act(async () => {
+        await lastOnCancel()();
+      });
+      expect(mockCancel).toHaveBeenCalledTimes(1);
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+
+    it('calls respondError and resets to Dashboard when wcContext is present', async () => {
+      const wcSignRoute = {
+        params: {
+          operation: 'sign',
+          signMode: 'eth',
+          signData: 'deadbeef',
+          derivationPath: "m/44'/60'/0'/0",
+          dataType: 1,
+          chainId: 1,
+          wcContext: { id: 99, topic: 'test-topic' },
+        },
+        key: 'Keycard',
+        name: 'Keycard',
+      } as any;
+
+      await renderScreen('nfc', wcSignRoute);
+      await act(async () => {
+        await lastOnCancel()();
+      });
+      expect(mockRespondError).toHaveBeenCalledWith(
+        { id: 99, topic: 'test-topic' },
+        4001,
+        'User rejected',
+      );
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+  });
+
+  describe('eth sign execute callback', () => {
+    it('calls signWithPath with the prepared hash and derivation path', async () => {
+      const { prepareSignHash } = require('../src/utils/keycardExport') as {
+        prepareSignHash: jest.Mock;
+      };
+      const hash = new Uint8Array(32).fill(0xcc);
+      (prepareSignHash as jest.Mock).mockReturnValue(hash);
+
+      const checkOK = jest.fn();
+      const signWithPath = jest.fn().mockResolvedValue({
+        checkOK,
+        data: new Uint8Array([0xde, 0xad]),
+      });
+
+      await renderScreen('pin_entry', signRoute);
+
+      const signOp = mockExecute.mock.calls[0][0];
+      const result = await signOp({ signWithPath });
+
+      expect(signWithPath).toHaveBeenCalledWith(
+        hash,
+        signRoute.params.derivationPath,
+        false,
+      );
+      expect(checkOK).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(new Uint8Array([0xde, 0xad]));
+    });
+  });
+
+  describe('btc PSBT execute callback', () => {
+    it('calls signWithKeycard and returns the signed psbtHex', async () => {
+      const { BtcSigningSession } = require('../src/utils/btcPsbt') as {
+        BtcSigningSession: jest.Mock;
+      };
+      const signWithKeycard = jest
+        .fn()
+        .mockResolvedValue({ psbtHex: 'signedpsbt' });
+      BtcSigningSession.mockImplementation(() => ({ signWithKeycard }));
+
+      await renderScreen('pin_entry', btcSignRoute);
+
+      const signOp = mockExecute.mock.calls[0][0];
+      const setStatus = jest.fn();
+      const result = await signOp({ signWithPath: jest.fn() }, { setStatus });
+
+      expect(signWithKeycard).toHaveBeenCalledWith(
+        { signWithPath: expect.any(Function) },
+        setStatus,
+      );
+      expect(result).toEqual({ psbtHex: 'signedpsbt' });
+    });
+  });
+
+  describe('export execute callback', () => {
+    it('calls exportKeyForWallet with derivationPath and setStatus', async () => {
+      const { exportKeyForWallet } = require('../src/utils/keycardExport') as {
+        exportKeyForWallet: jest.Mock;
+      };
+      exportKeyForWallet.mockResolvedValue({
+        exportRespData: new Uint8Array([1]),
+      });
+
+      await renderScreen('pin_entry', ethExportRoute);
+
+      const exportOp = mockExecute.mock.calls[0][0];
+      const cmdSet = {};
+      const setStatus = jest.fn();
+      await exportOp(cmdSet, { setStatus });
+
+      expect(exportKeyForWallet).toHaveBeenCalledWith(
+        cmdSet,
+        ethExportRoute.params.derivationPath,
+        setStatus,
+      );
+    });
+
+    it('does not navigate when export result is a Uint8Array (ArrayBuffer guard)', async () => {
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: new Uint8Array([1, 2, 3]),
+      });
+      await renderWithMockedHook(ethExportRoute);
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+      expect(navigation.reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('WalletConnect eth sign done', () => {
+    it('calls respondSuccess and resets to Dashboard instead of navigating to QRResult', async () => {
+      const { buildRawEthHexSignature } =
+        require('../src/utils/ethSignature') as {
+          buildRawEthHexSignature: jest.Mock;
+        };
+      buildRawEthHexSignature.mockReturnValue('0xdeadbeef');
+
+      const wcSignRoute = {
+        params: {
+          operation: 'sign',
+          signMode: 'eth',
+          signData: 'deadbeef',
+          derivationPath: "m/44'/60'/0'/0",
+          dataType: 1,
+          chainId: 1,
+          wcContext: { id: 42, topic: 'wc-topic' },
+        },
+        key: 'Keycard',
+        name: 'Keycard',
+      } as any;
+
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: new Uint8Array(65).fill(0xab),
+      });
+      await renderWithMockedHook(wcSignRoute);
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+      await act(async () => {});
+
+      expect(mockRespondSuccess).toHaveBeenCalledWith(
+        { id: 42, topic: 'wc-topic' },
+        '0xdeadbeef',
+      );
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Dashboard' }],
+      });
+    });
+  });
+
+  describe('handleEthSignDone guard', () => {
+    it('does not navigate when result is not a Uint8Array', async () => {
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: { unexpected: true },
+      });
+      await renderWithMockedHook(signRoute);
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+      expect(navigation.reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('UR build error handling', () => {
+    it('logs console.error when UR building throws inside the 800ms timer', async () => {
+      const { buildEthSignatureURFromResult } =
+        require('../src/utils/ethSignature') as {
+          buildEthSignatureURFromResult: jest.Mock;
+        };
+      buildEthSignatureURFromResult.mockImplementation(() => {
+        throw new Error('encode failed');
+      });
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      mockUseKeycardOperation.mockReturnValue({
+        ...hookMock('done'),
+        result: new Uint8Array(65).fill(0x01),
+      });
+      await renderWithMockedHook(signRoute);
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[KeycardScreen] Failed to build UR:',
+        'encode failed',
+      );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/__tests__/QRScannerScreen.test.tsx
+++ b/__tests__/QRScannerScreen.test.tsx
@@ -67,6 +67,11 @@ jest.mock('../src/utils/ur', () => ({
   handleUR: (...args: any[]) => mockHandleUR(...args),
 }));
 
+const mockDetectWcUri = jest.fn();
+jest.mock('../src/utils/walletConnect/qrDetector.online', () => ({
+  detectWcUri: (...args: any[]) => mockDetectWcUri(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -99,6 +104,8 @@ describe('QRScannerScreen', () => {
     mockResultUR.mockReturnValue(undefined);
     mockResultError.mockReturnValue('decode error');
     mockHandleUR.mockReset();
+    mockDetectWcUri.mockReset();
+    mockDetectWcUri.mockReturnValue(false);
     navigation.navigate.mockClear();
     navigation.setOptions.mockClear();
   });
@@ -107,7 +114,7 @@ describe('QRScannerScreen', () => {
     it('renders the scanner title', async () => {
       await renderScreen();
       expect(navigation.setOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Scan transaction QR' }),
+        expect.objectContaining({ title: 'Scan' }),
       );
     });
 
@@ -208,6 +215,50 @@ describe('QRScannerScreen', () => {
       });
 
       expect(navigation.navigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onCodeScanned — WalletConnect URI', () => {
+    it('sets scannedRef and returns early when detectWcUri returns true', async () => {
+      mockDetectWcUri.mockReturnValue(true);
+      await renderScreen();
+      await act(async () => {
+        scan('wc:abc123@2?relay-protocol=irn');
+        // second scan should be ignored because scannedRef is set
+        scan('wc:abc123@2?relay-protocol=irn');
+      });
+      // detectWcUri called once; second scan blocked by scannedRef guard
+      expect(mockDetectWcUri).toHaveBeenCalledTimes(1);
+      expect(mockReceivedPart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('camera permission — Android denied', () => {
+    const { PermissionsAndroid, Platform } = require('react-native');
+    let originalOS: string;
+    let originalRequest: typeof PermissionsAndroid.request;
+
+    beforeEach(() => {
+      originalOS = Platform.OS;
+      originalRequest = PermissionsAndroid.request;
+      (Platform as any).OS = 'android';
+      PermissionsAndroid.request = jest
+        .fn()
+        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
+    });
+
+    afterEach(() => {
+      (Platform as any).OS = originalOS;
+      PermissionsAndroid.request = originalRequest;
+    });
+
+    it('shows the permission denied UI with Open Settings button', async () => {
+      const { getByText } = render(
+        <QRScannerScreen navigation={navigation} route={{} as any} />,
+      );
+      await act(async () => {});
+      expect(getByText('Camera Permission Required')).toBeTruthy();
+      expect(getByText('Open Settings')).toBeTruthy();
     });
   });
 });

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 
 import TransactionDetailScreen from '../src/screens/TransactionDetailScreen';
 import type { EthSignRequest } from '../src/types';
@@ -7,6 +7,22 @@ import type { EthSignRequest } from '../src/types';
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
   default: { getItem: jest.fn(), setItem: jest.fn() },
+}));
+
+const mockRespondError = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../src/hooks/useWalletConnectSession.online', () => ({
+  useWalletConnectSession: () => ({
+    phase: 'idle',
+    activeSession: null,
+    pendingRequest: null,
+    pair: jest.fn(),
+    approveSession: jest.fn(),
+    rejectSession: jest.fn(),
+    disconnect: jest.fn(),
+    respondSuccess: jest.fn(),
+    respondError: mockRespondError,
+  }),
 }));
 
 jest.mock('../src/hooks/ens/useEnsName.online', () => ({
@@ -101,11 +117,17 @@ jest.mock('react-native-safe-area-context', () => ({
 
 // Use react-native's own Text so rendered content is visible in the JSON tree.
 jest.mock('react-native-paper', () => {
-  const { Text, TouchableOpacity, View } = require('react-native');
+  const { Text, Pressable, TouchableOpacity, View } = require('react-native');
   return {
     MD3DarkTheme: { colors: {} },
     Text,
     Icon: () => null,
+    Button: ({ children, onPress }: any) =>
+      require('react').createElement(
+        Pressable,
+        { onPress },
+        require('react').createElement(Text, null, children),
+      ),
     SegmentedButtons: ({
       buttons,
       onValueChange,
@@ -139,6 +161,29 @@ function renderScreen(result: any) {
       route={
         {
           params: { result },
+          key: 'TransactionDetail',
+          name: 'TransactionDetail',
+        } as any
+      }
+      navigation={navigation}
+    />,
+  );
+  return { ...view, navigation };
+}
+
+const wcContext = { id: 1, topic: 'test-topic' };
+
+function renderScreenWithWc(result: any) {
+  const navigation = {
+    navigate: jest.fn(),
+    reset: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
+  } as any;
+  const view = render(
+    <TransactionDetailScreen
+      route={
+        {
+          params: { result, wcContext },
           key: 'TransactionDetail',
           name: 'TransactionDetail',
         } as any
@@ -324,9 +369,8 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
         origin: 'MetaMask',
       },
     });
-    expect(screen.getByText('EIP-712 Typed Data')).toBeTruthy();
+    expect(screen.getAllByText('Mail').length).toBeGreaterThan(0);
     expect(screen.getByText('Primary type')).toBeTruthy();
-    expect(screen.getByText('Mail')).toBeTruthy();
     expect(screen.getByText('EIP-712 Domain')).toBeTruthy();
     expect(screen.getByText('Ether Mail')).toBeTruthy();
     expect(screen.getByText('Message Fields')).toBeTruthy();
@@ -443,5 +487,73 @@ describe('TransactionDetailScreen – btc-sign-request result', () => {
       address: request.address,
       origin: request.origin,
     });
+  });
+});
+
+describe('TransactionDetailScreen – WalletConnect context', () => {
+  beforeEach(() => mockRespondError.mockClear());
+
+  it('shows Reject button when wcContext is present', async () => {
+    renderScreenWithWc({ kind: 'eth-sign-request', request: fullRequest });
+    expect(screen.getByText('Reject')).toBeTruthy();
+  });
+
+  it('calls respondError and navigates to Dashboard on Reject press', async () => {
+    const { navigation } = renderScreenWithWc({
+      kind: 'eth-sign-request',
+      request: fullRequest,
+    });
+    fireEvent.press(screen.getByText('Reject'));
+    await act(async () => {});
+    expect(mockRespondError).toHaveBeenCalledWith(
+      wcContext,
+      4001,
+      'User rejected',
+    );
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] }),
+    );
+  });
+
+  it('registers beforeRemove listener when wcContext is present', () => {
+    const { navigation } = renderScreenWithWc({
+      kind: 'eth-sign-request',
+      request: fullRequest,
+    });
+    expect(navigation.addListener).toHaveBeenCalledWith(
+      'beforeRemove',
+      expect.any(Function),
+    );
+  });
+
+  it('rejects WalletConnect request on back navigation', async () => {
+    const { navigation } = renderScreenWithWc({
+      kind: 'eth-sign-request',
+      request: fullRequest,
+    });
+    const beforeRemove = navigation.addListener.mock.calls[0][1];
+
+    beforeRemove();
+    await act(async () => {});
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      wcContext,
+      4001,
+      'User rejected',
+    );
+  });
+
+  it('does not reject on beforeRemove when navigating to Keycard', async () => {
+    const { navigation } = renderScreenWithWc({
+      kind: 'eth-sign-request',
+      request: fullRequest,
+    });
+    const beforeRemove = navigation.addListener.mock.calls[0][1];
+
+    fireEvent.press(screen.getByText('Sign transaction'));
+    beforeRemove();
+    await act(async () => {});
+
+    expect(mockRespondError).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/WalletConnectPairingScreen.test.tsx
+++ b/__tests__/WalletConnectPairingScreen.test.tsx
@@ -1,0 +1,549 @@
+import React, { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text, Pressable, View } = require('react-native');
+  const colors = {
+    primary: '#FF6400',
+    secondary: '#1C8A80',
+    surface: '#1e1e1e',
+    background: '#121212',
+    onSurface: '#ffffff',
+    onSurfaceVariant: '#aaaaaa',
+    surfaceVariant: '#2a2a2a',
+    error: '#cf6679',
+    outline: '#555',
+    outlineVariant: '#333',
+  };
+  return {
+    MD3DarkTheme: { colors },
+    ActivityIndicator: () => require('react').createElement(View),
+    Button: ({ children, onPress }: any) =>
+      require('react').createElement(
+        Pressable,
+        { onPress },
+        require('react').createElement(Text, null, children),
+      ),
+    Checkbox: { Android: () => require('react').createElement(View) },
+    RadioButton: {
+      Group: ({ children }: any) =>
+        require('react').createElement(View, null, children),
+      Android: ({ onPress }: any) =>
+        require('react').createElement(Pressable, { onPress }),
+    },
+    Text: ({ children, ...rest }: any) =>
+      require('react').createElement(Text, rest, children),
+  };
+});
+
+jest.mock('react-native-svg', () => ({ SvgXml: () => null }));
+
+jest.mock('../src/assets/icons', () => {
+  const { View } = require('react-native');
+  const Icon = () => require('react').createElement(View);
+  return {
+    Icons: { scan: Icon, nfcActivate: Icon },
+  };
+});
+
+jest.mock('../src/components/AddressText', () => {
+  const { Text } = require('react-native');
+  return ({ address }: any) =>
+    require('react').createElement(Text, null, address);
+});
+
+jest.mock('../src/components/PrimaryButton', () => {
+  const { Pressable, Text } = require('react-native');
+  return ({ label, onPress, disabled }: any) =>
+    require('react').createElement(
+      Pressable,
+      { onPress, disabled },
+      require('react').createElement(Text, null, label),
+    );
+});
+
+jest.mock('../src/components/NFCBottomSheet', () => {
+  const { Pressable, Text } = require('react-native');
+  return ({ onCancel }: any) =>
+    require('react').createElement(
+      Pressable,
+      { onPress: onCancel },
+      require('react').createElement(Text, null, 'Cancel NFC'),
+    );
+});
+
+const mockPair = jest.fn().mockResolvedValue(undefined);
+const mockRejectSession = jest.fn().mockResolvedValue(undefined);
+const mockApproveSession = jest.fn().mockResolvedValue(undefined);
+const mockStartNfc = jest.fn();
+const mockCancelNfc = jest.fn();
+const mockDeriveAddresses = jest.fn(
+  (_key: unknown, count: number, _derive: unknown, start: number) =>
+    Array.from({ length: count }, (_, i) => `0xADDR${start + i}`),
+);
+let capturedKeycardOp: ((cmdSet: any) => Promise<unknown>) | null = null;
+
+let mockPhase: any = 'pairing';
+let mockNfcPhase: string = 'idle';
+let mockNfcResult: any = null;
+
+jest.mock('../src/hooks/useWalletConnectSession.online', () => ({
+  useWalletConnectSession: () => ({
+    phase: mockPhase,
+    activeSession: null,
+    pendingRequest: null,
+    pair: mockPair,
+    approveSession: mockApproveSession,
+    rejectSession: mockRejectSession,
+    disconnect: jest.fn(),
+    respondSuccess: jest.fn(),
+    respondError: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: (op: any, _opts: any) => {
+    capturedKeycardOp = op;
+    return {
+      phase: mockNfcPhase,
+      status: '',
+      result: mockNfcResult,
+      start: mockStartNfc,
+      cancel: mockCancelNfc,
+      submitPin: jest.fn(),
+    };
+  },
+}));
+
+jest.mock('keycard-sdk', () => ({
+  __esModule: true,
+  default: {
+    BIP32KeyPair: {
+      extendedKey: jest.fn((data: unknown) => ({ extendedKeyData: data })),
+    },
+  },
+}));
+
+jest.mock('../src/utils/hdAddress', () => ({
+  deriveAddresses: (...args: unknown[]) => mockDeriveAddresses(...args),
+}));
+
+jest.mock('../src/utils/ethereumAddress', () => ({
+  pubKeyToEthAddress: jest.fn(),
+}));
+
+jest.mock('../src/utils/chainMetadata', () => ({
+  getChainName: (id: number) => `Chain ${id}`,
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import WalletConnectPairingScreen from '../src/screens/WalletConnectPairingScreen';
+
+const navigation = {
+  reset: jest.fn(),
+  setOptions: jest.fn(),
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+};
+const route = { params: { uri: 'wc:test-uri@2?relay-protocol=irn' } };
+
+async function renderScreen() {
+  const view = render(
+    <WalletConnectPairingScreen
+      navigation={navigation as any}
+      route={route as any}
+    />,
+  );
+  await act(async () => {});
+  return view;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPhase = 'pairing';
+  mockNfcPhase = 'idle';
+  mockNfcResult = null;
+  capturedKeycardOp = null;
+});
+
+describe('WalletConnectPairingScreen', () => {
+  it('calls pair() with the uri on mount', async () => {
+    await renderScreen();
+    expect(mockPair).toHaveBeenCalledWith('wc:test-uri@2?relay-protocol=irn');
+  });
+
+  it('shows spinner in pairing phase', async () => {
+    await renderScreen();
+    expect(screen.getByText('Connecting to dApp…')).toBeTruthy();
+  });
+
+  it('shows proposal UI when wcPhase is proposal', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: {
+            metadata: { name: 'TestDApp', url: 'https://test.io', icons: [] },
+          },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getByText('TestDApp')).toBeTruthy();
+    expect(screen.getByText('Confirm')).toBeTruthy();
+    expect(screen.getByText('Reject')).toBeTruthy();
+  });
+
+  it('shows relay privacy notice in proposal phase', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: [] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getByText('Relay privacy notice')).toBeTruthy();
+  });
+
+  it('shows error UI in error phase', async () => {
+    mockPhase = { kind: 'error', message: 'Pairing failed' };
+    await renderScreen();
+    expect(screen.getByText('Pairing failed')).toBeTruthy();
+    expect(screen.getByText('Go back to Dashboard')).toBeTruthy();
+  });
+
+  it('shows requested chain names in proposal phase', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1', 'eip155:137'], methods: [] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getByText('Chain 1')).toBeTruthy();
+    expect(screen.getByText('Chain 137')).toBeTruthy();
+  });
+
+  it('shows error banner when required method is unsupported', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['eth_sendTransaction'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getByText(/eth_sendTransaction/)).toBeTruthy();
+  });
+
+  it('shows error banner when required namespace is unsupported', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            cosmos: { chains: ['cosmos:cosmoshub-4'], methods: [] },
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getByText(/cosmos/)).toBeTruthy();
+  });
+
+  it('shows error banner listing unsupported required chains', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1', 'eip155:56'], methods: [] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+    expect(screen.getAllByText(/56/).length).toBeGreaterThan(0);
+  });
+
+  it('shows approving phase after Confirm is pressed', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+
+    fireEvent.press(screen.getByText('Confirm'));
+    await act(async () => {});
+
+    expect(screen.getByText('Tap Keycard to connect…')).toBeTruthy();
+  });
+
+  it('navigates to Dashboard when active phase arrives after approving', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    const { rerender } = render(
+      <WalletConnectPairingScreen
+        navigation={navigation as any}
+        route={route as any}
+      />,
+    );
+    await act(async () => {});
+
+    // Simulate user clicking Confirm (sets localPhase to 'approving')
+    fireEvent.press(screen.getByText('Confirm'));
+    await act(async () => {});
+
+    // Now active phase arrives
+    mockPhase = {
+      kind: 'active',
+      session: {
+        topic: 't',
+        peer: { metadata: { name: 'App', url: '', icons: [] } },
+        namespaces: {},
+      },
+    };
+    rerender(
+      <WalletConnectPairingScreen
+        navigation={navigation as any}
+        route={route as any}
+      />,
+    );
+    await act(async () => {});
+
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] }),
+    );
+  });
+
+  it('calls rejectSession and navigates back when Reject is pressed', async () => {
+    const fakeProposal = {
+      id: 1,
+      params: {
+        id: 1,
+        proposer: { metadata: { name: 'App', url: '', icons: [] } },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+    mockPhase = { kind: 'proposal', proposal: fakeProposal };
+    await renderScreen();
+
+    fireEvent.press(screen.getByText('Reject'));
+    await act(async () => {});
+
+    expect(mockRejectSession).toHaveBeenCalled();
+    expect(navigation.reset).toHaveBeenCalled();
+  });
+
+  it('exports the selected account key from Keycard', async () => {
+    await renderScreen();
+    const response = { data: 'extended-key-data', checkOK: jest.fn() };
+    const cmdSet = {
+      exportExtendedKey: jest.fn().mockResolvedValue(response),
+    };
+
+    await expect(capturedKeycardOp?.(cmdSet)).resolves.toEqual({
+      extendedKeyData: 'extended-key-data',
+    });
+
+    expect(cmdSet.exportExtendedKey).toHaveBeenCalledWith(
+      0,
+      "m/44'/60'/0'",
+      false,
+    );
+    expect(response.checkOK).toHaveBeenCalled();
+  });
+
+  it('cancels NFC approval, rejects the proposal, and returns to Dashboard', async () => {
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+    await renderScreen();
+
+    fireEvent.press(screen.getByText('Confirm'));
+    await act(async () => {});
+    fireEvent.press(screen.getByText('Cancel NFC'));
+    await act(async () => {});
+
+    expect(mockCancelNfc).toHaveBeenCalled();
+    expect(mockRejectSession).toHaveBeenCalled();
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] }),
+    );
+  });
+
+  it('derives addresses after NFC export and approves selected address', async () => {
+    const derivedKey = { id: 'external-key' };
+    mockNfcPhase = 'done';
+    mockNfcResult = { deriveChild: jest.fn(() => derivedKey) };
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+
+    const { UNSAFE_getByType } = await renderScreen();
+
+    expect(mockNfcResult.deriveChild).toHaveBeenCalledWith(0);
+    expect(mockDeriveAddresses).toHaveBeenCalledWith(
+      derivedKey,
+      20,
+      expect.any(Function),
+      0,
+    );
+    expect(screen.getByText('0xADDR1')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('0xADDR1'));
+    await act(async () => {});
+    fireEvent.press(screen.getByText('Connect'));
+    await act(async () => {});
+
+    expect(mockApproveSession).toHaveBeenCalledWith(
+      '0xADDR1',
+      "m/44'/60'/0'/0/1",
+    );
+
+    await act(async () => {
+      UNSAFE_getByType(FlatList).props.onEndReached();
+    });
+
+    expect(mockDeriveAddresses).toHaveBeenLastCalledWith(
+      derivedKey,
+      20,
+      expect.any(Function),
+      20,
+    );
+  });
+
+  it('cancels address selection and rejects the proposal', async () => {
+    mockNfcPhase = 'done';
+    mockNfcResult = { deriveChild: jest.fn(() => ({ id: 'external-key' })) };
+    mockPhase = {
+      kind: 'proposal',
+      proposal: {
+        id: 1,
+        params: {
+          id: 1,
+          proposer: { metadata: { name: 'App', url: '', icons: [] } },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      },
+    };
+
+    await renderScreen();
+    fireEvent.press(screen.getByText('Cancel'));
+    await act(async () => {});
+
+    expect(mockRejectSession).toHaveBeenCalled();
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] }),
+    );
+  });
+
+  it('navigates back from the connection error screen', async () => {
+    mockPhase = { kind: 'error', message: 'Pairing failed' };
+    await renderScreen();
+
+    fireEvent.press(screen.getByText('Go back to Dashboard'));
+
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({ routes: [{ name: 'Dashboard' }] }),
+    );
+  });
+});

--- a/__tests__/WalletConnectPhaseComponents.test.tsx
+++ b/__tests__/WalletConnectPhaseComponents.test.tsx
@@ -1,0 +1,393 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { FlatList, Linking } from 'react-native';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text, Pressable, View } = require('react-native');
+  const colors = {
+    primary: '#FF6400',
+    secondary: '#1C8A80',
+    surface: '#1e1e1e',
+    background: '#121212',
+    onSurface: '#ffffff',
+    onSurfaceVariant: '#aaaaaa',
+    surfaceVariant: '#2a2a2a',
+    error: '#cf6679',
+    outline: '#555',
+    outlineVariant: '#333',
+  };
+  return {
+    MD3DarkTheme: { colors },
+    ActivityIndicator: () =>
+      require('react').createElement(Text, null, 'Loading addresses'),
+    Button: ({ children, onPress }: any) =>
+      require('react').createElement(
+        Pressable,
+        { onPress },
+        require('react').createElement(Text, null, children),
+      ),
+    RadioButton: {
+      Group: ({ children, onValueChange }: any) =>
+        require('react').createElement(
+          View,
+          null,
+          children,
+          require('react').createElement(
+            Pressable,
+            {
+              onPress: () => onValueChange('0'),
+              testID: 'path-group-select',
+            },
+            require('react').createElement(Text, null, 'Group select'),
+          ),
+        ),
+      Android: ({ onPress, value }: any) =>
+        require('react').createElement(Pressable, {
+          onPress,
+          testID: `radio-${value}`,
+        }),
+    },
+    Text: ({ children, ...rest }: any) =>
+      require('react').createElement(Text, rest, children),
+  };
+});
+
+jest.mock('react-native-svg', () => ({ SvgXml: () => null }));
+
+jest.mock('../src/assets/icons', () => {
+  const { View } = require('react-native');
+  const Icon = () => require('react').createElement(View);
+  return { Icons: { nfcActivate: Icon } };
+});
+
+jest.mock('../src/components/AddressText', () => {
+  const { Text } = require('react-native');
+  return ({ address }: any) =>
+    require('react').createElement(Text, null, address);
+});
+
+jest.mock('../src/components/PrimaryButton', () => {
+  const { Pressable, Text } = require('react-native');
+  return ({ label, onPress, disabled }: any) =>
+    require('react').createElement(
+      Pressable,
+      { onPress, disabled },
+      require('react').createElement(Text, null, label),
+    );
+});
+
+jest.mock('../src/components/NFCBottomSheet', () => () => null);
+
+import AddressSelectionPhase from '../src/screens/WalletConnectPairingScreen/AddressSelectionPhase';
+import ApprovingPhase from '../src/screens/WalletConnectPairingScreen/ApprovingPhase';
+import ProposalPhase from '../src/screens/WalletConnectPairingScreen/ProposalPhase';
+
+const insets = { top: 0, bottom: 0, left: 0, right: 0 };
+
+describe('AddressSelectionPhase', () => {
+  const addresses = ['0xAAA', '0xBBB', '0xCCC'];
+
+  it('renders address list and action buttons', () => {
+    render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress={null}
+        loading={false}
+        insets={insets}
+        onSelect={jest.fn()}
+        onLoadMore={jest.fn()}
+        onConnect={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Select address')).toBeTruthy();
+    expect(screen.getByText('0xAAA')).toBeTruthy();
+    expect(screen.getByText('Connect')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+  });
+
+  it('calls onSelect when an address row is pressed', async () => {
+    const onSelect = jest.fn();
+    render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress={null}
+        loading={false}
+        insets={insets}
+        onSelect={onSelect}
+        onLoadMore={jest.fn()}
+        onConnect={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    fireEvent.press(screen.getByText('0xBBB'));
+    expect(onSelect).toHaveBeenCalledWith('0xBBB');
+  });
+
+  it('calls onConnect when Connect is pressed', async () => {
+    const onConnect = jest.fn();
+    render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress="0xAAA"
+        loading={false}
+        insets={insets}
+        onSelect={jest.fn()}
+        onLoadMore={jest.fn()}
+        onConnect={onConnect}
+        onCancel={jest.fn()}
+      />,
+    );
+    fireEvent.press(screen.getByText('Connect'));
+    expect(onConnect).toHaveBeenCalled();
+  });
+
+  it('calls onCancel when Cancel is pressed', async () => {
+    const onCancel = jest.fn();
+    render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress={null}
+        loading={false}
+        insets={insets}
+        onSelect={jest.fn()}
+        onLoadMore={jest.fn()}
+        onConnect={jest.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.press(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('shows loading footer and keeps selected address checked', () => {
+    const onSelect = jest.fn();
+    render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress="0xBBB"
+        loading={true}
+        insets={insets}
+        onSelect={onSelect}
+        onLoadMore={jest.fn()}
+        onConnect={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Loading addresses')).toBeTruthy();
+    expect(screen.getByText('0xBBB')).toBeTruthy();
+    fireEvent.press(screen.getByTestId('radio-0xBBB'));
+    expect(onSelect).toHaveBeenCalledWith('0xBBB');
+  });
+
+  it('calls onLoadMore when the list reaches the end', () => {
+    const onLoadMore = jest.fn();
+    const { UNSAFE_getByType } = render(
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress={null}
+        loading={false}
+        insets={insets}
+        onSelect={jest.fn()}
+        onLoadMore={onLoadMore}
+        onConnect={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    UNSAFE_getByType(FlatList).props.onEndReached();
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+});
+
+describe('ApprovingPhase', () => {
+  it('renders tap prompt and calls onCancel', async () => {
+    const onCancel = jest.fn();
+    const fakeOp = {
+      phase: 'idle',
+      status: '',
+      result: null,
+      start: jest.fn(),
+      cancel: jest.fn(),
+      submitPin: jest.fn(),
+    };
+    render(
+      <ApprovingPhase
+        accountKeyOp={fakeOp as any}
+        insets={insets}
+        onCancel={onCancel}
+      />,
+    );
+    expect(screen.getByText('Tap Keycard to connect…')).toBeTruthy();
+  });
+});
+
+const baseProposalProps = {
+  dAppName: 'TestApp',
+  dAppUrl: 'https://testapp.io',
+  requestedChains: ['Ethereum', 'Polygon'],
+  pathOptions: [
+    {
+      label: 'Ethereum (standard)',
+      accountPath: "m/44'/60'/0'",
+      hasExternalChain: true,
+    },
+  ],
+  selectedPathIdx: 0,
+  activeSessionName: null,
+  verification: null,
+  expiryTimestamp: 0,
+  proposalError: null,
+  insets,
+  onSelectPath: jest.fn(),
+  onConfirm: jest.fn(),
+  onReject: jest.fn(),
+};
+
+describe('ProposalPhase', () => {
+  it('renders dApp name, chains, and action buttons', () => {
+    render(<ProposalPhase {...baseProposalProps} />);
+    expect(screen.getByText('TestApp')).toBeTruthy();
+    expect(screen.getByText('Ethereum')).toBeTruthy();
+    expect(screen.getByText('Polygon')).toBeTruthy();
+    expect(screen.getByText('Confirm')).toBeTruthy();
+    expect(screen.getByText('Reject')).toBeTruthy();
+  });
+
+  it('shows VALID verification banner', () => {
+    render(
+      <ProposalPhase
+        {...baseProposalProps}
+        verification={{ validation: 'VALID' }}
+      />,
+    );
+    expect(screen.getByText('✓ Verified domain')).toBeTruthy();
+  });
+
+  it('shows INVALID verification banner', () => {
+    render(
+      <ProposalPhase
+        {...baseProposalProps}
+        verification={{ validation: 'INVALID' }}
+      />,
+    );
+    expect(screen.getByText(/Domain could not be verified/)).toBeTruthy();
+  });
+
+  it('shows scam banner when isScam is true', () => {
+    render(
+      <ProposalPhase
+        {...baseProposalProps}
+        verification={{ validation: 'VALID', isScam: true }}
+      />,
+    );
+    expect(screen.getByText(/flagged as a scam/)).toBeTruthy();
+  });
+
+  it('shows proposalError banner', () => {
+    render(
+      <ProposalPhase
+        {...baseProposalProps}
+        proposalError="Required methods not supported: eth_sendTransaction"
+      />,
+    );
+    expect(screen.getByText(/eth_sendTransaction/)).toBeTruthy();
+  });
+
+  it('shows countdown when expiryTimestamp is set', () => {
+    const future = Math.floor(Date.now() / 1000) + 300;
+    render(<ProposalPhase {...baseProposalProps} expiryTimestamp={future} />);
+    expect(screen.getByText(/Expires in/)).toBeTruthy();
+  });
+
+  it('updates countdown until the proposal expires', () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+    jest.setSystemTime(now);
+    const future = Math.floor(now.getTime() / 1000) + 1;
+    render(<ProposalPhase {...baseProposalProps} expiryTimestamp={future} />);
+
+    expect(screen.getByText('Expires in 0:01')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Proposal expired')).toBeTruthy();
+  });
+
+  it('shows active session warning', () => {
+    render(
+      <ProposalPhase {...baseProposalProps} activeSessionName="Uniswap" />,
+    );
+    expect(screen.getByText(/Uniswap/)).toBeTruthy();
+  });
+
+  it('calls onConfirm when Confirm pressed', () => {
+    const onConfirm = jest.fn();
+    render(<ProposalPhase {...baseProposalProps} onConfirm={onConfirm} />);
+    fireEvent.press(screen.getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('calls onReject when Reject pressed', () => {
+    const onReject = jest.fn();
+    render(<ProposalPhase {...baseProposalProps} onReject={onReject} />);
+    fireEvent.press(screen.getByText('Reject'));
+    expect(onReject).toHaveBeenCalled();
+  });
+
+  it('renders no verify banner when verification is null', () => {
+    render(<ProposalPhase {...baseProposalProps} verification={null} />);
+    expect(screen.queryByText(/Verified domain/)).toBeNull();
+    expect(screen.queryByText(/could not be verified/)).toBeNull();
+    expect(screen.queryByText(/flagged as a scam/)).toBeNull();
+  });
+
+  it('renders no verify banner for unknown validation value', () => {
+    render(
+      <ProposalPhase
+        {...baseProposalProps}
+        verification={{ validation: 'UNKNOWN' as any }}
+      />,
+    );
+    expect(screen.queryByText(/Verified domain/)).toBeNull();
+  });
+
+  it('calls onSelectPath when a path row is pressed', () => {
+    const onSelectPath = jest.fn();
+    render(
+      <ProposalPhase {...baseProposalProps} onSelectPath={onSelectPath} />,
+    );
+    fireEvent.press(screen.getByText('Ethereum (standard)'));
+    expect(onSelectPath).toHaveBeenCalledWith(0);
+  });
+
+  it('calls onSelectPath when RadioButton.Group changes value', () => {
+    const onSelectPath = jest.fn();
+    render(
+      <ProposalPhase {...baseProposalProps} onSelectPath={onSelectPath} />,
+    );
+    fireEvent.press(screen.getByTestId('path-group-select'));
+    expect(onSelectPath).toHaveBeenCalledWith(0);
+  });
+
+  it('shows the relay privacy notice', () => {
+    render(<ProposalPhase {...baseProposalProps} />);
+    expect(screen.getByText('Relay privacy notice')).toBeTruthy();
+    expect(screen.getByText('WalletConnect Privacy Policy')).toBeTruthy();
+  });
+
+  it('opens the WalletConnect privacy policy', () => {
+    jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+    render(<ProposalPhase {...baseProposalProps} />);
+
+    fireEvent.press(screen.getByText('WalletConnect Privacy Policy'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://walletconnect.com/privacy',
+    );
+  });
+});

--- a/__tests__/WalletConnectProvider.test.tsx
+++ b/__tests__/WalletConnectProvider.test.tsx
@@ -1,0 +1,972 @@
+import React from 'react';
+import { AppState } from 'react-native';
+import { act, renderHook } from '@testing-library/react-native';
+
+// ── Module-level captured state (accessible inside jest.mock closures) ────────
+
+type EventHandler = (...args: any[]) => void;
+const capturedHandlers: Record<string, EventHandler> = {};
+
+const mockOn = jest.fn((event: string, handler: EventHandler) => {
+  capturedHandlers[event] = handler;
+});
+const mockOff = jest.fn();
+const mockApproveSession = jest.fn();
+const mockRejectSession = jest.fn().mockResolvedValue(undefined);
+const mockRespondSuccess = jest.fn().mockResolvedValue(undefined);
+const mockRespondError = jest.fn().mockResolvedValue(undefined);
+const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+const mockPair = jest.fn().mockResolvedValue(undefined);
+const mockGetClient = jest.fn();
+let mockNavigationReady = true;
+const mockNavigate = jest.fn();
+let capturedAppStateHandler: ((next: any) => void) | null = null;
+
+jest.mock('../src/utils/walletConnect/client.online', () => ({
+  wcClient: {
+    getClient: (...args: unknown[]) => mockGetClient(...args),
+    pair: (...args: unknown[]) => mockPair(...args),
+    respondSuccess: (...args: unknown[]) => mockRespondSuccess(...args),
+    respondError: (...args: unknown[]) => mockRespondError(...args),
+    disconnect: (...args: unknown[]) => mockDisconnect(...args),
+  },
+}));
+
+jest.mock('../src/navigation/navigationRef', () => ({
+  navigationRef: { isReady: () => mockNavigationReady, navigate: mockNavigate },
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { WalletConnectProvider } from '../src/providers/walletConnect/Provider.online';
+import { navigationRef } from '../src/navigation/navigationRef';
+import { useWalletConnectSession } from '../src/hooks/useWalletConnectSession.online';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <WalletConnectProvider>{children}</WalletConnectProvider>;
+}
+
+function makeFakeClient() {
+  return {
+    on: mockOn,
+    off: mockOff,
+    approveSession: mockApproveSession,
+    rejectSession: mockRejectSession,
+  };
+}
+
+async function waitForClientInit() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const signerAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+const signerPath = "m/44'/60'/0'/0/0";
+
+async function approveTestSession(result: any) {
+  await act(async () => {
+    capturedHandlers.session_proposal?.({
+      id: 42,
+      params: {
+        id: 42,
+        expiryTimestamp: 0,
+        proposer: {
+          metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] },
+        },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    });
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await result.current.approveSession(signerAddress, signerPath);
+  });
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.keys(capturedHandlers).forEach(k => delete capturedHandlers[k]);
+
+  mockApproveSession.mockResolvedValue({
+    topic: 'approved-topic',
+    peer: { metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] } },
+    namespaces: { eip155: { accounts: ['eip155:1:0xabc'] } },
+  });
+  mockGetClient.mockResolvedValue(makeFakeClient());
+  mockNavigationReady = true;
+  (navigationRef as any).isReady = jest.fn(() => mockNavigationReady);
+  (navigationRef as any).navigate = mockNavigate;
+  capturedAppStateHandler = null;
+
+  jest
+    .spyOn(AppState, 'addEventListener')
+    .mockImplementation((_event, handler) => {
+      capturedAppStateHandler = handler as any;
+      return { remove: jest.fn() } as any;
+    });
+  Object.defineProperty(AppState, 'currentState', {
+    value: 'active',
+    configurable: true,
+    writable: true,
+  });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('WalletConnectProvider — initial state', () => {
+  it('starts in idle phase', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.activeSession).toBeNull();
+    expect(result.current.pendingRequest).toBeNull();
+  });
+});
+
+describe('WalletConnectProvider — pairing', () => {
+  it('sets phase to pairing when pair() is called', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      result.current.pair('wc:test-uri');
+    });
+
+    expect(mockPair).toHaveBeenCalledWith('wc:test-uri');
+    expect(result.current.phase).toBe('pairing');
+  });
+
+  it('transitions to proposal phase when session_proposal fires', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 1,
+      params: {
+        id: 1,
+        proposer: {
+          metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] },
+        },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+
+    expect(result.current.phase).toEqual({
+      kind: 'proposal',
+      proposal: fakeProposal,
+    });
+  });
+});
+
+describe('WalletConnectProvider — approveSession', () => {
+  async function setupProposal(
+    requiredNamespaces: Record<
+      string,
+      { chains?: string[]; methods?: string[] }
+    > = {
+      eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+    },
+    optionalNamespaces: Record<
+      string,
+      { chains?: string[]; methods?: string[] }
+    > = {},
+  ) {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 42,
+      params: {
+        id: 42,
+        proposer: {
+          metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] },
+        },
+        requiredNamespaces,
+        optionalNamespaces,
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+
+    return { result, fakeProposal };
+  }
+
+  it('approves session with intersection chains and transitions to active', async () => {
+    const { result } = await setupProposal({
+      eip155: {
+        chains: ['eip155:1', 'eip155:137'],
+        methods: ['personal_sign'],
+      },
+    });
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockApproveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        namespaces: expect.objectContaining({
+          eip155: expect.objectContaining({
+            chains: expect.arrayContaining(['eip155:1', 'eip155:137']),
+            accounts: expect.arrayContaining([
+              'eip155:1:0xabc',
+              'eip155:137:0xabc',
+            ]),
+          }),
+        }),
+      }),
+    );
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({ kind: 'active' }),
+    );
+  });
+
+  it('approves all supported chains and methods when proposal omits them', async () => {
+    const { result } = await setupProposal({ eip155: {} });
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockApproveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespaces: expect.objectContaining({
+          eip155: expect.objectContaining({
+            chains: expect.arrayContaining(['eip155:1', 'eip155:137']),
+            methods: expect.arrayContaining(['personal_sign']),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('rejects session when intersection is empty', async () => {
+    const { result } = await setupProposal({
+      eip155: { chains: ['eip155:56'], methods: ['personal_sign'] },
+    }); // BSC not supported
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockRejectSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42 }),
+    );
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({ kind: 'error' }),
+    );
+  });
+
+  it('rejects session when a required namespace is unsupported', async () => {
+    const { result } = await setupProposal({
+      cosmos: { chains: ['cosmos:cosmoshub-4'], methods: [] },
+      eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+    });
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockRejectSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        reason: expect.objectContaining({
+          message: expect.stringContaining('cosmos'),
+        }),
+      }),
+    );
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        message: expect.stringContaining('cosmos'),
+      }),
+    );
+  });
+
+  it('rejects session when a required method is unsupported', async () => {
+    const { result } = await setupProposal({
+      eip155: {
+        chains: ['eip155:1'],
+        methods: ['eth_sendTransaction'],
+      },
+    });
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockRejectSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        reason: expect.objectContaining({
+          message: expect.stringContaining('eth_sendTransaction'),
+        }),
+      }),
+    );
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        message: expect.stringContaining('eth_sendTransaction'),
+      }),
+    );
+  });
+});
+
+describe('WalletConnectProvider — session_request', () => {
+  it('sets pendingRequest for supported method when app is active', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 99,
+        topic: 'test-topic',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingRequest).toMatchObject({
+      id: 99,
+      topic: 'test-topic',
+      method: 'personal_sign',
+    });
+    expect(mockRespondError).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported method immediately', async () => {
+    renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 100,
+        topic: 'test-topic',
+        params: { request: { method: 'eth_sendTransaction', params: [] } },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      100,
+      'test-topic',
+      -32601,
+      expect.stringContaining('eth_sendTransaction'),
+    );
+  });
+
+  it('rejects second request when busy', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 1,
+        topic: 'topic1',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    mockRespondError.mockClear();
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 2,
+        topic: 'topic2',
+        params: { request: { method: 'personal_sign', params: [] } },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      2,
+      'topic2',
+      -32000,
+      'Wallet is busy',
+    );
+  });
+
+  it('rejects request when app is in background', async () => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'background',
+      configurable: true,
+      writable: true,
+    });
+
+    renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 5,
+        topic: 'topic',
+        params: { request: { method: 'personal_sign', params: [] } },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      5,
+      'topic',
+      -32000,
+      'Wallet is not active',
+    );
+  });
+
+  it('uses AppState change events to reject background requests', async () => {
+    renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    act(() => {
+      capturedAppStateHandler?.('background');
+    });
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 7,
+        topic: 'topic',
+        params: { request: { method: 'personal_sign', params: [] } },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      7,
+      'topic',
+      -32000,
+      'Wallet is not active',
+    );
+  });
+
+  it('rejects and clears pending request when navigation is not ready', async () => {
+    mockNavigationReady = false;
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 6,
+        topic: 'topic',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      6,
+      'topic',
+      -32000,
+      'Wallet not ready',
+    );
+    expect(result.current.pendingRequest).toBeNull();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('WalletConnectProvider — respondSuccess / respondError', () => {
+  it('respondSuccess calls wcClient and clears pendingRequest', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 77,
+        topic: 'topic-x',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.respondSuccess(
+        { id: 77, topic: 'topic-x' },
+        '0xsig',
+      );
+    });
+
+    expect(mockRespondSuccess).toHaveBeenCalledWith(77, 'topic-x', '0xsig');
+    expect(result.current.pendingRequest).toBeNull();
+  });
+
+  it('respondSuccess is idempotent — second call ignored', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 88,
+        topic: 'topic-y',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.respondSuccess(
+        { id: 88, topic: 'topic-y' },
+        '0xsig',
+      );
+    });
+    await act(async () => {
+      await result.current.respondSuccess(
+        { id: 88, topic: 'topic-y' },
+        '0xsig2',
+      );
+    });
+
+    expect(mockRespondSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('respondError calls wcClient, clears pendingRequest, and is idempotent', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 77,
+        topic: 'topic-x',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.respondError(
+        { id: 77, topic: 'topic-x' },
+        4001,
+        'User rejected',
+      );
+    });
+    await act(async () => {
+      await result.current.respondError(
+        { id: 77, topic: 'topic-x' },
+        4001,
+        'User rejected again',
+      );
+    });
+
+    expect(mockRespondError).toHaveBeenCalledTimes(1);
+    expect(mockRespondError).toHaveBeenCalledWith(
+      77,
+      'topic-x',
+      4001,
+      'User rejected',
+    );
+    expect(result.current.pendingRequest).toBeNull();
+  });
+});
+
+describe('WalletConnectProvider — session_delete', () => {
+  it('clears session and resets to idle on session_delete', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 1,
+      params: {
+        id: 1,
+        proposer: {
+          metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] },
+        },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+    expect(result.current.activeSession).not.toBeNull();
+
+    await act(async () => {
+      capturedHandlers.session_delete?.();
+    });
+
+    expect(result.current.activeSession).toBeNull();
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.pendingRequest).toBeNull();
+  });
+});
+
+describe('WalletConnectProvider — session_request invalid params', () => {
+  it('responds with -32602 when wcRequestToScanResult throws', async () => {
+    renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 55,
+        topic: 'topic-bad',
+        params: { request: { method: 'personal_sign', params: [] } },
+      });
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      55,
+      'topic-bad',
+      -32602,
+      'Invalid params',
+    );
+  });
+});
+
+describe('WalletConnectProvider — approveSession edge cases', () => {
+  it('is a no-op when phase is not proposal', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(mockApproveSession).not.toHaveBeenCalled();
+  });
+
+  it('sets error phase with friendly message when proposal has expired', async () => {
+    mockApproveSession.mockRejectedValueOnce(
+      new Error("proposal id doesn't exist"),
+    );
+
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 99,
+      params: {
+        id: 99,
+        proposer: { metadata: { name: 'dApp', url: '', icons: [] } },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        message: expect.stringContaining('expired'),
+      }),
+    );
+  });
+
+  it('sets error phase with friendly message when WalletConnect reports no matching key', async () => {
+    mockApproveSession.mockRejectedValueOnce(new Error('No matching key'));
+
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 101,
+      params: {
+        id: 101,
+        proposer: { metadata: { name: 'dApp', url: '', icons: [] } },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        message: expect.stringContaining('expired'),
+      }),
+    );
+  });
+
+  it('rejects pending request and disconnects active session before approving a replacement', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    await act(async () => {
+      await capturedHandlers.session_request?.({
+        id: 123,
+        topic: 'request-topic',
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: ['0xdeadbeef', signerAddress],
+          },
+        },
+      });
+    });
+    expect(result.current.pendingRequest).toMatchObject({ id: 123 });
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.({
+        id: 100,
+        params: {
+          id: 100,
+          expiryTimestamp: 0,
+          proposer: {
+            metadata: {
+              name: 'Replacement dApp',
+              url: 'https://replacement.example',
+              icons: [],
+            },
+          },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.approveSession('0xdef', "m/44'/60'/0'/0/1");
+    });
+
+    expect(mockRespondError).toHaveBeenCalledWith(
+      123,
+      'request-topic',
+      -32000,
+      'Wallet session replaced',
+    );
+    expect(mockDisconnect).toHaveBeenCalledWith('approved-topic');
+    expect(result.current.pendingRequest).toBeNull();
+  });
+
+  it('disconnects active session before approving a replacement with no pending request', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+    mockDisconnect.mockClear();
+    mockRespondError.mockClear();
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.({
+        id: 101,
+        params: {
+          id: 101,
+          expiryTimestamp: 0,
+          proposer: {
+            metadata: {
+              name: 'Replacement dApp',
+              url: 'https://replacement.example',
+              icons: [],
+            },
+          },
+          requiredNamespaces: {
+            eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+          },
+          optionalNamespaces: {},
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.approveSession('0xdef', "m/44'/60'/0'/0/1");
+    });
+
+    expect(mockDisconnect).toHaveBeenCalledWith('approved-topic');
+    expect(mockRespondError).not.toHaveBeenCalled();
+  });
+});
+
+describe('WalletConnectProvider — rejectSession', () => {
+  it('goes to idle when no active session', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 5,
+      params: {
+        id: 5,
+        proposer: { metadata: { name: 'dApp', url: '', icons: [] } },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.rejectSession(fakeProposal as any);
+    });
+
+    expect(mockRejectSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 5 }),
+    );
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('restores active phase when rejecting a new proposal over an active session', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+    await approveTestSession(result);
+
+    const fakeProposal = {
+      id: 6,
+      params: {
+        id: 6,
+        proposer: { metadata: { name: 'dApp2', url: '', icons: [] } },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.rejectSession(fakeProposal as any);
+    });
+
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({ kind: 'active' }),
+    );
+  });
+});
+
+describe('WalletConnectProvider — pair failure', () => {
+  it('sets error phase when pair throws', async () => {
+    mockPair.mockRejectedValueOnce(new Error('Pairing failed'));
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await result.current.pair('wc:bad-uri');
+    });
+
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({ kind: 'error', message: 'Pairing failed' }),
+    );
+  });
+
+  it('uses fallback error when pair throws a non-Error value', async () => {
+    mockPair.mockRejectedValueOnce('bad pairing');
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await result.current.pair('wc:bad-uri');
+    });
+
+    expect(result.current.phase).toEqual(
+      expect.objectContaining({ kind: 'error', message: 'Pairing failed' }),
+    );
+  });
+});
+
+describe('WalletConnectProvider — disconnect', () => {
+  it('is a no-op when no session is active', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockDisconnect).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('resets to idle and clears session on disconnect', async () => {
+    const { result } = renderHook(() => useWalletConnectSession(), { wrapper });
+    await waitForClientInit();
+
+    const fakeProposal = {
+      id: 1,
+      params: {
+        id: 1,
+        proposer: {
+          metadata: { name: 'dApp', url: 'https://dapp.io', icons: [] },
+        },
+        requiredNamespaces: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optionalNamespaces: {},
+      },
+    };
+
+    await act(async () => {
+      capturedHandlers.session_proposal?.(fakeProposal);
+    });
+    await act(async () => {
+      await result.current.approveSession('0xabc', "m/44'/60'/0'/0/0");
+    });
+
+    expect(result.current.activeSession).not.toBeNull();
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(result.current.activeSession).toBeNull();
+    expect(result.current.phase).toBe('idle');
+  });
+});

--- a/__tests__/ethSignature.test.ts
+++ b/__tests__/ethSignature.test.ts
@@ -2,7 +2,13 @@
 import * as secp from '@noble/secp256k1';
 import { URDecoder } from '@ngraveio/bc-ur';
 import CBOR from 'cbor-sync';
-import { buildEthSignatureUR } from '../src/utils/ethSignature';
+import {
+  buildEthSignatureUR,
+  buildEthSignatureURFromResult,
+  buildRawEthHexSignature,
+  buildRawHexSignature,
+  computeEthV,
+} from '../src/utils/ethSignature';
 
 // ── TLV builder helpers ──────────────────────────────────────────────────────
 
@@ -213,5 +219,211 @@ describe('buildEthSignatureUR', () => {
     expect(() =>
       buildEthSignatureUR('deadbeef', HASH, 4, undefined, undefined),
     ).toThrow();
+  });
+});
+
+describe('computeEthV', () => {
+  it('EIP-2930 (txType=0x01): returns recId regardless of dataType/chainId', () => {
+    expect(computeEthV(0, 1, 1, 0x01)).toBe(0);
+    expect(computeEthV(1, 1, 1, 0x01)).toBe(1);
+  });
+
+  it('EIP-1559 (txType=0x02): returns recId', () => {
+    expect(computeEthV(0, 4, 1, 0x02)).toBe(0);
+    expect(computeEthV(1, 4, 1, 0x02)).toBe(1);
+  });
+
+  it('legacy EIP-155 tx (dataType=1): v = 35 + 2*chainId + recId', () => {
+    expect(computeEthV(0, 1, 1, undefined)).toBe(37);
+    expect(computeEthV(1, 1, 1, undefined)).toBe(38);
+    expect(computeEthV(0, 1, 137, undefined)).toBe(35 + 274);
+  });
+
+  it('legacy EIP-155 tx (dataType=1) with no chainId: v = 35 + recId', () => {
+    expect(computeEthV(0, 1, undefined, undefined)).toBe(35);
+    expect(computeEthV(1, 1, undefined, undefined)).toBe(36);
+  });
+
+  it('typed tx without explicit txType (dataType=4): v = recId', () => {
+    expect(computeEthV(0, 4, undefined, undefined)).toBe(0);
+    expect(computeEthV(1, 4, undefined, undefined)).toBe(1);
+  });
+
+  it('personal_sign (dataType=3): v = 27 + recId', () => {
+    expect(computeEthV(0, 3, undefined, undefined)).toBe(27);
+    expect(computeEthV(1, 3, undefined, undefined)).toBe(28);
+  });
+
+  it('EIP-712 (dataType=2): v = 27 + recId', () => {
+    expect(computeEthV(0, 2, undefined, undefined)).toBe(27);
+    expect(computeEthV(1, 2, undefined, undefined)).toBe(28);
+  });
+
+  it('undefined dataType: v = 27 + recId', () => {
+    expect(computeEthV(0, undefined, undefined, undefined)).toBe(27);
+    expect(computeEthV(1, undefined, undefined, undefined)).toBe(28);
+  });
+});
+
+describe('buildRawEthHexSignature', () => {
+  let tlvBytes: Uint8Array;
+  let recId: number;
+
+  beforeAll(async () => {
+    const sigBytes = await secp.signAsync(HASH, PRIV_KEY, {
+      prehash: false,
+      format: 'recovered',
+      extraEntropy: false,
+    });
+    recId = sigBytes[0];
+    const r = sigBytes.slice(1, 33);
+    const s = sigBytes.slice(33, 65);
+    const pubKey = secp.getPublicKey(PRIV_KEY, false);
+    const hex = buildSignatureTLV(pubKey, r, s);
+    tlvBytes = new Uint8Array(Buffer.from(hex, 'hex'));
+  });
+
+  it('returns 0x-prefixed hex of length 132 (single-byte v)', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, undefined);
+    expect(result).toMatch(/^0x[0-9a-f]{130}$/);
+  });
+
+  it('v = recId for dataType=4', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, undefined);
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+
+  it('v = 27 + recId for dataType=3 (personal_sign)', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 3, undefined);
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(27 + recId);
+  });
+
+  it('detects EIP-2930 from 0x-prefixed signData first byte 0x01 → v = recId', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 1, 1, '0x01aabbcc');
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+
+  it('detects EIP-1559 from signData first byte 0x02 → v = recId', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, 1, '02aabbcc');
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+
+  it('falls back to default v when signData is undefined', () => {
+    const result = buildRawEthHexSignature(
+      tlvBytes,
+      HASH,
+      3,
+      undefined,
+      undefined,
+    );
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(27 + recId);
+  });
+
+  it('non-typed signData (first byte not 0x01/0x02) does not override dataType v', () => {
+    // 0xde is not a typed tx prefix → detectTxType returns undefined → uses dataType=4 → v = recId
+    const result = buildRawEthHexSignature(
+      tlvBytes,
+      HASH,
+      4,
+      undefined,
+      '0xdeadbeef',
+    );
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+});
+
+describe('buildEthSignatureURFromResult', () => {
+  let tlvBytes: Uint8Array;
+
+  beforeAll(async () => {
+    const sigBytes = await secp.signAsync(HASH, PRIV_KEY, {
+      prehash: false,
+      format: 'recovered',
+      extraEntropy: false,
+    });
+    const r = sigBytes.slice(1, 33);
+    const s = sigBytes.slice(33, 65);
+    const pubKey = secp.getPublicKey(PRIV_KEY, false);
+    const hex = buildSignatureTLV(pubKey, r, s);
+    tlvBytes = new Uint8Array(Buffer.from(hex, 'hex'));
+  });
+
+  it('returns a ur:eth-signature string', () => {
+    const ur = buildEthSignatureURFromResult(
+      tlvBytes,
+      HASH,
+      4,
+      undefined,
+      undefined,
+    );
+    expect(ur.toLowerCase()).toMatch(/^ur:eth-signature\//);
+  });
+
+  it('passes requestId through to the UR', () => {
+    const ur = buildEthSignatureURFromResult(
+      tlvBytes,
+      HASH,
+      4,
+      undefined,
+      '0102030405060708090a0b0c0d0e0f10',
+    );
+    const decoded = decodeUR(ur);
+    expect(decoded[1]).toBeDefined();
+  });
+
+  it('detects tx type from signData for correct v encoding', () => {
+    const ur = buildEthSignatureURFromResult(
+      tlvBytes,
+      HASH,
+      1,
+      1,
+      undefined,
+      '0x01deadbeef',
+    );
+    const sig: Buffer = decodeUR(ur)[2];
+    // EIP-2930 → v = recId (0 or 1), not 37+
+    expect(sig[sig.length - 1]).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('buildRawHexSignature', () => {
+  const r32 = new Uint8Array(32).fill(0xaa);
+  const s32 = new Uint8Array(32).fill(0xbb);
+
+  it('returns 0x-prefixed hex string', () => {
+    const result = buildRawHexSignature(r32, s32, 27);
+    expect(result).toMatch(/^0x[0-9a-f]+$/i);
+  });
+
+  it('is 132 chars (0x + 64 r + 64 s + 2 v) for single-byte v', () => {
+    const result = buildRawHexSignature(r32, s32, 27);
+    expect(result).toHaveLength(2 + 64 + 64 + 2);
+  });
+
+  it('pads r and s to 32 bytes', () => {
+    const shortR = new Uint8Array(1).fill(0x01);
+    const shortS = new Uint8Array(1).fill(0x02);
+    const result = buildRawHexSignature(shortR, shortS, 27);
+    // r should be left-padded: 31 zero bytes + 0x01
+    expect(result.slice(2, 2 + 64)).toBe('0'.repeat(62) + '01');
+    // s should be left-padded: 31 zero bytes + 0x02
+    expect(result.slice(2 + 64, 2 + 128)).toBe('0'.repeat(62) + '02');
+  });
+
+  it('encodes v correctly in the last byte(s)', () => {
+    const result = buildRawHexSignature(r32, s32, 28);
+    expect(result.slice(2 + 128)).toBe('1c');
+  });
+
+  it('encodes multi-byte v values', () => {
+    // v = 0x0101 = 257
+    const result = buildRawHexSignature(r32, s32, 0x0101);
+    expect(result.slice(2 + 128)).toBe('0101');
   });
 });

--- a/__tests__/metro.resolveRequest.test.ts
+++ b/__tests__/metro.resolveRequest.test.ts
@@ -57,6 +57,23 @@ describe('metro.resolveRequest', () => {
         'android',
       );
     });
+
+    it('forces async-storage resolution from the project root shim', () => {
+      resolveRequest(
+        mockContext as any,
+        '@react-native-async-storage/async-storage',
+        'android',
+      );
+      expect(resolve).toHaveBeenCalledTimes(1);
+      assertNoResolveRequestRecursion();
+      expect(resolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originModulePath: expect.stringMatching(/_shim_\.js$/),
+        }),
+        '@react-native-async-storage/async-storage',
+        'android',
+      );
+    });
   });
 
   describe('offline build', () => {

--- a/__tests__/qrDetector.test.ts
+++ b/__tests__/qrDetector.test.ts
@@ -1,0 +1,30 @@
+import { detectWcUri } from '../src/utils/walletConnect/qrDetector.online';
+
+const navigate = jest.fn();
+const navigation = { navigate } as any;
+
+beforeEach(() => navigate.mockClear());
+
+describe('detectWcUri', () => {
+  it('returns false and does not navigate for non-wc URIs', () => {
+    expect(detectWcUri('https://example.com', navigation)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('returns false for empty string', () => {
+    expect(detectWcUri('', navigation)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('returns true and navigates for wc: URI', () => {
+    const uri = 'wc:abc123@2?relay-protocol=irn';
+    expect(detectWcUri(uri, navigation)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith('WalletConnectPairing', { uri });
+  });
+
+  it('is case-insensitive for the wc: prefix', () => {
+    const uri = 'WC:abc123@2?relay-protocol=irn';
+    expect(detectWcUri(uri, navigation)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith('WalletConnectPairing', { uri });
+  });
+});

--- a/__tests__/useWalletConnectSession.test.ts
+++ b/__tests__/useWalletConnectSession.test.ts
@@ -1,0 +1,131 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import { SUPPORTED_WC_EIP155_CHAIN_IDS } from '../src/constants/walletConnect';
+import {
+  WalletConnectContext,
+  WalletConnectContextValue,
+} from '../src/providers/walletConnect/context';
+import { useWalletConnectSession as useWalletConnectSessionOnline } from '../src/hooks/useWalletConnectSession.online';
+
+// ── Chain intersection helpers (mirrors logic in Provider.online.tsx) ────────
+
+function computeApprovedChains(requestedChains: string[]): string[] {
+  const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
+  return requestedChains.filter(c => supported.includes(c));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('WalletConnect chain intersection', () => {
+  it('approves chains present in the allowlist', () => {
+    const result = computeApprovedChains(['eip155:1', 'eip155:137']);
+    expect(result).toEqual(['eip155:1', 'eip155:137']);
+  });
+
+  it('filters out chains not in the allowlist', () => {
+    const result = computeApprovedChains(['eip155:1', 'eip155:56']); // BSC not supported
+    expect(result).toEqual(['eip155:1']);
+  });
+
+  it('returns empty array when no requested chain is supported', () => {
+    const result = computeApprovedChains(['eip155:56', 'eip155:250']);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array for empty request', () => {
+    expect(computeApprovedChains([])).toHaveLength(0);
+  });
+
+  it('includes all five supported chains when all are requested', () => {
+    const allSupported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(
+      id => `eip155:${id}`,
+    );
+    expect(computeApprovedChains(allSupported)).toEqual(allSupported);
+  });
+});
+
+describe('WalletConnect supported methods', () => {
+  const SUPPORTED_METHODS = [
+    'personal_sign',
+    'eth_signTypedData',
+    'eth_signTypedData_v4',
+  ];
+
+  it('personal_sign is supported', () => {
+    expect(SUPPORTED_METHODS).toContain('personal_sign');
+  });
+
+  it('eth_signTypedData_v4 is supported', () => {
+    expect(SUPPORTED_METHODS).toContain('eth_signTypedData_v4');
+  });
+
+  it('eth_sendTransaction is not supported', () => {
+    expect(SUPPORTED_METHODS).not.toContain('eth_sendTransaction');
+  });
+
+  it('wallet_switchEthereumChain is not supported', () => {
+    expect(SUPPORTED_METHODS).not.toContain('wallet_switchEthereumChain');
+  });
+
+  it('unknown methods are not supported', () => {
+    expect(SUPPORTED_METHODS).not.toContain('eth_accounts');
+  });
+});
+
+describe('useWalletConnectSession offline stub', () => {
+  const {
+    useWalletConnectSession,
+  } = require('../src/hooks/useWalletConnectSession.offline');
+
+  it('returns idle phase and null session', () => {
+    const result = useWalletConnectSession();
+    expect(result.phase).toBe('idle');
+    expect(result.activeSession).toBeNull();
+    expect(result.pendingRequest).toBeNull();
+  });
+
+  it('all actions are no-ops', async () => {
+    const result = useWalletConnectSession();
+    await expect(result.pair('wc:test')).resolves.toBeUndefined();
+    await expect(result.approveSession('0x123')).resolves.toBeUndefined();
+    await expect(result.disconnect()).resolves.toBeUndefined();
+    await expect(
+      result.respondSuccess({ id: 1, topic: 't' }, '0x'),
+    ).resolves.toBeUndefined();
+    await expect(
+      result.respondError({ id: 1, topic: 't' }, -32000, 'err'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('useWalletConnectSession online hook', () => {
+  const value: WalletConnectContextValue = {
+    phase: 'idle',
+    activeSession: null,
+    pendingRequest: null,
+    pair: jest.fn(),
+    approveSession: jest.fn(),
+    rejectSession: jest.fn(),
+    disconnect: jest.fn(),
+    respondSuccess: jest.fn(),
+    respondError: jest.fn(),
+  };
+
+  it('throws when used outside WalletConnectProvider', () => {
+    expect(() => renderHook(() => useWalletConnectSessionOnline())).toThrow(
+      'useWalletConnectSession must be used inside WalletConnectProvider',
+    );
+  });
+
+  it('returns the WalletConnect context value when provided', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(WalletConnectContext.Provider, { value }, children);
+
+    const { result } = renderHook(() => useWalletConnectSessionOnline(), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(value);
+  });
+});

--- a/__tests__/walletConnectRequestAdapter.test.ts
+++ b/__tests__/walletConnectRequestAdapter.test.ts
@@ -1,0 +1,226 @@
+import { wcRequestToScanResult } from '../src/utils/walletConnect/requestAdapter';
+import type { WCRequest } from '../src/providers/walletConnect/context';
+
+function makeReq(method: string, params: unknown[]): WCRequest {
+  return { id: 1, topic: 'topic', method, params };
+}
+
+function expectEthSignResult(result: ReturnType<typeof wcRequestToScanResult>) {
+  expect(result.kind).toBe('eth-sign-request');
+  if (result.kind !== 'eth-sign-request') {
+    throw new Error('Expected eth-sign-request');
+  }
+  return result;
+}
+
+describe('wcRequestToScanResult — personal_sign', () => {
+  const addr = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+  const addressToPath = new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/0"]]);
+
+  it('standard order [message, address] → dataType=3', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', ['0xdeadbeef', addr]),
+        addressToPath,
+      ),
+    );
+    expect(result.request.dataType).toBe(3);
+    expect(result.request.signData).toBe('0xdeadbeef');
+    expect(result.request.address).toBe(addr);
+  });
+
+  it('reversed order [address, message] → still correct', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', [addr, '0xdeadbeef']),
+        addressToPath,
+      ),
+    );
+    expect(result.request.signData).toBe('0xdeadbeef');
+    expect(result.request.address).toBe(addr);
+  });
+
+  it('hex-encodes plain UTF-8 message string', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', ['Hello GapSign', addr]),
+        addressToPath,
+      ),
+    );
+    // "Hello GapSign" → hex
+    expect(result.request.signData).toMatch(/^0x[0-9a-f]+$/);
+    expect(result.request.signData).not.toBe('0x'); // non-empty
+  });
+
+  it('preserves 0x-prefixed message as-is', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', ['0xabcd1234', addr]),
+        addressToPath,
+      ),
+    );
+    expect(result.request.signData).toBe('0xabcd1234');
+  });
+
+  it('sets derivationPath and origin', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', ['0xdeadbeef', addr]),
+        addressToPath,
+      ),
+    );
+    expect(result.request.derivationPath).toBe("m/44'/60'/0'/0/0");
+    expect(result.request.origin).toBe('WalletConnect');
+  });
+});
+
+describe('wcRequestToScanResult — eth_signTypedData_v4', () => {
+  const addr = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+  const validPayload = JSON.stringify({
+    domain: { name: 'Test', version: '1', chainId: 1 },
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+      ],
+      Mail: [{ name: 'contents', type: 'string' }],
+    },
+    primaryType: 'Mail',
+    message: { contents: 'hello' },
+  });
+
+  it('returns dataType=0 with 0x-prefixed digest', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+        new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/0"]]),
+      ),
+    );
+    expect(result.request.dataType).toBe(0);
+    expect(result.request.signData).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('sets address and origin', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+        new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/0"]]),
+      ),
+    );
+    expect(result.request.address).toBe(addr);
+    expect(result.request.origin).toBe('WalletConnect');
+  });
+
+  it('includes hex-encoded reviewData', () => {
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+        new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/0"]]),
+      ),
+    );
+    expect(result.request.reviewData).toMatch(/^0x/);
+  });
+
+  it('resolves derivation path from addressToPath map', () => {
+    const map = new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/1"]]);
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+        map,
+      ),
+    );
+    expect(result.request.derivationPath).toBe("m/44'/60'/0'/0/1");
+  });
+
+  it('throws when no address map is provided', () => {
+    expect(() =>
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+      ),
+    ).toThrow('Missing WalletConnect address mapping');
+  });
+
+  it('throws when address is not in the map', () => {
+    const map = new Map<string, string>();
+    expect(() =>
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, validPayload]),
+        map,
+      ),
+    ).toThrow('not found in session');
+  });
+
+  it('throws when payload is not valid JSON', () => {
+    expect(() =>
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [addr, 'not-json']),
+      ),
+    ).toThrow('JSON parse failed');
+  });
+
+  it('throws when domain/types/message missing', () => {
+    expect(() =>
+      wcRequestToScanResult(
+        makeReq('eth_signTypedData_v4', [
+          addr,
+          JSON.stringify({ domain: {}, types: {} }),
+        ]),
+      ),
+    ).toThrow('missing domain/types/message');
+  });
+
+  it('throws when hashing fails (invalid type reference)', () => {
+    const bad = JSON.stringify({
+      domain: {},
+      types: { Foo: [{ name: 'bar', type: 'NonExistentType' }] },
+      primaryType: 'Foo',
+      message: { bar: 'x' },
+    });
+    expect(() =>
+      wcRequestToScanResult(makeReq('eth_signTypedData_v4', [addr, bad])),
+    ).toThrow('hashing failed');
+  });
+});
+
+describe('wcRequestToScanResult — personal_sign path resolution', () => {
+  it('resolves derivation path from addressToPath map', () => {
+    const addr = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+    const map = new Map([[addr.toLowerCase(), "m/44'/60'/0'/0/3"]]);
+    const result = expectEthSignResult(
+      wcRequestToScanResult(
+        makeReq('personal_sign', ['0xdeadbeef', addr]),
+        map,
+      ),
+    );
+    expect(result.request.derivationPath).toBe("m/44'/60'/0'/0/3");
+  });
+});
+
+describe('wcRequestToScanResult — unsupported methods', () => {
+  it('throws for unknown method', () => {
+    expect(() =>
+      wcRequestToScanResult(makeReq('eth_sendTransaction', [{}])),
+    ).toThrow('Unsupported method');
+  });
+});
+
+describe('wcRequestToScanResult — invalid params', () => {
+  it('throws when params array is too short', () => {
+    expect(() =>
+      wcRequestToScanResult(makeReq('personal_sign', ['only-one'])),
+    ).toThrow('expected array of at least 2 strings');
+  });
+
+  it('throws when params contain non-string values', () => {
+    expect(() =>
+      wcRequestToScanResult(makeReq('personal_sign', [123, 456])),
+    ).toThrow('expected strings');
+  });
+
+  it('throws when params do not contain a signer address', () => {
+    expect(() =>
+      wcRequestToScanResult(makeReq('personal_sign', ['message', 'payload'])),
+    ).toThrow('signer address missing');
+  });
+});

--- a/__tests__/walletConnectStorage.test.ts
+++ b/__tests__/walletConnectStorage.test.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../src/utils/buildConfig', () => ({
+  INTERNET_ENABLED: true,
+  WC_PROJECT_ID: 'build-time-id',
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+import { loadWCProjectId, saveWCProjectId } from '../src/storage/walletConnect';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('loadWCProjectId', () => {
+  it('returns override when stored', async () => {
+    mockGetItem.mockResolvedValue('  custom-id  ');
+    expect(await loadWCProjectId()).toBe('custom-id');
+  });
+
+  it('returns build-time ID when no override', async () => {
+    mockGetItem.mockResolvedValue(null);
+    expect(await loadWCProjectId()).toBe('build-time-id');
+  });
+
+  it('returns build-time ID when override is blank', async () => {
+    mockGetItem.mockResolvedValue('   ');
+    expect(await loadWCProjectId()).toBe('build-time-id');
+  });
+
+  it('returns build-time ID on AsyncStorage error', async () => {
+    mockGetItem.mockRejectedValue(new Error('storage error'));
+    expect(await loadWCProjectId()).toBe('build-time-id');
+  });
+});
+
+describe('saveWCProjectId', () => {
+  it('trims and stores the id', async () => {
+    mockSetItem.mockResolvedValue(undefined);
+    await saveWCProjectId('  my-id  ');
+    expect(mockSetItem).toHaveBeenCalledWith('wc_project_id_override', 'my-id');
+  });
+});

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,6 +78,10 @@ def enableProguardInReleaseBuilds = true
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def dotenv = new Properties()
+def dotenvFile = rootProject.file("../.env")
+if (dotenvFile.exists()) dotenv.load(dotenvFile.newInputStream())
+def wcProjectId = System.getenv("WC_PROJECT_ID") ?: dotenv.getProperty("WC_PROJECT_ID", "")
 def releaseKeystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
 def releaseKeystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
 def releaseKeyAlias = System.getenv("ANDROID_KEY_ALIAS")
@@ -105,12 +109,14 @@ android {
             // Usage in Java/Kotlin: if (BuildConfig.INTERNET_ENABLED) { ... }
             // Usage in JS: expose via a NativeModule when the first internet feature lands
             buildConfigField "boolean", "INTERNET_ENABLED", "true"
+            buildConfigField "String", "WC_PROJECT_ID", "\"${wcProjectId}\""
         }
         offline {
             dimension "distribution"
             applicationId "tech.gapsign.offline"
             // BuildConfig.INTERNET_ENABLED == false — INTERNET permission never declared
             buildConfigField "boolean", "INTERNET_ENABLED", "false"
+            buildConfigField "String", "WC_PROJECT_ID", "\"\""
         }
     }
     buildFeatures {

--- a/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
+++ b/android/app/src/main/java/tech/gapsign/BuildConfigModule.kt
@@ -7,5 +7,8 @@ class BuildConfigModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
     override fun getName() = "BuildConfig"
 
-    override fun getConstants(): Map<String, Any> = mapOf("INTERNET_ENABLED" to BuildConfig.INTERNET_ENABLED)
+    override fun getConstants(): Map<String, Any> = mapOf(
+        "INTERNET_ENABLED" to BuildConfig.INTERNET_ENABLED,
+        "WC_PROJECT_ID" to BuildConfig.WC_PROJECT_ID,
+    )
 }

--- a/docs/adr/0003-network-features-are-opt-in.md
+++ b/docs/adr/0003-network-features-are-opt-in.md
@@ -14,12 +14,15 @@ ENS resolution was already opt-in at launch. Token image fetching was opt-out (r
 
 Every network-touching feature in the online build must be **opt-in**: disabled by default, enabled explicitly by the user in Settings. Preferences are persisted via `preferencesStorage`. Storage keys for opt-in features use an `_enabled` suffix so that the unset state (no stored value) maps to `false` via the existing `loadBoolean` helper, which defaults to `false`.
 
+**Exception — gesture-gated features:** A feature does not require a Settings toggle when the user's deliberate gesture to activate it is itself an unambiguous opt-in. The activation must be explicit, targeted (not ambient), and require active user confirmation before any network connection is made. WalletConnect v2 qualifies: the user must scan a `wc:` QR code and then approve the session proposal — no network activity occurs until those steps complete. No Settings toggle is required for such features.
+
 Features covered by this decision:
 
 - ENS reverse resolution — opt-in toggle in Settings (already compliant)
 - Remote token image downloads — opt-in toggle in Settings (added in 1.7.0)
+- WalletConnect v2 — exempt; `wc:` QR scan + session approval is the opt-in gesture
 
-Any future network-touching feature added to the online build must follow the same pattern.
+Any future network-touching feature added to the online build must follow the same pattern or qualify under the gesture-gated exception.
 
 ## Rationale
 
@@ -29,10 +32,12 @@ Any future network-touching feature added to the online build must follow the sa
 
 ## Consequences
 
-- New network-touching features require a Settings toggle before shipping.
+- New network-touching features require a Settings toggle before shipping, unless they qualify under the gesture-gated exception.
 - Token images are disabled by default; users must opt in via Settings.
 - The `preferencesStorage` module grows one load/save pair per opt-in feature.
+- WalletConnect v2 ships without a Settings toggle; the `wc:` QR scan + session approval gates all network activity.
 
 ## Revisit if
 
-- A feature is so fundamental to the online build that opt-out is a better UX (e.g., a future WalletConnect integration that is the reason a user installs the online build at all).
+- A gesture-gated feature is found to make ambient network calls before user confirmation (would remove the exception for that feature).
+- The gesture-gated exception is abused for features whose activation is not clearly deliberate and targeted.

--- a/ios/GapSign.xcodeproj/project.pbxproj
+++ b/ios/GapSign.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8358A8EFDD3FDCD172AD2848 /* CameraView.m in Sources */ = {isa = PBXBuildFile; fileRef = 57CA86AF77A0EDD777EB2F36 /* CameraView.m */; };
 		8C5DBC153B2942C2944D6FD3 /* Inter_18pt-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0B00C339B9474862BB1A70F4 /* Inter_18pt-SemiBold.ttf */; };
 		911E2EBCBBDAF829F8F3F76E /* CameraViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D18B5B2CBEAB5651E0309E /* CameraViewManager.m */; };
+		AA11BB22CC33DD44AA11BB22 /* BuildConfigModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD4400112233 /* BuildConfigModule.m */; };
 		99D8BF80EADAD18B333197A2 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +28,8 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = GapSign/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-GapSign.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GapSign.debug.xcconfig"; path = "Target Support Files/Pods-GapSign/Pods-GapSign.debug.xcconfig"; sourceTree = "<group>"; };
 		43D18B5B2CBEAB5651E0309E /* CameraViewManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CameraViewManager.m; path = GapSign/CameraViewManager.m; sourceTree = "<group>"; };
+		AA11BB22CC33DD4400112233 /* BuildConfigModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = BuildConfigModule.m; path = GapSign/BuildConfigModule.m; sourceTree = "<group>"; };
+		AA11BB22CC33DD4400AABBCC /* BuildConfigModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = BuildConfigModule.h; path = GapSign/BuildConfigModule.h; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-GapSign.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GapSign.release.xcconfig"; path = "Target Support Files/Pods-GapSign/Pods-GapSign.release.xcconfig"; sourceTree = "<group>"; };
 		57CA86AF77A0EDD777EB2F36 /* CameraView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CameraView.m; path = GapSign/CameraView.m; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-GapSign.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-GapSign.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -61,6 +64,8 @@
 				E6D2A27E40DB81D631A6EF6E /* CameraView.h */,
 				57CA86AF77A0EDD777EB2F36 /* CameraView.m */,
 				43D18B5B2CBEAB5651E0309E /* CameraViewManager.m */,
+				AA11BB22CC33DD4400AABBCC /* BuildConfigModule.h */,
+				AA11BB22CC33DD4400112233 /* BuildConfigModule.m */,
 			);
 			name = GapSign;
 			sourceTree = "<group>";
@@ -275,6 +280,7 @@
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
 				8358A8EFDD3FDCD172AD2848 /* CameraView.m in Sources */,
 				911E2EBCBBDAF829F8F3F76E /* CameraViewManager.m in Sources */,
+				AA11BB22CC33DD44AA11BB22 /* BuildConfigModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +297,7 @@
 				CURRENT_PROJECT_VERSION = 10602;
 				DEVELOPMENT_TEAM = 53Q5365S97;
 				ENABLE_BITCODE = NO;
+				INTERNET_ENABLED = YES;
 				INFOPLIST_FILE = GapSign/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -326,6 +333,7 @@
 				CODE_SIGN_ENTITLEMENTS = GapSign/GapSign.entitlements;
 				CURRENT_PROJECT_VERSION = 10602;
 				DEVELOPMENT_TEAM = 53Q5365S97;
+				INTERNET_ENABLED = YES;
 				INFOPLIST_FILE = GapSign/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/GapSign/BuildConfigModule.h
+++ b/ios/GapSign/BuildConfigModule.h
@@ -1,0 +1,4 @@
+#import <React/RCTBridgeModule.h>
+
+@interface BuildConfigModule : NSObject <RCTBridgeModule>
+@end

--- a/ios/GapSign/BuildConfigModule.m
+++ b/ios/GapSign/BuildConfigModule.m
@@ -1,0 +1,32 @@
+#import "BuildConfigModule.h"
+
+@implementation BuildConfigModule
+
+RCT_EXPORT_MODULE(BuildConfig)
+
+- (NSDictionary *)constantsToExport {
+  id raw = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"WC_PROJECT_ID"];
+  id rawInternet =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"INTERNET_ENABLED"];
+  NSString *wcProjectId = @"";
+  BOOL internetEnabled = [rawInternet respondsToSelector:@selector(boolValue)]
+                             ? [rawInternet boolValue]
+                             : NO;
+  if ([raw isKindOfClass:[NSString class]]) {
+    NSString *str = (NSString *)raw;
+    // Xcode leaves the literal "$(WC_PROJECT_ID)" when the build var is unset
+    if (![str hasPrefix:@"$("]) {
+      wcProjectId = str;
+    }
+  }
+  return @{
+    @"INTERNET_ENABLED" : @(internetEnabled),
+    @"WC_PROJECT_ID" : wcProjectId,
+  };
+}
+
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+@end

--- a/ios/GapSign/Info.plist
+++ b/ios/GapSign/Info.plist
@@ -65,5 +65,9 @@
 		<string>A000000804000101</string>
 		<string>A0000008040001</string>
 	</array>
+	<key>INTERNET_ENABLED</key>
+	<string>$(INTERNET_ENABLED)</string>
+	<key>WC_PROJECT_ID</key>
+	<string>$(WC_PROJECT_ID)</string>
 </dict>
 </plist>

--- a/metro.config.js
+++ b/metro.config.js
@@ -23,6 +23,11 @@ const config = {
     extraNodeModules: {
       ...nodeLibs,
       crypto: path.join(__dirname, 'src/shims/crypto.ts'),
+      // Force WalletConnect's bundled async-storage v1 to resolve to our v3 (TurboModule-compatible)
+      '@react-native-async-storage/async-storage': path.join(
+        __dirname,
+        'node_modules/@react-native-async-storage/async-storage',
+      ),
     },
     resolveRequest: createResolveRequest(process.env.ONLINE_BUILD === 'true'),
   },

--- a/metro.resolveRequest.js
+++ b/metro.resolveRequest.js
@@ -1,4 +1,6 @@
+const path = require('path');
 const { resolve } = require('metro-resolver');
+
 
 /**
  * Creates a Metro resolveRequest hook that maps `.online` imports to `.offline`
@@ -10,6 +12,18 @@ const { resolve } = require('metro-resolver');
 function createResolveRequest(isOnlineBuild) {
   return function resolveRequest(context, moduleName, platform) {
     const { resolveRequest: _, ...restContext } = context;
+
+    // Force every require of async-storage to the root v3 package so WalletConnect's
+    // nested v1 (which breaks New Architecture) is never loaded. Spoofing
+    // originModulePath to the project root makes Metro climb from there and find
+    // the root node_modules copy instead of the nested one.
+    if (moduleName === '@react-native-async-storage/async-storage') {
+      return resolve(
+        { ...restContext, originModulePath: path.join(__dirname, '_shim_.js') },
+        moduleName,
+        platform,
+      );
+    }
 
     if (!isOnlineBuild) {
       const offlineModuleName = moduleName.replace(/\.online\b/, '.offline');

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,18 @@
         "@react-native-async-storage/async-storage": "^3.0.2",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/blur": "^4.4.1",
+        "@react-native-community/netinfo": "12.0.1",
         "@react-native-vector-icons/material-design-icons": "^13.0.0",
         "@react-native/new-app-screen": "0.83.1",
         "@react-navigation/native": "^7.1.28",
         "@react-navigation/native-stack": "^7.13.0",
+        "@reown/walletkit": "^1.5.5",
         "@scure/base": "^2.0.0",
         "@scure/bip32": "^2.0.1",
         "@scure/bip39": "^2.0.1",
+        "@walletconnect/react-native-compat": "2.23.9",
         "bitcoinjs-lib": "^6.1.7",
+        "fast-text-encoding": "1.0.6",
         "keycard-sdk": "^3.1.8",
         "node-libs-react-native": "^1.2.1",
         "react": "^19.2.0",
@@ -2943,6 +2947,15 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@ngraveio/bc-ur": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/@ngraveio/bc-ur/-/bc-ur-1.1.13.tgz",
@@ -3356,6 +3369,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native-vector-icons/common": {
@@ -3992,6 +4015,22 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
+      }
+    },
+    "node_modules/@reown/walletkit": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@reown/walletkit/-/walletkit-1.5.5.tgz",
+      "integrity": "sha512-Od8XpSCuGIkckTF5Qy7qUm0vcay98D0Vqz94wEUDz581nSipWfJIsKbm0dL2Da/wme/KcyIipLtfJN5w/GtnRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.9",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/pay": "1.0.8",
+        "@walletconnect/sign-client": "2.23.9",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9"
       }
     },
     "node_modules/@scure/base": {
@@ -4898,6 +4937,647 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.9.tgz",
+      "integrity": "sha512-ws4WG8LeagUo2ERRo02HryXRcpwIRmCQ3pHLW5gWbVReLXXIpgk6ZAfID3fEGHevIwwnHSGww+nNhNpdXyiq0g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/environment/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/heartbeat/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/pay": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/pay/-/pay-1.0.8.tgz",
+      "integrity": "sha512-0LaCIlt0XIST8CpwuUHH9z485PEX+1J869tAq04zgPIxMA6gNZJ0j7vff2smFNCeKmKjFU4RpOdbw4zDAHcJwg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "brotli": "^1.3.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/react-native-compat": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/react-native-compat/-/react-native-compat-2.23.9.tgz",
+      "integrity": "sha512-lR5CCtI8zEQNAFQVjURifN2uA3ujx3+80wzF5r/CldJ/c064Edbkyim3YeskDNVdUjUm2/ModeP5n/LYkfGAVQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "events": "3.3.0",
+        "fast-text-encoding": "1.0.6",
+        "react-native-url-polyfill": "2.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "*",
+        "@react-native-community/netinfo": "*",
+        "expo-application": "*",
+        "react-native": "*",
+        "react-native-get-random-values": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-application": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/react-native-compat/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/safe-json/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.9.tgz",
+      "integrity": "sha512-Xj+hw4E6mGRyhCdVOT/RMgnG+up/Y3v0ho5PlkVozvXWeVSqHNh9DmjLuU97a7OACoGd/oHBF6g3NVqD7MgCMQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.9",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
+      "integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.9.tgz",
+      "integrity": "sha512-C5TltCs8UPypNiteYnKSv8+ZDK2EjVDyXCxN6kA9bkA+j6KGsNIV7l9MUA8WBAvE5Gi5EcBdhD3R9Hpo/1HHqQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -5327,6 +6007,15 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5751,6 +6440,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
     "node_modules/bn.js": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -5841,6 +6536,15 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "license": "MIT"
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -6164,6 +6868,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chrome-launcher": {
@@ -6503,6 +7222,12 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -6630,6 +7355,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/crypto-js": {
@@ -6912,6 +7646,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6931,6 +7671,12 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6940,6 +7686,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -7369,6 +8121,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -8134,6 +8896,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -8651,6 +9419,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8944,6 +9729,12 @@
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9090,6 +9881,15 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arguments": {
@@ -9418,6 +10218,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -10507,6 +11318,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10910,6 +11727,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -11464,6 +12295,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -11548,6 +12385,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -11645,6 +12488,12 @@
       "dependencies": {
         "inherits": "2.0.3"
       }
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -11836,6 +12685,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -12303,6 +13172,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -12563,6 +13469,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/promise": {
@@ -12849,6 +13771,18 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
     "node_modules/randombytes": {
@@ -13266,6 +14200,18 @@
         "react-native-svg": ">=12.0.0"
       }
     },
+    "node_modules/react-native-url-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/codegen": {
       "version": "0.83.4",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.4.tgz",
@@ -13382,6 +14328,28 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -13755,6 +14723,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -14221,6 +15198,12 @@
       "integrity": "sha512-XWPeAofN5SSffrAw11HIjBWL+lcRmZMOYR/N8QPYKHh2wwAE5dVTw2EOBtl2atUojcssApsoVw0F2AvQVnGZdQ==",
       "license": "MIT"
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -14230,6 +15213,15 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -14269,6 +15261,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -14787,6 +15788,15 @@
       "deprecated": "no longer maintained",
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -15094,6 +16104,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -15112,6 +16137,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -15192,6 +16223,111 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -15487,11 +16623,34 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "android": "ONLINE_BUILD=true react-native run-android --mode fullDebug",
     "android:offline": "react-native run-android --mode offlineDebug",
-    "ios": "react-native run-ios",
+    "ios": "set -a; [ -f .env ] && . ./.env; set +a; react-native run-ios",
     "lint": "eslint .",
     "lint:android": "cd android && ./gradlew ktlintCheck",
     "lint:ios": "cd ios && swiftlint lint",
@@ -54,6 +54,10 @@
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.23.0",
     "react-native-svg": "^15.15.3",
+    "@react-native-community/netinfo": "12.0.1",
+    "@reown/walletkit": "^1.5.5",
+    "@walletconnect/react-native-compat": "2.23.9",
+    "fast-text-encoding": "1.0.6",
     "slip39": "^0.1.9",
     "viem": "^2.47.6"
   },

--- a/scripts/check-offline-bundle.js
+++ b/scripts/check-offline-bundle.js
@@ -3,15 +3,23 @@
 const fs = require('fs');
 const path = require('path');
 
-// These markers are string literals that only appear if our own ENS source
-// files are bundled. Avoid viem function names — viem is a shared dependency
-// and its barrel exports include ENS internals regardless of tree-shaking.
+// These markers are string literals that only appear if our own ENS or
+// WalletConnect source files are bundled. Avoid viem function names — viem
+// is a shared dependency and its barrel exports include ENS internals
+// regardless of tree-shaking.
 const FORBIDDEN_MARKERS = [
+  // ENS
   'ethereum-rpc.publicnode.com',
   'EnsSettingsSection',
   'saveEnsEnabled',
   'ENS RPC URL',
   'ENS lookups send',
+  // WalletConnect
+  'WalletConnectProvider',
+  'WalletConnectSettingsSection',
+  'wc_project_id_override',
+  '@reown/walletkit',
+  'reown.com/privacy-policy',
 ];
 
 function parseArgs(argv) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,12 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { PaperProvider } from 'react-native-paper';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
 import theme from './theme';
 import type { RootStackParamList } from './navigation/types';
+import { navigationRef } from './navigation/navigationRef';
 import { routes } from './navigation/routes';
+import { OnlineProviders } from './providers/onlineProviders.online';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -24,17 +27,19 @@ export default function App() {
           barStyle="light-content"
           backgroundColor={theme.colors.background}
         />
-        <NavigationContainer>
-          <Stack.Navigator screenOptions={{ headerShown: false }}>
-            {routes.map(r => (
-              <Stack.Screen
-                key={r.name}
-                name={r.name}
-                component={r.component}
-                options={r.options}
-              />
-            ))}
-          </Stack.Navigator>
+        <NavigationContainer ref={navigationRef}>
+          <OnlineProviders>
+            <Stack.Navigator screenOptions={{ headerShown: false }}>
+              {routes.map(r => (
+                <Stack.Screen
+                  key={r.name}
+                  name={r.name}
+                  component={r.component}
+                  options={r.options}
+                />
+              ))}
+            </Stack.Navigator>
+          </OnlineProviders>
         </NavigationContainer>
       </PaperProvider>
     </SafeAreaProvider>

--- a/src/components/SignRequestDetail/eth/DataTabPanel/Eip712JsonPanel.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/Eip712JsonPanel.tsx
@@ -29,13 +29,19 @@ export default function Eip712JsonPanel({
 
   const eip712Digest = useMemo(() => {
     const raw = parseEip712RawTypedData(request.signData);
-    if (!raw) return null;
-    return computeEip712DigestFromJson(
-      raw.domain,
-      raw.message,
-      raw.primaryType,
-      raw.types,
-    );
+    if (raw) {
+      return computeEip712DigestFromJson(
+        raw.domain,
+        raw.message,
+        raw.primaryType,
+        raw.types,
+      );
+    }
+    // dataType=0 (WC pre-hashed): signData is already the 32-byte digest
+    if (/^0x[0-9a-fA-F]{64}$/.test(request.signData)) {
+      return request.signData;
+    }
+    return null;
   }, [request.signData]);
 
   return (

--- a/src/components/SignRequestDetail/eth/SignRequestDetail.tsx
+++ b/src/components/SignRequestDetail/eth/SignRequestDetail.tsx
@@ -22,14 +22,15 @@ export default function SignRequestDetail({
     request.chainId !== undefined
       ? getNativeCurrencySymbol(request.chainId)
       : 'ETH';
-  const typeLabel = getTxLabel(request.signData, request.dataType);
-  const tx = parseTx(request.signData, request.dataType, nativeSymbol);
-  const eip712 =
-    request.dataType === 2 ? parseEip712Summary(request.signData) : null;
+  // WC EIP-712 requests carry original JSON in reviewData (dataType=0 + digest in signData)
+  const eip712Source =
+    request.reviewData ?? (request.dataType === 2 ? request.signData : null);
+  const eip712 = eip712Source ? parseEip712Summary(eip712Source) : null;
   const eip712Prehashed =
-    request.dataType === 2 && !eip712
-      ? parseEip712Prehashed(request.signData)
-      : null;
+    eip712Source && !eip712 ? parseEip712Prehashed(eip712Source) : null;
+  const typeLabel =
+    eip712?.primaryType ?? getTxLabel(request.signData, request.dataType);
+  const tx = parseTx(request.signData, request.dataType, nativeSymbol);
   const signer = request.address
     ? checksumEthAddress(request.address)
     : request.derivationPath;

--- a/src/components/settings/TextInputSetting.tsx
+++ b/src/components/settings/TextInputSetting.tsx
@@ -1,52 +1,66 @@
-import { ActivityIndicator, StyleSheet, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  KeyboardTypeOptions,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
 import { Text } from 'react-native-paper';
 
-import theme from '../../../theme';
+import theme from '../../theme';
 
-export default function EnsRpcUrlInput({
-  input,
+export default function TextInputSetting({
+  label,
+  value,
   dirty,
-  validating,
+  saving,
   error,
+  placeholder,
+  keyboardType,
   onChangeText,
   onRevert,
   onSave,
 }: {
-  input: string;
+  label: string;
+  value: string;
   dirty: boolean;
-  validating: boolean;
-  error: string | null;
-  onChangeText: (value: string) => void;
+  saving?: boolean;
+  error?: string | null;
+  placeholder?: string;
+  keyboardType?: KeyboardTypeOptions;
+  onChangeText: (v: string) => void;
   onRevert: () => void;
   onSave: () => void;
 }) {
   return (
     <>
-      <Text variant="bodySmall" style={styles.fieldLabel}>
-        RPC URL
+      <Text variant="bodySmall" style={styles.label}>
+        {label}
       </Text>
       <TextInput
         style={styles.input}
-        value={input}
+        value={value}
         onChangeText={onChangeText}
         autoCapitalize="none"
         autoCorrect={false}
-        keyboardType="url"
-        editable={!validating}
+        placeholder={placeholder}
+        placeholderTextColor={theme.colors.onSurfaceVariant}
+        keyboardType={keyboardType}
+        editable={!saving}
       />
-      {error && <Text style={styles.error}>{error}</Text>}
-      {(dirty || validating) && (
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {(dirty || saving) && (
         <View style={styles.buttonRow}>
-          {dirty && !validating && (
+          {dirty && !saving && (
             <Text style={styles.revertButton} onPress={onRevert}>
               Revert
             </Text>
           )}
           <Text
-            style={[styles.saveButton, validating && styles.saveButtonDisabled]}
-            onPress={validating ? undefined : onSave}
+            style={[styles.saveButton, saving && styles.saveButtonDisabled]}
+            onPress={saving ? undefined : onSave}
           >
-            {validating ? (
+            {saving ? (
               <ActivityIndicator size="small" color={theme.colors.primary} />
             ) : (
               'Save'
@@ -59,7 +73,7 @@ export default function EnsRpcUrlInput({
 }
 
 const styles = StyleSheet.create({
-  fieldLabel: {
+  label: {
     color: theme.colors.onSurfaceVariant,
   },
   input: {

--- a/src/components/settings/WalletConnectSettingsSection.offline.tsx
+++ b/src/components/settings/WalletConnectSettingsSection.offline.tsx
@@ -1,0 +1,3 @@
+export default function WalletConnectSettingsSection() {
+  return null;
+}

--- a/src/components/settings/WalletConnectSettingsSection.online.tsx
+++ b/src/components/settings/WalletConnectSettingsSection.online.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import theme from '../../theme';
+
+import TextInputSetting from './TextInputSetting';
+
+import { loadWCProjectId, saveWCProjectId } from '../../storage/walletConnect';
+import { wcClient } from '../../utils/walletConnect/client.online';
+
+export default function WalletConnectSettingsSection() {
+  const [input, setInput] = useState('');
+  const [saved, setSaved] = useState('');
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    loadWCProjectId()
+      .then(id => {
+        setInput(id);
+        setSaved(id);
+      })
+      .finally(() => setLoaded(true));
+  }, []);
+
+  const dirty = loaded && input !== saved;
+
+  const handleRevert = useCallback(() => {
+    setInput(saved);
+  }, [saved]);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = input.trim();
+    await saveWCProjectId(trimmed);
+    setSaved(trimmed);
+    wcClient.resetClient();
+  }, [input]);
+
+  if (!loaded) return null;
+
+  return (
+    <View style={styles.section}>
+      <Text variant="labelLarge" style={styles.title}>
+        WalletConnect
+      </Text>
+      <TextInputSetting
+        label="Project ID"
+        value={input}
+        dirty={dirty}
+        placeholder="Enter WalletConnect Project ID"
+        onChangeText={setInput}
+        onRevert={handleRevert}
+        onSave={handleSave}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    gap: 8,
+  },
+  title: {
+    color: theme.colors.onSurface,
+  },
+});

--- a/src/components/settings/ens/EnsSettingsSection.online.tsx
+++ b/src/components/settings/ens/EnsSettingsSection.online.tsx
@@ -4,7 +4,7 @@ import { Text } from 'react-native-paper';
 
 import theme from '../../../theme';
 
-import EnsRpcUrlInput from './EnsRpcUrlInput';
+import TextInputSetting from '../TextInputSetting';
 import SettingsToggleRow from '../SettingsToggleRow';
 
 import { clearEnsNameCache } from '../../../hooks/ens/useEnsName.online';
@@ -105,11 +105,14 @@ export default function EnsSettingsSection() {
         onValueChange={handleToggle}
       />
       {enabled && (
-        <EnsRpcUrlInput
-          input={input}
+        <TextInputSetting
+          label="RPC URL"
+          value={input}
           dirty={dirty}
-          validating={validating}
+          saving={validating}
           error={error}
+          placeholder={DEFAULT_ENS_RPC_URL}
+          keyboardType="url"
           onChangeText={value => {
             setInput(value);
             setError(null);

--- a/src/components/walletConnect/DashboardCard.offline.tsx
+++ b/src/components/walletConnect/DashboardCard.offline.tsx
@@ -1,0 +1,3 @@
+export default function WalletConnectDashboardCard() {
+  return null;
+}

--- a/src/components/walletConnect/DashboardCard.online.tsx
+++ b/src/components/walletConnect/DashboardCard.online.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+
+import theme from '@/theme';
+
+import AddressText from '@/components/AddressText';
+import { useWalletConnectSession } from '@/hooks/useWalletConnectSession.online';
+
+export default function WalletConnectDashboardCard() {
+  const { phase, disconnect } = useWalletConnectSession();
+
+  const handleDisconnect = useCallback(() => {
+    disconnect();
+  }, [disconnect]);
+
+  if (typeof phase !== 'object' || phase.kind !== 'active') {
+    return null;
+  }
+
+  const { session } = phase;
+  const { name, url } = session.peer.metadata;
+  const accounts = session.namespaces.eip155?.accounts ?? [];
+  const firstAddress = accounts[0]?.split(':')[2] ?? null;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <View style={styles.info}>
+          <Text variant="labelLarge" style={styles.dAppName}>
+            {name}
+          </Text>
+          {!!url && (
+            <Text variant="bodySmall" style={styles.dAppUrl}>
+              {url}
+            </Text>
+          )}
+          {!!firstAddress && (
+            <AddressText address={firstAddress} style={styles.address} />
+          )}
+        </View>
+        <Button
+          mode="outlined"
+          compact
+          onPress={handleDisconnect}
+          textColor={theme.colors.error}
+          style={styles.disconnectBtn}
+        >
+          Disconnect
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 12,
+    padding: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  info: {
+    flex: 1,
+    gap: 2,
+  },
+  dAppName: {
+    color: theme.colors.onSurface,
+    fontWeight: '600',
+  },
+  dAppUrl: {
+    color: theme.colors.onSurfaceVariant,
+  },
+  address: {
+    marginTop: 2,
+  },
+  disconnectBtn: {
+    borderColor: theme.colors.error,
+  },
+});

--- a/src/constants/walletConnect.ts
+++ b/src/constants/walletConnect.ts
@@ -1,0 +1,23 @@
+export const SUPPORTED_WC_METHODS = [
+  'personal_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v4',
+] as const;
+
+export const SUPPORTED_WC_EIP155_CHAIN_IDS = [
+  // Mainnets
+  1, // Ethereum Mainnet
+  10, // Optimism
+  137, // Polygon
+  8453, // Base
+  42161, // Arbitrum One
+  // Testnets
+  11155111, // Sepolia
+  11155420, // Optimism Sepolia
+  80002, // Polygon Amoy
+  84532, // Base Sepolia
+  421614, // Arbitrum Sepolia
+  17000, // Holesky
+] as const;
+
+export type WCContext = { id: number; topic: string };

--- a/src/hooks/useWalletConnectSession.offline.ts
+++ b/src/hooks/useWalletConnectSession.offline.ts
@@ -1,0 +1,30 @@
+import type { WCContext } from '@/constants/walletConnect';
+import type {
+  SessionPhase,
+  WCRequest,
+  ActiveSession,
+} from './useWalletConnectSession.online';
+
+export type { SessionPhase, WCRequest, ActiveSession };
+
+export function useWalletConnectSession() {
+  const phase: SessionPhase = 'idle';
+  const activeSession: ActiveSession | null = null;
+  const pendingRequest: WCRequest | null = null;
+
+  return {
+    phase,
+    activeSession,
+    pendingRequest,
+    pair: async (_uri: string) => {},
+    approveSession: async (_address: string, _derivationPath: string) => {},
+    rejectSession: async (_proposal: unknown) => {},
+    disconnect: async () => {},
+    respondSuccess: async (_context: WCContext, _result: string) => {},
+    respondError: async (
+      _context: WCContext,
+      _code: number,
+      _message: string,
+    ) => {},
+  };
+}

--- a/src/hooks/useWalletConnectSession.online.ts
+++ b/src/hooks/useWalletConnectSession.online.ts
@@ -1,0 +1,22 @@
+import { useContext } from 'react';
+
+import {
+  WalletConnectContext,
+  WalletConnectContextValue,
+} from '@/providers/walletConnect/context';
+
+export type {
+  SessionPhase,
+  WCRequest,
+  ActiveSession,
+} from '@/providers/walletConnect/context';
+
+export function useWalletConnectSession(): WalletConnectContextValue {
+  const ctx = useContext(WalletConnectContext);
+  if (!ctx) {
+    throw new Error(
+      'useWalletConnectSession must be used inside WalletConnectProvider',
+    );
+  }
+  return ctx;
+}

--- a/src/navigation/navigationRef.ts
+++ b/src/navigation/navigationRef.ts
@@ -1,0 +1,5 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+import type { RootStackParamList } from './types';
+
+export const navigationRef = createNavigationContainerRef<RootStackParamList>();

--- a/src/navigation/onlineRoutes.offline.ts
+++ b/src/navigation/onlineRoutes.offline.ts
@@ -1,0 +1,10 @@
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import type { RootStackParamList } from './types';
+
+type Route = {
+  name: keyof RootStackParamList;
+  component: React.ComponentType<any>;
+  options?: NativeStackNavigationOptions;
+};
+
+export const onlineRoutes: Route[] = [];

--- a/src/navigation/onlineRoutes.online.ts
+++ b/src/navigation/onlineRoutes.online.ts
@@ -1,0 +1,15 @@
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import React from 'react';
+
+import type { RootStackParamList } from './types';
+import WalletConnectPairingScreen from '../screens/WalletConnectPairingScreen';
+
+type Route = {
+  name: keyof RootStackParamList;
+  component: React.ComponentType<any>;
+  options?: NativeStackNavigationOptions;
+};
+
+export const onlineRoutes: Route[] = [
+  { name: 'WalletConnectPairing', component: WalletConnectPairingScreen },
+];

--- a/src/navigation/routes.ts
+++ b/src/navigation/routes.ts
@@ -3,6 +3,7 @@ import React from 'react';
 
 import theme from '../theme';
 import type { RootStackParamList } from './types';
+import { onlineRoutes } from './onlineRoutes.online';
 
 // Top-level screens
 import AboutScreen from '../screens/AboutScreen';
@@ -191,4 +192,6 @@ export const routes: Route[] = [
     component: SettingsScreen,
     options: { ...defaultHeaderOptions, title: 'Settings' },
   },
+
+  ...onlineRoutes,
 ];

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,6 +1,7 @@
 import { NavigationProp } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
+import type { WCContext } from '../constants/walletConnect';
 import type { ScanResult } from '../types';
 
 export type KeycardParams =
@@ -12,6 +13,7 @@ export type KeycardParams =
       chainId?: number;
       requestId?: string;
       dataType?: number;
+      wcContext?: WCContext;
     }
   | {
       operation: 'sign';
@@ -38,13 +40,14 @@ export type SecretType = 'pin' | 'puk' | 'pairing';
 
 export type RootStackParamList = {
   Dashboard: { toast?: string } | undefined;
+  WalletConnectPairing: { uri: string };
   KeycardMenu: undefined;
   SetCardName: undefined;
   InitCard: undefined;
   SecretsMenu: undefined;
   ChangeSecret: { secretType: SecretType };
   QRScanner: undefined;
-  TransactionDetail: { result: ScanResult };
+  TransactionDetail: { result: ScanResult; wcContext?: WCContext };
   Keycard: KeycardParams;
   ExportKey: undefined;
   KeyPairMenu: undefined;
@@ -202,6 +205,11 @@ export type UrlQRScreenProps = NativeStackScreenProps<
 export type SettingsScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'Settings'
+>;
+
+export type WalletConnectPairingScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  'WalletConnectPairing'
 >;
 
 export type DashboardAction = {

--- a/src/providers/onlineProviders.offline.tsx
+++ b/src/providers/onlineProviders.offline.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function OnlineProviders({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/providers/onlineProviders.online.tsx
+++ b/src/providers/onlineProviders.online.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { WalletConnectProvider } from './walletConnect/Provider.online';
+
+export function OnlineProviders({ children }: { children: React.ReactNode }) {
+  return <WalletConnectProvider>{children}</WalletConnectProvider>;
+}

--- a/src/providers/walletConnect/Provider.online.tsx
+++ b/src/providers/walletConnect/Provider.online.tsx
@@ -1,0 +1,418 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+import {
+  SUPPORTED_WC_EIP155_CHAIN_IDS,
+  SUPPORTED_WC_METHODS,
+  WCContext,
+} from '@/constants/walletConnect';
+import { navigationRef } from '@/navigation/navigationRef';
+import { wcClient } from '@/utils/walletConnect/client.online';
+import { wcRequestToScanResult } from '@/utils/walletConnect/requestAdapter';
+
+import {
+  ActiveSession,
+  SessionPhase,
+  SessionProposalEvent,
+  WalletConnectContext,
+  WalletConnectContextValue,
+  WCRequest,
+} from './context';
+
+const SUPPORTED_METHODS: string[] = [...SUPPORTED_WC_METHODS];
+
+type ResolvedNamespaces = {
+  approvedChains: string[];
+  approvedMethods: string[];
+  unsupportedNamespaces: string[];
+  unsupportedRequired: string[];
+  unsupportedRequiredChains: string[];
+};
+
+function resolveNamespaces(proposal: SessionProposalEvent): ResolvedNamespaces {
+  const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
+  const unsupportedNamespaces = Object.keys(
+    proposal.params.requiredNamespaces,
+  ).filter(ns => ns !== 'eip155');
+
+  const requiredChains =
+    proposal.params.requiredNamespaces.eip155?.chains ?? [];
+  const optionalChains =
+    proposal.params.optionalNamespaces?.eip155?.chains ?? [];
+  const requestedChains = [...new Set([...requiredChains, ...optionalChains])];
+  const approvedChains =
+    requestedChains.length > 0
+      ? requestedChains.filter(c => supported.includes(c))
+      : supported;
+
+  const requiredMethods =
+    proposal.params.requiredNamespaces.eip155?.methods ?? [];
+  const optionalMethods =
+    proposal.params.optionalNamespaces?.eip155?.methods ?? [];
+  const requestedMethods = [
+    ...new Set([...requiredMethods, ...optionalMethods]),
+  ];
+  const approvedMethods =
+    requestedMethods.length > 0
+      ? requestedMethods.filter(m => SUPPORTED_METHODS.includes(m))
+      : SUPPORTED_METHODS;
+
+  const unsupportedRequired = requiredMethods.filter(
+    m => !SUPPORTED_METHODS.includes(m),
+  );
+
+  const unsupportedRequiredChains = requiredChains.filter(
+    c => !supported.includes(c),
+  );
+
+  return {
+    approvedChains,
+    approvedMethods,
+    unsupportedNamespaces,
+    unsupportedRequired,
+    unsupportedRequiredChains,
+  };
+}
+
+export function WalletConnectProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [phase, setPhase] = useState<SessionPhase>('idle');
+  const [activeSession, setActiveSession] = useState<ActiveSession | null>(
+    null,
+  );
+  const [pendingRequest, setPendingRequest] = useState<WCRequest | null>(null);
+
+  const activeSessionRef = useRef<ActiveSession | null>(null);
+  const activeRequestRef = useRef<WCRequest | null>(null);
+  const addressPathRef = useRef<Map<string, string>>(new Map());
+  const respondedRef = useRef(false);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', next => {
+      appStateRef.current = next;
+    });
+    return () => sub.remove();
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    let removeListeners: (() => void) | undefined;
+
+    wcClient.getClient().then(client => {
+      if (!mounted) return;
+
+      function onProposal(event: SessionProposalEvent) {
+        if (!mounted) return;
+        setPhase({ kind: 'proposal', proposal: event });
+      }
+
+      async function onRequest(event: {
+        id: number;
+        topic: string;
+        params: { request: { method: string; params: unknown } };
+      }) {
+        if (!mounted) return;
+
+        const { id, topic } = event;
+        const { method, params } = event.params.request;
+
+        if (!SUPPORTED_METHODS.includes(method)) {
+          await wcClient.respondError(
+            id,
+            topic,
+            -32601,
+            `${method} not supported`,
+          );
+          return;
+        }
+
+        if (activeRequestRef.current) {
+          await wcClient.respondError(id, topic, -32000, 'Wallet is busy');
+          return;
+        }
+
+        if (appStateRef.current !== 'active') {
+          await wcClient.respondError(
+            id,
+            topic,
+            -32000,
+            'Wallet is not active',
+          );
+          return;
+        }
+
+        const req: WCRequest = { id, topic, method, params };
+        activeRequestRef.current = req;
+        respondedRef.current = false;
+        setPendingRequest(req);
+
+        try {
+          const result = wcRequestToScanResult(req, addressPathRef.current);
+          if (navigationRef.isReady()) {
+            navigationRef.navigate('TransactionDetail', {
+              result,
+              wcContext: { id, topic },
+            });
+          } else {
+            await wcClient.respondError(id, topic, -32000, 'Wallet not ready');
+            activeRequestRef.current = null;
+            respondedRef.current = true;
+            setPendingRequest(null);
+          }
+        } catch {
+          await wcClient.respondError(id, topic, -32602, 'Invalid params');
+          activeRequestRef.current = null;
+          respondedRef.current = true;
+          setPendingRequest(null);
+        }
+      }
+
+      function onDelete() {
+        if (!mounted) return;
+        activeSessionRef.current = null;
+        activeRequestRef.current = null;
+        addressPathRef.current.clear();
+        setActiveSession(null);
+        setPendingRequest(null);
+        setPhase('idle');
+      }
+
+      client.on('session_proposal', onProposal);
+      client.on('session_request', onRequest);
+      client.on('session_delete', onDelete);
+
+      removeListeners = () => {
+        client.off('session_proposal', onProposal);
+        client.off('session_request', onRequest);
+        client.off('session_delete', onDelete);
+      };
+    });
+
+    return () => {
+      mounted = false;
+      removeListeners?.();
+    };
+  }, []);
+
+  const pair = useCallback(async (uri: string) => {
+    setPhase('pairing');
+    try {
+      await wcClient.pair(uri);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Pairing failed';
+      setPhase({ kind: 'error', message: msg });
+    }
+  }, []);
+
+  const rejectProposal = useCallback(
+    async (
+      proposal: SessionProposalEvent,
+      reason: string,
+      code = 5100,
+      noSessionPhase: SessionPhase = { kind: 'error', message: reason },
+    ) => {
+      try {
+        const client = await wcClient.getClient();
+        await client.rejectSession({
+          id: proposal.id,
+          reason: { code, message: reason },
+        });
+      } catch {
+        // ignore
+      }
+      setPhase(
+        activeSessionRef.current
+          ? { kind: 'active', session: activeSessionRef.current }
+          : noSessionPhase,
+      );
+    },
+    [],
+  );
+
+  const displaceActiveSession = useCallback(async () => {
+    if (!activeSessionRef.current) return;
+    if (activeRequestRef.current) {
+      const { id, topic } = activeRequestRef.current;
+      await wcClient.respondError(id, topic, -32000, 'Wallet session replaced');
+      activeRequestRef.current = null;
+      setPendingRequest(null);
+    }
+    await wcClient.disconnect(activeSessionRef.current.topic);
+  }, []);
+
+  const approveSession = useCallback(
+    async (address: string, derivationPath: string) => {
+      const currentPhase = phase;
+      if (
+        typeof currentPhase !== 'object' ||
+        currentPhase.kind !== 'proposal'
+      ) {
+        return;
+      }
+      const { proposal } = currentPhase;
+      const {
+        approvedChains,
+        approvedMethods,
+        unsupportedNamespaces,
+        unsupportedRequired,
+        unsupportedRequiredChains,
+      } = resolveNamespaces(proposal);
+
+      if (
+        unsupportedNamespaces.length > 0 ||
+        unsupportedRequiredChains.length > 0 ||
+        unsupportedRequired.length > 0
+      ) {
+        const reason =
+          unsupportedNamespaces.length > 0
+            ? `Required namespaces not supported: ${unsupportedNamespaces.join(
+                ', ',
+              )}`
+            : unsupportedRequiredChains.length > 0
+            ? `Required chains not supported: ${unsupportedRequiredChains.join(
+                ', ',
+              )}`
+            : `Required methods not supported: ${unsupportedRequired.join(
+                ', ',
+              )}`;
+        await rejectProposal(proposal, reason);
+        return;
+      }
+
+      addressPathRef.current.set(address.toLowerCase(), derivationPath);
+      setPhase('approving');
+
+      try {
+        await displaceActiveSession();
+
+        const client = await wcClient.getClient();
+        const session = await client.approveSession({
+          id: proposal.id,
+          namespaces: {
+            eip155: {
+              chains: approvedChains,
+              methods: approvedMethods,
+              events: ['accountsChanged', 'chainChanged'],
+              accounts: approvedChains.map((c: string) => `${c}:${address}`),
+            },
+          },
+        });
+
+        activeSessionRef.current = session as unknown as ActiveSession;
+        setActiveSession(session as unknown as ActiveSession);
+        setPhase({
+          kind: 'active',
+          session: session as unknown as ActiveSession,
+        });
+      } catch (e: unknown) {
+        const raw = e instanceof Error ? e.message : '';
+        const msg =
+          raw.includes("proposal id doesn't exist") ||
+          raw.includes('No matching key')
+            ? 'Connection request expired. Scan the QR code again.'
+            : raw || 'Session approval failed';
+        setPhase({ kind: 'error', message: msg });
+      }
+    },
+    [phase, rejectProposal, displaceActiveSession],
+  );
+
+  const rejectSession = useCallback(
+    async (proposal: SessionProposalEvent) => {
+      await rejectProposal(
+        proposal,
+        'User rejected the session proposal',
+        5000,
+        'idle',
+      );
+    },
+    [rejectProposal],
+  );
+
+  const disconnect = useCallback(async () => {
+    const session = activeSessionRef.current;
+    if (!session) return;
+    try {
+      await wcClient.disconnect(session.topic);
+    } catch {
+      // ignore — session may already be gone on the relay
+    }
+    activeSessionRef.current = null;
+    activeRequestRef.current = null;
+    addressPathRef.current.clear();
+    setActiveSession(null);
+    setPendingRequest(null);
+    setPhase('idle');
+  }, []);
+
+  const respondSuccess = useCallback(
+    async (context: WCContext, result: string) => {
+      if (respondedRef.current) return;
+      respondedRef.current = true;
+      try {
+        await wcClient.respondSuccess(context.id, context.topic, result);
+      } catch {
+        // ignore — request may have expired on the relay
+      }
+      activeRequestRef.current = null;
+      setPendingRequest(null);
+    },
+    [],
+  );
+
+  const respondError = useCallback(
+    async (context: WCContext, code: number, message: string) => {
+      if (respondedRef.current) return;
+      respondedRef.current = true;
+      try {
+        await wcClient.respondError(context.id, context.topic, code, message);
+      } catch {
+        // ignore — request may have expired on the relay
+      }
+      activeRequestRef.current = null;
+      setPendingRequest(null);
+    },
+    [],
+  );
+
+  const value = useMemo<WalletConnectContextValue>(
+    () => ({
+      phase,
+      activeSession,
+      pendingRequest,
+      pair,
+      approveSession,
+      rejectSession,
+      disconnect,
+      respondSuccess,
+      respondError,
+    }),
+    [
+      phase,
+      activeSession,
+      pendingRequest,
+      pair,
+      approveSession,
+      rejectSession,
+      disconnect,
+      respondSuccess,
+      respondError,
+    ],
+  );
+
+  return (
+    <WalletConnectContext.Provider value={value}>
+      {children}
+    </WalletConnectContext.Provider>
+  );
+}

--- a/src/providers/walletConnect/context.ts
+++ b/src/providers/walletConnect/context.ts
@@ -1,0 +1,75 @@
+import { createContext } from 'react';
+
+import type { WCContext } from '@/constants/walletConnect';
+import type { ScanResult } from '@/types';
+
+export type SessionPhase =
+  | 'idle'
+  | 'pairing'
+  | { kind: 'proposal'; proposal: SessionProposalEvent }
+  | 'approving'
+  | { kind: 'active'; session: ActiveSession }
+  | { kind: 'error'; message: string };
+
+export type WCRequest = {
+  id: number;
+  topic: string;
+  method: string;
+  params: unknown;
+};
+
+// Minimal session shape we need from WalletKit (avoids importing WalletKit types here)
+export type ActiveSession = {
+  topic: string;
+  peer: { metadata: { name: string; url: string; icons: string[] } };
+  namespaces: Record<string, { accounts: string[] }>;
+};
+
+export type VerifyValidation = 'VALID' | 'INVALID' | 'UNKNOWN';
+
+// Minimal proposal shape
+export type SessionProposalEvent = {
+  id: number;
+  verifyContext?: {
+    verified: {
+      validation: VerifyValidation;
+      isScam?: boolean;
+      origin: string;
+    };
+  };
+  params: {
+    id: number;
+    expiryTimestamp: number;
+    proposer: { metadata: { name: string; url: string; icons: string[] } };
+    requiredNamespaces: Record<
+      string,
+      { chains?: string[]; methods?: string[] }
+    >;
+    optionalNamespaces: Record<
+      string,
+      { chains?: string[]; methods?: string[] }
+    >;
+  };
+};
+
+export type WalletConnectContextValue = {
+  phase: SessionPhase;
+  activeSession: ActiveSession | null;
+  pendingRequest: WCRequest | null;
+  pair: (uri: string) => Promise<void>;
+  approveSession: (address: string, derivationPath: string) => Promise<void>;
+  rejectSession: (proposal: SessionProposalEvent) => Promise<void>;
+  disconnect: () => Promise<void>;
+  respondSuccess: (context: WCContext, result: string) => Promise<void>;
+  respondError: (
+    context: WCContext,
+    code: number,
+    message: string,
+  ) => Promise<void>;
+};
+
+// Used by ScanResult conversion in requestAdapter (Task 5+)
+export type { ScanResult };
+
+export const WalletConnectContext =
+  createContext<WalletConnectContextValue | null>(null);

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -10,6 +10,7 @@ import { DashboardScreenProps } from '../navigation/types';
 import theme from '../theme';
 
 import DashboardKeycardNotice from '../components/DashboardKeycardNotice';
+import WalletConnectDashboardCard from '../components/walletConnect/DashboardCard.online';
 import Menu from '../components/Menu';
 import PrimaryButton from '../components/PrimaryButton';
 
@@ -51,13 +52,10 @@ export default function DashboardScreen({
       <Menu entries={entries} />
 
       <DashboardKeycardNotice />
+      <WalletConnectDashboardCard />
 
       <View style={styles.actions}>
-        <PrimaryButton
-          label="Scan transaction"
-          onPress={handleSign}
-          icon={Icons.scan}
-        />
+        <PrimaryButton label="Scan" onPress={handleSign} icon={Icons.scan} />
       </View>
 
       <Snackbar

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -8,6 +8,7 @@ import theme from '../theme';
 import NFCBottomSheet from '../components/NFCBottomSheet';
 
 import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
+import { useWalletConnectSession } from '../hooks/useWalletConnectSession.online';
 
 import {
   buildBtcSignatureUR,
@@ -15,40 +16,16 @@ import {
   parseKeycardBtcMessageSignature,
 } from '../utils/btcMessage';
 import { BtcSigningSession, buildCryptoPsbtUR } from '../utils/btcPsbt';
-import { buildEthSignatureUR } from '../utils/ethSignature';
+import {
+  buildEthSignatureURFromResult,
+  buildRawEthHexSignature,
+} from '../utils/ethSignature';
 import {
   buildExportUr,
   exportKeyForWallet,
   prepareSignHash,
   type ExportKeyResult,
 } from '../utils/keycardExport';
-
-function buildEthResultUR(
-  result: Uint8Array,
-  hash: Uint8Array,
-  params: {
-    dataType?: number;
-    chainId?: number;
-    requestId?: string;
-    signData?: string;
-  },
-): string {
-  const firstByte = params.signData
-    ? parseInt(params.signData.slice(0, 2), 16)
-    : undefined;
-  const txType =
-    firstByte === 0x01 || firstByte === 0x02 ? firstByte : undefined;
-  return buildEthSignatureUR(
-    Array.from(result)
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join(''),
-    hash,
-    params.dataType,
-    params.chainId,
-    params.requestId,
-    txType,
-  );
-}
 
 export default function KeycardScreen({
   route,
@@ -58,11 +35,23 @@ export default function KeycardScreen({
   const insets = useSafeAreaInsets();
   const hashRef = useRef<Uint8Array | null>(null);
   const btcSessionRef = useRef<BtcSigningSession | null>(null);
+  const respondedRef = useRef(false);
+
+  const { respondSuccess, respondError } = useWalletConnectSession();
+
+  const wcContext =
+    params.operation === 'sign' && params.signMode === 'eth'
+      ? params.wcContext
+      : undefined;
 
   const keycard = useKeycardOperation<
     ExportKeyResult | { psbtHex: string } | Uint8Array
   >();
   const { phase, result, execute, cancel } = keycard;
+
+  const resetToDashboard = useCallback(() => {
+    navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+  }, [navigation]);
 
   const handleSign = useCallback(() => {
     if (params.operation !== 'sign') {
@@ -171,18 +160,45 @@ export default function KeycardScreen({
     if (!hashRef.current || !(result instanceof Uint8Array)) {
       return;
     }
-    const urString = buildEthResultUR(
-      result,
-      hashRef.current,
-      params as {
-        dataType?: number;
-        chainId?: number;
-        requestId?: string;
-        signData?: string;
-      },
+
+    const p = params as {
+      dataType?: number;
+      chainId?: number;
+      requestId?: string;
+      signData?: string;
+    };
+
+    if (wcContext && !respondedRef.current) {
+      respondedRef.current = true;
+      const rawSig = buildRawEthHexSignature(
+        result,
+        hashRef.current,
+        p.dataType,
+        p.chainId,
+        p.signData,
+      );
+      respondSuccess(wcContext, rawSig).finally(() => resetToDashboard());
+      return;
+    }
+
+    navigateToSignResult(
+      buildEthSignatureURFromResult(
+        result,
+        hashRef.current,
+        p.dataType,
+        p.chainId,
+        p.requestId,
+        p.signData,
+      ),
     );
-    navigateToSignResult(urString);
-  }, [result, params, navigateToSignResult]);
+  }, [
+    result,
+    params,
+    wcContext,
+    respondSuccess,
+    resetToDashboard,
+    navigateToSignResult,
+  ]);
 
   const handleBtcSignDone = useCallback(() => {
     if (
@@ -276,10 +292,18 @@ export default function KeycardScreen({
     navigation.setOptions({ title: 'Enter Keycard PIN' });
   }, [navigation]);
 
-  const handleCancel = useCallback(() => {
+  const handleCancel = useCallback(async () => {
     cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
+    if (wcContext && !respondedRef.current) {
+      respondedRef.current = true;
+      try {
+        await respondError(wcContext, 4001, 'User rejected');
+      } catch {
+        // ignore — relay may have already expired
+      }
+    }
+    resetToDashboard();
+  }, [cancel, wcContext, respondError, resetToDashboard]);
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>

--- a/src/screens/QRScannerScreen.tsx
+++ b/src/screens/QRScannerScreen.tsx
@@ -23,13 +23,14 @@ import theme from '../theme';
 import CameraView from '../components/CameraView';
 import { type ReadCodeEvent } from '../components/Camera';
 import { handleUR } from '../utils/ur';
+import { detectWcUri } from '../utils/walletConnect/qrDetector.online';
 
 export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
 
   useLayoutEffect(() => {
-    navigation.setOptions({ title: 'Scan transaction QR' });
+    navigation.setOptions({ title: 'Scan' });
   }, [navigation]);
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [progress, setProgress] = useState(0);
@@ -66,6 +67,11 @@ export default function QRScannerScreen({ navigation }: QRScannerScreenProps) {
 
       const value = event.nativeEvent.codeStringValue;
       if (!value) {
+        return;
+      }
+
+      if (detectWcUri(value, navigation)) {
+        scannedRef.current = true;
         return;
       }
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import theme from '../theme';
 import EnsSettingsSection from '../components/settings/ens/EnsSettingsSection.online';
 import PinPadSettingsSection from '../components/settings/PinPadSettingsSection';
 import TokenImagesSettingsSection from '../components/settings/TokenImagesSettingsSection.online';
+import WalletConnectSettingsSection from '../components/settings/WalletConnectSettingsSection.online';
 
 export const dashboardEntry: DashboardAction = {
   label: 'Settings',
@@ -30,6 +31,7 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
         <PinPadSettingsSection />
         <TokenImagesSettingsSection />
         <EnsSettingsSection />
+        <WalletConnectSettingsSection />
       </View>
     </ScrollView>
   );

--- a/src/screens/TransactionDetailScreen.tsx
+++ b/src/screens/TransactionDetailScreen.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { StyleSheet, ScrollView, View } from 'react-native';
+import { Button } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 import { Icons } from '../assets/icons';
 import type { TransactionDetailScreenProps } from '../navigation/types';
 import theme from '../theme';
+
 import SignRequestDetail from '../components/SignRequestDetail';
 import PrimaryButton from '../components/PrimaryButton';
+import { useWalletConnectSession } from '../hooks/useWalletConnectSession.online';
 import { inspectBtcPsbt } from '../utils/btcPsbt';
 import { buildSignKeycardParams } from '../utils/signNavigation';
 
@@ -14,7 +18,12 @@ export default function TransactionDetailScreen({
   navigation,
 }: TransactionDetailScreenProps) {
   const insets = useSafeAreaInsets();
-  const { result } = route.params;
+  const { result, wcContext } = route.params;
+  const { respondError } = useWalletConnectSession();
+
+  const respondedRef = useRef(false);
+  const navigatingToKeycardRef = useRef(false);
+
   const isBip322Message =
     result.kind === 'crypto-psbt' &&
     (() => {
@@ -30,11 +39,41 @@ export default function TransactionDetailScreen({
 
   const keycardParams = buildSignKeycardParams(result);
 
-  const handleSign = useCallback(() => {
-    if (keycardParams) {
-      navigation.navigate('Keycard', keycardParams);
+  const rejectWC = useCallback(async () => {
+    if (wcContext && !respondedRef.current) {
+      respondedRef.current = true;
+      try {
+        await respondError(wcContext, 4001, 'User rejected');
+      } catch {
+        // ignore — relay may have already expired
+      }
     }
-  }, [keycardParams, navigation]);
+  }, [wcContext, respondError]);
+
+  // Reject WC request on back/swipe unless we navigated forward to Keycard
+  useEffect(() => {
+    if (!wcContext) return;
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      if (!navigatingToKeycardRef.current) {
+        rejectWC();
+      }
+    });
+    return unsubscribe;
+  }, [navigation, wcContext, rejectWC]);
+
+  const handleSign = useCallback(() => {
+    if (!keycardParams) return;
+    navigatingToKeycardRef.current = true;
+    navigation.navigate('Keycard', {
+      ...keycardParams,
+      ...(wcContext ? { wcContext } : {}),
+    } as any);
+  }, [keycardParams, navigation, wcContext]);
+
+  const handleReject = useCallback(async () => {
+    await rejectWC();
+    navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+  }, [rejectWC, navigation]);
 
   return (
     <View style={styles.container}>
@@ -47,6 +86,15 @@ export default function TransactionDetailScreen({
 
       {keycardParams !== null && (
         <View style={[styles.actions, { paddingBottom: insets.bottom + 16 }]}>
+          {wcContext && (
+            <Button
+              mode="outlined"
+              onPress={handleReject}
+              textColor={theme.colors.error}
+            >
+              Reject
+            </Button>
+          )}
           <PrimaryButton
             label={
               isBip322Message || result.kind === 'btc-sign-request'
@@ -79,5 +127,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     backgroundColor: theme.colors.background,
+    gap: 8,
   },
 });

--- a/src/screens/WalletConnectPairingScreen/AddressSelectionPhase.tsx
+++ b/src/screens/WalletConnectPairingScreen/AddressSelectionPhase.tsx
@@ -1,0 +1,89 @@
+import { FlatList, Pressable, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Button,
+  RadioButton,
+  Text,
+} from 'react-native-paper';
+import { EdgeInsets } from 'react-native-safe-area-context';
+
+import theme from '@/theme';
+import AddressText from '@/components/AddressText';
+import PrimaryButton from '@/components/PrimaryButton';
+
+import styles from './styles';
+
+export default function AddressSelectionPhase({
+  addresses,
+  selectedAddress,
+  loading,
+  insets,
+  onSelect,
+  onLoadMore,
+  onConnect,
+  onCancel,
+}: {
+  addresses: string[];
+  selectedAddress: string | null;
+  loading: boolean;
+  insets: EdgeInsets;
+  onSelect: (address: string) => void;
+  onLoadMore: () => void;
+  onConnect: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
+      <Text variant="titleMedium" style={styles.sectionTitle}>
+        Select address
+      </Text>
+      <FlatList
+        data={addresses}
+        keyExtractor={item => item}
+        style={styles.list}
+        renderItem={({ item, index }) => (
+          <Pressable style={styles.addrRow} onPress={() => onSelect(item)}>
+            <RadioButton.Android
+              value={item}
+              status={selectedAddress === item ? 'checked' : 'unchecked'}
+              onPress={() => onSelect(item)}
+              color={theme.colors.primary}
+            />
+            <Text style={styles.addrIndex}>{index}</Text>
+            <AddressText address={item} style={styles.addrText} />
+          </Pressable>
+        )}
+        onEndReached={onLoadMore}
+        onEndReachedThreshold={0.3}
+        ListFooterComponent={
+          loading ? (
+            <ActivityIndicator
+              size="small"
+              color={theme.colors.primary}
+              style={styles.listFooter}
+            />
+          ) : null
+        }
+      />
+      <View style={styles.proposalActions}>
+        <Button
+          mode="outlined"
+          onPress={onCancel}
+          textColor={theme.colors.error}
+        >
+          Cancel
+        </Button>
+        <PrimaryButton
+          label="Connect"
+          onPress={onConnect}
+          disabled={!selectedAddress}
+        />
+      </View>
+    </View>
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/ApprovingPhase.tsx
+++ b/src/screens/WalletConnectPairingScreen/ApprovingPhase.tsx
@@ -1,0 +1,28 @@
+import { View } from 'react-native';
+import { ActivityIndicator, Text } from 'react-native-paper';
+import { EdgeInsets } from 'react-native-safe-area-context';
+
+import theme from '@/theme';
+import NFCBottomSheet, { NFCOperation } from '@/components/NFCBottomSheet';
+
+import styles from './styles';
+
+export default function ApprovingPhase({
+  accountKeyOp,
+  insets,
+  onCancel,
+}: {
+  accountKeyOp: NFCOperation;
+  insets: EdgeInsets;
+  onCancel: () => void;
+}) {
+  return (
+    <>
+      <View style={[styles.centered, { paddingTop: insets.top }]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+        <Text style={styles.statusText}>Tap Keycard to connect…</Text>
+      </View>
+      <NFCBottomSheet nfc={accountKeyOp} onCancel={onCancel} />
+    </>
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/ErrorPhase.tsx
+++ b/src/screens/WalletConnectPairingScreen/ErrorPhase.tsx
@@ -1,0 +1,27 @@
+import { View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+import { EdgeInsets } from 'react-native-safe-area-context';
+
+import styles from './styles';
+
+export default function ErrorPhase({
+  message,
+  insets,
+  onBack,
+}: {
+  message: string;
+  insets: EdgeInsets;
+  onBack: () => void;
+}) {
+  return (
+    <View
+      style={[
+        styles.centered,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
+      <Text style={styles.errorText}>{message}</Text>
+      <Button onPress={onBack}>Go back to Dashboard</Button>
+    </View>
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/PairingPhase.tsx
+++ b/src/screens/WalletConnectPairingScreen/PairingPhase.tsx
@@ -1,0 +1,16 @@
+import { View } from 'react-native';
+import { ActivityIndicator, Text } from 'react-native-paper';
+import { EdgeInsets } from 'react-native-safe-area-context';
+
+import theme from '@/theme';
+
+import styles from './styles';
+
+export default function PairingPhase({ insets }: { insets: EdgeInsets }) {
+  return (
+    <View style={[styles.centered, { paddingTop: insets.top }]}>
+      <ActivityIndicator size="large" color={theme.colors.primary} />
+      <Text style={styles.statusText}>Connecting to dApp…</Text>
+    </View>
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/ProposalPhase.tsx
+++ b/src/screens/WalletConnectPairingScreen/ProposalPhase.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from 'react';
+import { Linking, Pressable, ScrollView, View } from 'react-native';
+import { Button, RadioButton, Text } from 'react-native-paper';
+import { EdgeInsets } from 'react-native-safe-area-context';
+
+import theme from '@/theme';
+import PrimaryButton from '@/components/PrimaryButton';
+import type { VerifyValidation } from '@/providers/walletConnect/context';
+
+import styles from './styles';
+
+function useSecondsRemaining(expiryTimestamp: number): number {
+  const [secs, setSecs] = useState(() =>
+    Math.max(0, expiryTimestamp - Math.floor(Date.now() / 1000)),
+  );
+  useEffect(() => {
+    if (secs === 0) return;
+    const id = setInterval(() => {
+      const remaining = Math.max(
+        0,
+        expiryTimestamp - Math.floor(Date.now() / 1000),
+      );
+      setSecs(remaining);
+      if (remaining === 0) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [expiryTimestamp, secs]);
+  return secs;
+}
+
+function formatCountdown(secs: number): string {
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+const RELAY_PRIVACY_URL = 'https://walletconnect.com/privacy';
+
+type PathOption = {
+  label: string;
+  accountPath: string;
+  hasExternalChain: boolean;
+};
+
+function VerifyBanner({
+  validation,
+  isScam,
+}: {
+  validation: VerifyValidation;
+  isScam?: boolean;
+}) {
+  if (isScam) {
+    return (
+      <View style={styles.verifyScam}>
+        <Text style={styles.verifyScamText}>
+          ⚠ This site has been flagged as a scam. Do not connect.
+        </Text>
+      </View>
+    );
+  }
+  if (validation === 'INVALID') {
+    return (
+      <View style={styles.verifyInvalid}>
+        <Text style={styles.verifyInvalidText}>
+          ⚠ Domain could not be verified. Proceed with caution.
+        </Text>
+      </View>
+    );
+  }
+  if (validation === 'VALID') {
+    return (
+      <View style={styles.verifyValid}>
+        <Text style={styles.verifyValidText}>✓ Verified domain</Text>
+      </View>
+    );
+  }
+  return null;
+}
+
+export default function ProposalPhase({
+  dAppName,
+  dAppUrl,
+  requestedChains,
+  pathOptions,
+  selectedPathIdx,
+  activeSessionName,
+  verification,
+  expiryTimestamp,
+  proposalError,
+  insets,
+  onSelectPath,
+  onConfirm,
+  onReject,
+}: {
+  dAppName: string;
+  dAppUrl: string;
+  requestedChains: string[];
+  pathOptions: PathOption[];
+  selectedPathIdx: number;
+  activeSessionName: string | null;
+  verification: { validation: VerifyValidation; isScam?: boolean } | null;
+  expiryTimestamp: number;
+  proposalError: string | null;
+  insets: EdgeInsets;
+  onSelectPath: (idx: number) => void;
+  onConfirm: () => void;
+  onReject: () => void;
+}) {
+  const isScam = verification?.isScam ?? false;
+  const hasExpiry = expiryTimestamp > 0;
+  const secsRemaining = useSecondsRemaining(expiryTimestamp);
+  const expired = hasExpiry && secsRemaining === 0;
+  const urgent = hasExpiry && secsRemaining <= 30 && !expired;
+
+  return (
+    <View
+      style={[styles.proposalContainer, { paddingBottom: insets.bottom + 16 }]}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingTop: insets.top + 16 },
+        ]}
+      >
+        <Text variant="titleLarge" style={styles.dAppName}>
+          {dAppName}
+        </Text>
+        {!!dAppUrl && (
+          <Text variant="bodySmall" style={styles.dAppUrl}>
+            {dAppUrl}
+          </Text>
+        )}
+
+        {hasExpiry && (
+          <Text
+            variant="bodySmall"
+            style={[
+              styles.countdown,
+              urgent && styles.countdownUrgent,
+              expired && styles.countdownExpired,
+            ]}
+          >
+            {expired
+              ? 'Proposal expired'
+              : `Expires in ${formatCountdown(secsRemaining)}`}
+          </Text>
+        )}
+
+        {verification && (
+          <VerifyBanner
+            validation={verification.validation}
+            isScam={verification.isScam}
+          />
+        )}
+
+        {!!proposalError && (
+          <View style={styles.verifyScam}>
+            <Text style={styles.verifyScamText}>⚠ {proposalError}</Text>
+          </View>
+        )}
+
+        {requestedChains.length > 0 && (
+          <View style={styles.section}>
+            <Text variant="labelMedium" style={styles.label}>
+              Requested networks
+            </Text>
+            <View style={styles.chainGrid}>
+              {requestedChains.map(c => (
+                <Text key={c} style={styles.chainItem}>
+                  {c}
+                </Text>
+              ))}
+            </View>
+          </View>
+        )}
+
+        <View style={styles.section}>
+          <Text variant="labelMedium" style={styles.label}>
+            Derivation path
+          </Text>
+          <RadioButton.Group
+            onValueChange={val => onSelectPath(Number(val))}
+            value={String(selectedPathIdx)}
+          >
+            {pathOptions.map((opt, idx) => (
+              <Pressable
+                key={opt.label}
+                style={styles.pathRow}
+                onPress={() => onSelectPath(idx)}
+              >
+                <RadioButton.Android
+                  value={String(idx)}
+                  color={theme.colors.primary}
+                />
+                <Text style={styles.pathLabel}>{opt.label}</Text>
+              </Pressable>
+            ))}
+          </RadioButton.Group>
+        </View>
+
+        {activeSessionName && (
+          <View style={styles.warningBox}>
+            <Text style={styles.warningText}>
+              Connecting will close your existing session with{' '}
+              {activeSessionName}.
+            </Text>
+          </View>
+        )}
+
+        <View style={styles.relayWarning}>
+          <Text variant="labelMedium" style={styles.relayTitle}>
+            Relay privacy notice
+          </Text>
+          <Text style={styles.relayBody}>
+            This connection is routed through WalletConnect relay servers.
+            WalletConnect can observe pairing metadata and traffic patterns even
+            though signing content is end-to-end encrypted.
+          </Text>
+          <Button
+            compact
+            onPress={() => Linking.openURL(RELAY_PRIVACY_URL)}
+            textColor={theme.colors.primary}
+          >
+            WalletConnect Privacy Policy
+          </Button>
+        </View>
+      </ScrollView>
+
+      <View style={styles.proposalActions}>
+        <Button
+          mode="outlined"
+          onPress={onReject}
+          textColor={theme.colors.error}
+        >
+          Reject
+        </Button>
+        <PrimaryButton
+          label="Confirm"
+          onPress={onConfirm}
+          disabled={isScam || expired || !!proposalError}
+        />
+      </View>
+    </View>
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/index.tsx
+++ b/src/screens/WalletConnectPairingScreen/index.tsx
@@ -1,0 +1,301 @@
+import { HDKey } from '@scure/bip32';
+import Keycard from 'keycard-sdk';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { WalletConnectPairingScreenProps } from '@/navigation/types';
+import {
+  SUPPORTED_WC_EIP155_CHAIN_IDS,
+  SUPPORTED_WC_METHODS,
+} from '@/constants/walletConnect';
+import { useKeycardOp } from '@/hooks/keycard/useKeycardOperation';
+import { useWalletConnectSession } from '@/hooks/useWalletConnectSession.online';
+import type { SessionProposalEvent } from '@/providers/walletConnect/context';
+import { getChainName } from '@/utils/chainMetadata';
+import { pubKeyToEthAddress } from '@/utils/ethereumAddress';
+import { deriveAddresses } from '@/utils/hdAddress';
+
+import AddressSelectionPhase from './AddressSelectionPhase';
+import ApprovingPhase from './ApprovingPhase';
+import ErrorPhase from './ErrorPhase';
+import PairingPhase from './PairingPhase';
+import ProposalPhase from './ProposalPhase';
+
+const BATCH = 20;
+
+type PathOption = {
+  label: string;
+  // Path exported from Keycard; addresses are derived as path/0/i (hasExternalChain=true) or path/i (false)
+  accountPath: string;
+  hasExternalChain: boolean;
+};
+
+const PATH_OPTIONS: PathOption[] = [
+  {
+    label: 'Ethereum (standard)',
+    accountPath: "m/44'/60'/0'",
+    hasExternalChain: true,
+  },
+  {
+    label: 'Ledger Legacy',
+    accountPath: "m/44'/60'/0'",
+    hasExternalChain: false,
+  },
+];
+
+type LocalPhase =
+  | 'pairing'
+  | 'proposal'
+  | 'approving'
+  | 'address_selection'
+  | 'error';
+
+export default function WalletConnectPairingScreen({
+  navigation,
+  route,
+}: WalletConnectPairingScreenProps) {
+  const { uri } = route.params;
+  const insets = useSafeAreaInsets();
+  const {
+    phase: wcPhase,
+    activeSession,
+    pair,
+    approveSession,
+    rejectSession,
+  } = useWalletConnectSession();
+
+  const [localPhase, setLocalPhase] = useState<LocalPhase>('pairing');
+  const [selectedPathIdx, setSelectedPathIdx] = useState(0);
+  const [addresses, setAddresses] = useState<string[]>([]);
+  const [selectedAddress, setSelectedAddress] = useState<string | null>(null);
+  const [accountKey, setAccountKey] = useState<HDKey | null>(null);
+  const [loading, setLoading] = useState(false);
+  const nextIndexRef = useRef(0);
+
+  const proposal = useMemo(() => {
+    if (typeof wcPhase === 'object' && wcPhase.kind === 'proposal') {
+      return wcPhase.proposal;
+    }
+    return null;
+  }, [wcPhase]);
+
+  useEffect(() => {
+    pair(uri);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (wcPhase === 'pairing') {
+      // pair() was just called — clear any stale error from a previous attempt
+      setLocalPhase('pairing');
+      return;
+    }
+    if (typeof wcPhase !== 'object') return;
+
+    if (
+      wcPhase.kind === 'proposal' &&
+      (localPhase === 'pairing' || localPhase === 'proposal')
+    ) {
+      setLocalPhase('proposal');
+    } else if (wcPhase.kind === 'active' && localPhase !== 'pairing') {
+      // Only navigate to Dashboard when active arrives from our own approval flow.
+      // Ignore if localPhase is still 'pairing' — that means a pre-existing active
+      // session was present when this screen mounted, not our own new session.
+      navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+    } else if (wcPhase.kind === 'error') {
+      setLocalPhase('error');
+    }
+  }, [wcPhase, navigation, localPhase]);
+
+  const selectedOpt = PATH_OPTIONS[selectedPathIdx];
+  const accountKeyOp = useKeycardOp<HDKey>(
+    useCallback(
+      async cmdSet => {
+        const resp = await cmdSet.exportExtendedKey(
+          0,
+          selectedOpt.accountPath,
+          false,
+        );
+        resp.checkOK();
+        return Keycard.BIP32KeyPair.extendedKey(resp.data);
+      },
+      [selectedOpt.accountPath],
+    ),
+    { requiresPin: true },
+  );
+
+  const { phase: nfcPhase, start: startNfc, cancel: cancelNfc } = accountKeyOp;
+
+  useEffect(() => {
+    if (nfcPhase === 'done' && accountKeyOp.result) {
+      const key = accountKeyOp.result;
+      const enumerationKey = selectedOpt.hasExternalChain
+        ? key.deriveChild(0)
+        : key;
+      setAccountKey(enumerationKey);
+      const batch = deriveAddresses(
+        enumerationKey,
+        BATCH,
+        pubKeyToEthAddress,
+        0,
+      );
+      nextIndexRef.current = BATCH;
+      setAddresses(batch);
+      setLocalPhase('address_selection');
+    }
+  }, [nfcPhase, accountKeyOp.result, selectedOpt.hasExternalChain]);
+
+  const handleConfirm = useCallback(() => {
+    setLocalPhase('approving');
+    startNfc();
+  }, [startNfc]);
+
+  const handleRejectProposal = useCallback(async () => {
+    if (proposal) {
+      await rejectSession(proposal as SessionProposalEvent);
+    }
+    navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+  }, [proposal, rejectSession, navigation]);
+
+  const handleNfcCancel = useCallback(async () => {
+    cancelNfc();
+    if (proposal) {
+      await rejectSession(proposal as SessionProposalEvent);
+    }
+    navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+  }, [cancelNfc, proposal, rejectSession, navigation]);
+
+  const handleConnect = useCallback(async () => {
+    if (!selectedAddress) return;
+    const idx = addresses.indexOf(selectedAddress);
+    const fullPath = selectedOpt.hasExternalChain
+      ? `${selectedOpt.accountPath}/0/${idx}`
+      : `${selectedOpt.accountPath}/${idx}`;
+    await approveSession(selectedAddress, fullPath);
+  }, [selectedAddress, addresses, selectedOpt, approveSession]);
+
+  const handleCancelAddressSelection = useCallback(async () => {
+    if (proposal) {
+      await rejectSession(proposal as SessionProposalEvent);
+    }
+    navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
+  }, [proposal, rejectSession, navigation]);
+
+  const loadMore = useCallback(() => {
+    if (!accountKey || loading) return;
+    setLoading(true);
+    const batch = deriveAddresses(
+      accountKey,
+      BATCH,
+      pubKeyToEthAddress,
+      nextIndexRef.current,
+    );
+    nextIndexRef.current += BATCH;
+    setAddresses(prev => [...prev, ...batch]);
+    setLoading(false);
+  }, [accountKey, loading]);
+
+  const requestedChains = useMemo(() => {
+    const required = proposal?.params.requiredNamespaces.eip155?.chains ?? [];
+    const optional = proposal?.params.optionalNamespaces?.eip155?.chains ?? [];
+    const chains = [...new Set([...required, ...optional])];
+    return chains.map(c => {
+      const id = parseInt(c.replace('eip155:', ''), 10);
+      return getChainName(id) || c;
+    });
+  }, [proposal]);
+
+  const proposalError = useMemo(() => {
+    if (!proposal) return null;
+    const requiredNamespaces = proposal.params.requiredNamespaces ?? {};
+    const unsupportedNamespaces = Object.keys(requiredNamespaces).filter(
+      ns => ns !== 'eip155',
+    );
+    if (unsupportedNamespaces.length > 0) {
+      return `Required namespaces not supported: ${unsupportedNamespaces.join(
+        ', ',
+      )}`;
+    }
+
+    const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
+    const requiredChains = requiredNamespaces.eip155?.chains ?? [];
+    const unsupportedChains = requiredChains.filter(
+      c => !supported.includes(c),
+    );
+    if (unsupportedChains.length > 0) {
+      return `Required chains not supported: ${unsupportedChains
+        .map(c => c.replace('eip155:', ''))
+        .join(', ')}`;
+    }
+    const requiredMethods = requiredNamespaces.eip155?.methods ?? [];
+    const unsupported = requiredMethods.filter(
+      m => !(SUPPORTED_WC_METHODS as readonly string[]).includes(m),
+    );
+    if (unsupported.length > 0) {
+      return `Required methods not supported: ${unsupported.join(', ')}`;
+    }
+    return null;
+  }, [proposal]);
+
+  if (localPhase === 'pairing') {
+    return <PairingPhase insets={insets} />;
+  }
+
+  if (localPhase === 'error') {
+    const msg =
+      typeof wcPhase === 'object' && wcPhase.kind === 'error'
+        ? wcPhase.message
+        : 'Connection failed';
+    return (
+      <ErrorPhase
+        message={msg}
+        insets={insets}
+        onBack={() =>
+          navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] })
+        }
+      />
+    );
+  }
+
+  if (localPhase === 'approving') {
+    return (
+      <ApprovingPhase
+        accountKeyOp={accountKeyOp}
+        insets={insets}
+        onCancel={handleNfcCancel}
+      />
+    );
+  }
+
+  if (localPhase === 'address_selection') {
+    return (
+      <AddressSelectionPhase
+        addresses={addresses}
+        selectedAddress={selectedAddress}
+        loading={loading}
+        insets={insets}
+        onSelect={setSelectedAddress}
+        onLoadMore={loadMore}
+        onConnect={handleConnect}
+        onCancel={handleCancelAddressSelection}
+      />
+    );
+  }
+
+  return (
+    <ProposalPhase
+      dAppName={proposal?.params.proposer.metadata.name ?? ''}
+      dAppUrl={proposal?.params.proposer.metadata.url ?? ''}
+      requestedChains={requestedChains}
+      pathOptions={PATH_OPTIONS}
+      selectedPathIdx={selectedPathIdx}
+      activeSessionName={activeSession?.peer.metadata.name ?? null}
+      verification={proposal?.verifyContext?.verified ?? null}
+      expiryTimestamp={proposal?.params.expiryTimestamp ?? 0}
+      proposalError={proposalError}
+      insets={insets}
+      onSelectPath={setSelectedPathIdx}
+      onConfirm={handleConfirm}
+      onReject={handleRejectProposal}
+    />
+  );
+}

--- a/src/screens/WalletConnectPairingScreen/styles.ts
+++ b/src/screens/WalletConnectPairingScreen/styles.ts
@@ -1,0 +1,176 @@
+import { StyleSheet } from 'react-native';
+
+import theme from '@/theme';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  scroll: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    gap: 12,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background,
+    gap: 16,
+    padding: 24,
+  },
+  statusText: {
+    color: theme.colors.onSurface,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: theme.colors.error,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  dAppName: {
+    color: theme.colors.onSurface,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  dAppUrl: {
+    color: theme.colors.onSurfaceVariant,
+    textAlign: 'center',
+  },
+  section: {
+    gap: 4,
+  },
+  label: {
+    color: theme.colors.onSurfaceVariant,
+    marginBottom: 4,
+  },
+  chainGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  chainItem: {
+    width: '50%',
+    color: theme.colors.onSurface,
+    paddingVertical: 2,
+  },
+  pathRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  pathLabel: {
+    color: theme.colors.onSurface,
+    marginLeft: 4,
+  },
+  countdown: {
+    color: theme.colors.onSurfaceVariant,
+    textAlign: 'center',
+  },
+  countdownUrgent: {
+    color: theme.colors.error,
+    fontWeight: '600',
+  },
+  countdownExpired: {
+    color: theme.colors.error,
+    fontWeight: '700',
+  },
+  verifyScam: {
+    backgroundColor: theme.colors.errorContainer,
+    borderRadius: 8,
+    padding: 12,
+  },
+  verifyScamText: {
+    color: theme.colors.onErrorContainer,
+    fontWeight: '700',
+  },
+  verifyInvalid: {
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 8,
+    padding: 12,
+    borderLeftWidth: 3,
+    borderLeftColor: theme.colors.error,
+  },
+  verifyInvalidText: {
+    color: theme.colors.onSurface,
+  },
+  verifyValid: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  verifyValidText: {
+    color: theme.colors.primary,
+    fontSize: 13,
+  },
+  warningBox: {
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 8,
+    padding: 12,
+  },
+  warningText: {
+    color: theme.colors.onSurfaceVariant,
+  },
+  relayWarning: {
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 8,
+    padding: 12,
+    gap: 4,
+  },
+  relayTitle: {
+    color: theme.colors.onSurface,
+    fontWeight: '600',
+  },
+  relayBody: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  sectionTitle: {
+    color: theme.colors.onSurface,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  list: {
+    flex: 1,
+  },
+  addrRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+  },
+  addrIndex: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 12,
+    width: 24,
+    textAlign: 'right',
+    marginRight: 8,
+  },
+  addrText: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  listFooter: {
+    paddingVertical: 12,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    gap: 8,
+  },
+  proposalContainer: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  proposalActions: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    gap: 8,
+  },
+});

--- a/src/storage/walletConnect.ts
+++ b/src/storage/walletConnect.ts
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { WC_PROJECT_ID } from '@/utils/buildConfig';
+
+const WC_PROJECT_ID_OVERRIDE_KEY = 'wc_project_id_override';
+
+export async function loadWCProjectId(): Promise<string> {
+  try {
+    const override = await AsyncStorage.getItem(WC_PROJECT_ID_OVERRIDE_KEY);
+    if (override && override.trim()) {
+      return override.trim();
+    }
+  } catch {
+    // fall through to build-time default
+  }
+  return WC_PROJECT_ID;
+}
+
+export async function saveWCProjectId(id: string): Promise<void> {
+  await AsyncStorage.setItem(WC_PROJECT_ID_OVERRIDE_KEY, id.trim());
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type EthSignRequest = {
   derivationPath: string;
   address?: string;
   origin?: string;
+  reviewData?: string; // UI-only: original EIP-712 JSON for WC requests
 };
 
 export type BtcPsbtRequest = {

--- a/src/utils/buildConfig.ts
+++ b/src/utils/buildConfig.ts
@@ -2,7 +2,7 @@
 import { NativeModules, Platform } from 'react-native';
 
 const nativeBuildConfig = NativeModules.BuildConfig as
-  | { INTERNET_ENABLED: boolean }
+  | { INTERNET_ENABLED: boolean; WC_PROJECT_ID: string }
   | undefined;
 
 // iOS has no offline flavor — internet is always available there
@@ -10,3 +10,5 @@ export const INTERNET_ENABLED: boolean =
   Platform.OS === 'android'
     ? nativeBuildConfig?.INTERNET_ENABLED ?? true
     : true;
+
+export const WC_PROJECT_ID: string = nativeBuildConfig?.WC_PROJECT_ID ?? '';

--- a/src/utils/ethSignature.ts
+++ b/src/utils/ethSignature.ts
@@ -39,17 +39,89 @@ function encodeV(v: number): Uint8Array {
   ]);
 }
 
-/**
- * Parse the raw Keycard signature TLV, compute v, and wrap in a
- * `ur:eth-signature` UR string ready to display as a QR code.
- *
- * @param signRespDataHex - hex string of `signResp.data` (TLV from Keycard)
- * @param hash            - the 32-byte hash that was signed (for recId recovery)
- * @param dataType        - eth-sign-request dataType (1=legacy, 2=typed, 3=personal, 4=typed transaction)
- * @param chainId         - chain ID (used for legacy tx v calculation)
- * @param requestId       - optional UUID hex from the original eth-sign-request
- * @param txType          - optional EIP-2718 transaction type byte (0x01 EIP-2930, 0x02 EIP-1559)
- */
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// Detects EIP-2718 tx type from first byte of signData (0x01=EIP-2930, 0x02=EIP-1559).
+function detectTxType(signData?: string): number | undefined {
+  if (!signData) return undefined;
+  const hex = signData.startsWith('0x') ? signData.slice(2) : signData;
+  const firstByte = parseInt(hex.slice(0, 2), 16);
+  return firstByte === 0x01 || firstByte === 0x02 ? firstByte : undefined;
+}
+
+export function computeEthV(
+  recId: number,
+  dataType: number | undefined,
+  chainId: number | undefined,
+  txType?: number,
+): number {
+  if (txType === 0x01 || txType === 0x02) {
+    return recId;
+  }
+  switch (dataType) {
+    case 1:
+      return V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
+    case 4:
+      return recId;
+    default:
+      return V_BASE_LEGACY + recId;
+  }
+}
+
+export function buildRawHexSignature(
+  r: Uint8Array,
+  s: Uint8Array,
+  v: number,
+): string {
+  const paddedR = pad32(r);
+  const paddedS = pad32(s);
+  const vBytes = encodeV(v);
+  let hex = '0x';
+  for (const part of [paddedR, paddedS, vBytes]) {
+    for (const byte of part) {
+      hex += byte.toString(16).padStart(2, '0');
+    }
+  }
+  return hex;
+}
+
+export function buildRawEthHexSignature(
+  result: Uint8Array,
+  hash: Uint8Array,
+  dataType: number | undefined,
+  chainId: number | undefined,
+  signData?: string,
+): string {
+  const sig = new Keycard.RecoverableSignature({
+    hash,
+    tlvData: hexToBytes(ensureHexPrefix(bytesToHex(result))),
+  });
+  const v = computeEthV(sig.recId!, dataType, chainId, detectTxType(signData));
+  return buildRawHexSignature(sig.r!, sig.s!, v);
+}
+
+export function buildEthSignatureURFromResult(
+  result: Uint8Array,
+  hash: Uint8Array,
+  dataType: number | undefined,
+  chainId: number | undefined,
+  requestId: string | undefined,
+  signData?: string,
+): string {
+  return buildEthSignatureUR(
+    bytesToHex(result),
+    hash,
+    dataType,
+    chainId,
+    requestId,
+    detectTxType(signData),
+  );
+}
+
 export function buildEthSignatureUR(
   signRespDataHex: string,
   hash: Uint8Array,
@@ -66,23 +138,7 @@ export function buildEthSignatureUR(
   const recId = sig.recId!;
   const r = pad32(sig.r!);
   const s = pad32(sig.s!);
-
-  let v: number;
-  if (txType === 0x01 || txType === 0x02) {
-    // Typed transactions use yParity directly: v = recId.
-    v = recId;
-  } else {
-    switch (dataType) {
-      case 1: // legacy transaction (EIP-155)
-        v = V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
-        break;
-      case 4: // typed transaction without an explicit txType
-        v = recId;
-        break;
-      default: // EIP-712 (2), personal_sign (3), unknown
-        v = V_BASE_LEGACY + recId;
-    }
-  }
+  const v = computeEthV(recId, dataType, chainId, txType);
 
   const sigBytes = new Uint8Array(r.length + s.length + encodeV(v).length);
   sigBytes.set(r, 0);

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -34,7 +34,7 @@ export function prepareSignHash(
   signData: string,
   dataType: number | undefined,
 ): Uint8Array {
-  const raw = new Uint8Array(Buffer.from(signData, 'hex'));
+  const raw = new Uint8Array(Buffer.from(signData.replace(/^0x/i, ''), 'hex'));
   if (dataType === 1 || dataType === 4) {
     return keccak_256(raw);
   }

--- a/src/utils/walletConnect/client.offline.ts
+++ b/src/utils/walletConnect/client.offline.ts
@@ -1,0 +1,12 @@
+export const wcClient = {
+  pair: async (_uri: string) => {},
+  respondSuccess: async (_id: number, _topic: string, _result: string) => {},
+  respondError: async (
+    _id: number,
+    _topic: string,
+    _code: number,
+    _msg: string,
+  ) => {},
+  disconnect: async (_topic: string) => {},
+  resetClient: () => {},
+};

--- a/src/utils/walletConnect/client.online.ts
+++ b/src/utils/walletConnect/client.online.ts
@@ -1,0 +1,102 @@
+import '@walletconnect/react-native-compat';
+
+import { Core } from '@walletconnect/core';
+import { WalletKit, WalletKitTypes } from '@reown/walletkit';
+
+import { WC_PROJECT_ID } from '@/utils/buildConfig';
+
+let _client: Awaited<ReturnType<typeof WalletKit.init>> | null = null;
+let _initPromise: Promise<Awaited<ReturnType<typeof WalletKit.init>>> | null =
+  null;
+
+async function getClient(
+  projectIdOverride?: string,
+): Promise<Awaited<ReturnType<typeof WalletKit.init>>> {
+  if (_client) {
+    return _client;
+  }
+  if (_initPromise) {
+    return _initPromise;
+  }
+  const projectId = projectIdOverride ?? WC_PROJECT_ID;
+  if (!projectId) {
+    throw new Error(
+      'WalletConnect Project ID is not configured. Set WC_PROJECT_ID in build environment or override it in Settings.',
+    );
+  }
+
+  const memoryStorage = new Map<string, string>();
+  const core = new Core({
+    projectId,
+    storage: {
+      getItem: async (key: string) => memoryStorage.get(key) ?? undefined,
+      setItem: async (key: string, value: string) => {
+        memoryStorage.set(key, value);
+      },
+      removeItem: async (key: string) => {
+        memoryStorage.delete(key);
+      },
+      getKeys: async () => [...memoryStorage.keys()],
+    } as any,
+  });
+
+  _initPromise = WalletKit.init({
+    core,
+    metadata: {
+      name: 'GapSign',
+      description: 'Air-gapped hardware wallet companion',
+      url: 'https://gapsign.tech',
+      icons: [],
+    },
+  }).catch(e => {
+    _initPromise = null;
+    throw e;
+  });
+
+  _client = await _initPromise;
+  return _client;
+}
+
+export type WCClientEventMap = WalletKitTypes.EventArguments;
+
+export const wcClient = {
+  getClient,
+  pair: async (uri: string, projectIdOverride?: string) => {
+    const client = await getClient(projectIdOverride);
+    await client.pair({ uri });
+  },
+  respondSuccess: async (id: number, topic: string, result: string) => {
+    const client = await getClient();
+    await client.respondSessionRequest({
+      topic,
+      response: { id, jsonrpc: '2.0', result },
+    });
+  },
+  respondError: async (
+    id: number,
+    topic: string,
+    code: number,
+    message: string,
+  ) => {
+    const client = await getClient();
+    await client.respondSessionRequest({
+      topic,
+      response: {
+        id,
+        jsonrpc: '2.0',
+        error: { code, message },
+      },
+    });
+  },
+  disconnect: async (topic: string) => {
+    const client = await getClient();
+    await client.disconnectSession({
+      topic,
+      reason: { code: 6000, message: 'User disconnected' },
+    });
+  },
+  resetClient: () => {
+    _client = null;
+    _initPromise = null;
+  },
+};

--- a/src/utils/walletConnect/qrDetector.offline.ts
+++ b/src/utils/walletConnect/qrDetector.offline.ts
@@ -1,0 +1,3 @@
+export function detectWcUri(_value: string, _navigation: unknown): boolean {
+  return false;
+}

--- a/src/utils/walletConnect/qrDetector.online.ts
+++ b/src/utils/walletConnect/qrDetector.online.ts
@@ -1,0 +1,14 @@
+import type { NavigationProp } from '@react-navigation/native';
+
+import type { RootStackParamList } from '@/navigation/types';
+
+export function detectWcUri(
+  value: string,
+  navigation: NavigationProp<RootStackParamList>,
+): boolean {
+  if (!value.toLowerCase().startsWith('wc:')) {
+    return false;
+  }
+  navigation.navigate('WalletConnectPairing', { uri: value });
+  return true;
+}

--- a/src/utils/walletConnect/requestAdapter.ts
+++ b/src/utils/walletConnect/requestAdapter.ts
@@ -1,0 +1,132 @@
+import { hashTypedData, isAddress } from 'viem';
+
+import type { WCContext } from '@/constants/walletConnect';
+import type { WCRequest } from '@/providers/walletConnect/context';
+import type { ScanResult } from '@/types';
+
+export type { WCContext };
+
+function splitAddrParam(params: unknown): { address: string; other: string } {
+  if (!Array.isArray(params) || params.length < 2) {
+    throw new Error('Invalid params: expected array of at least 2 strings');
+  }
+  const [p0, p1] = params as [unknown, unknown];
+  if (typeof p0 !== 'string' || typeof p1 !== 'string') {
+    throw new Error('Invalid params: expected strings');
+  }
+  if (isAddress(p0, { strict: false })) {
+    return { address: p0, other: p1 };
+  }
+  if (isAddress(p1, { strict: false })) {
+    return { address: p1, other: p0 };
+  }
+  throw new Error('Invalid params: signer address missing');
+}
+
+function hexEncodeMessage(value: string): string {
+  if (value.toLowerCase().startsWith('0x')) {
+    return value;
+  }
+  const bytes = new TextEncoder().encode(value);
+  let hex = '0x';
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+function resolvePath(
+  address: string,
+  addressToPath?: Map<string, string>,
+): string {
+  if (!addressToPath) {
+    throw new Error('Missing WalletConnect address mapping');
+  }
+  const resolved = addressToPath.get(address.toLowerCase());
+  if (!resolved) {
+    throw new Error(
+      `Address ${address} not found in session — cannot determine derivation path`,
+    );
+  }
+  return resolved;
+}
+
+function handlePersonalSign(
+  req: WCRequest,
+  addressToPath?: Map<string, string>,
+): ScanResult {
+  const { address, other: message } = splitAddrParam(req.params);
+  return {
+    kind: 'eth-sign-request',
+    request: {
+      signData: hexEncodeMessage(message),
+      dataType: 3, // personal_sign — EIP-191 prefix applied in prepareSignHash
+      derivationPath: resolvePath(address, addressToPath),
+      address,
+      origin: 'WalletConnect',
+    },
+  };
+}
+
+function handleTypedData(
+  req: WCRequest,
+  addressToPath?: Map<string, string>,
+): ScanResult {
+  const { address, other: typedDataJson } = splitAddrParam(req.params);
+
+  let parsed: { domain: any; types: any; primaryType?: string; message: any };
+  try {
+    parsed = JSON.parse(typedDataJson);
+  } catch {
+    throw new Error('Invalid EIP-712 payload: JSON parse failed');
+  }
+
+  const { domain, types, primaryType, message } = parsed;
+  if (!domain || !types || !message) {
+    throw new Error('Invalid EIP-712 payload: missing domain/types/message');
+  }
+
+  let digest: `0x${string}`;
+  try {
+    // Remove EIP712Domain — the hashing library adds it internally from domain
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { EIP712Domain: _EIP712Domain, ...signingTypes } = types;
+    digest = hashTypedData({
+      domain,
+      types: signingTypes,
+      primaryType: primaryType ?? Object.keys(signingTypes)[0],
+      message,
+    });
+  } catch {
+    throw new Error('Invalid EIP-712 payload: hashing failed');
+  }
+
+  return {
+    kind: 'eth-sign-request',
+    request: {
+      signData: digest, // 32-byte hash — dataType=0 means no further hashing
+      dataType: 0,
+      derivationPath: resolvePath(address, addressToPath),
+      address,
+      origin: 'WalletConnect',
+      reviewData: hexEncodeMessage(typedDataJson),
+    },
+  };
+}
+
+export function wcRequestToScanResult(
+  req: WCRequest,
+  addressToPath?: Map<string, string>,
+): ScanResult {
+  const { method } = req;
+
+  if (method === 'personal_sign') {
+    return handlePersonalSign(req, addressToPath);
+  }
+
+  if (method === 'eth_signTypedData' || method === 'eth_signTypedData_v4') {
+    return handleTypedData(req, addressToPath);
+  }
+
+  throw new Error(`Unsupported method: ${method}`);
+}


### PR DESCRIPTION
## Summary

- Adds WalletConnect v2 session pairing: scan a `wc:` URI QR code, review the dApp proposal (requested chains, expiry countdown, domain verification banner, relay privacy notice), export the account key from Keycard via NFC, pick a derivation address, and approve the session
- Handles `personal_sign`, `eth_signTypedData`, and `eth_signTypedData_v4` signing requests routed through the existing `TransactionDetail` review flow; responds with a raw `0x{r}{s}{v}` hex signature
- Validates required namespaces at proposal time — shows an error banner and disables Confirm when the dApp requires unsupported methods or chains, preserving any existing active session
- Proposal screen shows WalletConnect Verify domain attestation (scam / invalid / verified), expiry countdown, and a relay privacy notice
- Rejecting or losing a session restores the previous active session on the dashboard instead of going idle
- Online-only: all WC code is behind the `.online` / `.offline` Metro build boundary; offline builds import zero WC packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WalletConnect v2: scan QR to pair dApps, approve sessions, and sign via Keycard (pairing UI, address selection, approval flow)
  * Settings: configure and persist WalletConnect Project ID; WalletConnect settings section added
  * Dashboard: card shows active WalletConnect session with disconnect action
  * Transaction details: show EIP‑712 and calldata digests for independent verification
  * UI: primary button label changed from “Scan transaction” to “Scan”; reject flow and permission-denied UI improvements

* **Bug Fixes**
  * Token image downloads moved to an opt-in Settings toggle (default off)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->