### PR TITLE
feat: add Tenderly transaction simulation (online build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- (online) Tenderly transaction simulation: opt-in tab on the transaction review screen showing success/revert, asset changes, and a trace link; credentials configured in Settings
 - (online) WalletConnect v2: connect a dApp via QR, sign `personal_sign` and `eth_signTypedData_v4` with Keycard, configure project ID in Settings
 - Show ERC-8213 verification digests (Calldata Digest for transactions, EIP-712 Digest for typed data) so you can independently verify what you're signing
 - (online) Add opt-in toggle in Settings to enable remote token image downloads; preference persisted via `preferencesStorage`, default off
 
 ### Changed
 
+- PIN entry modal promoted to full-screen `Modal` in `NFCBottomSheet` so it covers the whole screen regardless of nesting depth
+- Settings screen wrapped in `KeyboardAvoidingView` so bottom inputs are not hidden by the keyboard
 - Extract `usePinPadScramble` hook from `PinPad`; preference loading is no longer inlined in the component
 - Extract `keycardTlv.ts` with shared DER/TLV constants and `parseDerSignature`; removes duplication across `btcMessage`, `btcPsbt`, and `cryptoMultiAccounts`
 - Support `@/` import alias for `src/` to eliminate deep relative paths across the codebase

--- a/__tests__/DataTabPanel.test.tsx
+++ b/__tests__/DataTabPanel.test.tsx
@@ -5,6 +5,29 @@ import EthDataTabPanel from '../src/components/SignRequestDetail/eth/DataTabPane
 import type { EthSignRequest } from '../src/types';
 import type { ParsedTx } from '../src/utils/txParser';
 
+jest.mock('../src/components/NFCBottomSheet', () => () => null);
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    pinError: null,
+    result: null,
+    start: jest.fn(),
+    cancel: jest.fn(),
+    submitPin: jest.fn(),
+    reset: jest.fn(),
+    retry: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+jest.mock('../src/hooks/useTenderlyConfig.online', () => ({
+  useTenderlyConfig: jest.fn(() => ({ credentials: null })),
+}));
+jest.mock('../src/utils/tenderly/client.online', () => ({
+  simulateTransaction: jest.fn(),
+}));
+
 jest.mock('react-native-paper', () => {
   const { Text, TouchableOpacity, View } = require('react-native');
   return {

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -5,6 +5,29 @@ import { RLP } from '@ethereumjs/rlp';
 import EthSignRequestDetail from '../src/components/SignRequestDetail/eth/SignRequestDetail';
 import type { EthSignRequest } from '../src/types';
 
+jest.mock('../src/components/NFCBottomSheet', () => () => null);
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    pinError: null,
+    result: null,
+    start: jest.fn(),
+    cancel: jest.fn(),
+    submitPin: jest.fn(),
+    reset: jest.fn(),
+    retry: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+jest.mock('../src/hooks/useTenderlyConfig.online', () => ({
+  useTenderlyConfig: jest.fn(() => ({ credentials: null })),
+}));
+jest.mock('../src/utils/tenderly/client.online', () => ({
+  simulateTransaction: jest.fn(),
+}));
+
 jest.mock('react-native-paper', () => {
   const { Text, TouchableOpacity, View } = require('react-native');
   return {

--- a/__tests__/SimulationPanel.test.tsx
+++ b/__tests__/SimulationPanel.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import SimulationPanel from '../src/components/SignRequestDetail/eth/DataTabPanel/SimulationPanel';
+import type { SimulationState } from '../src/components/SignRequestDetail/eth/DataTabPanel/SimulationPanel';
+import type { SimulationResult } from '../src/utils/tenderly/client.online';
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return {
+    Text: ({ children, ...props }: any) => <Text {...props}>{children}</Text>,
+    ActivityIndicator: () => <Text>loading</Text>,
+  };
+});
+
+jest.mock('../src/theme', () => ({
+  __esModule: true,
+  default: {
+    colors: {
+      primary: '#FF6400',
+      onSurface: '#fff',
+      onSurfaceVariant: '#aaa',
+      onSurfaceMuted: '#888',
+      onSurfaceSubtle: '#666',
+      onSurfaceDisabled: '#444',
+      surfaceVariant: '#2d2d2d',
+      error: '#E95460',
+      success: '#1C8A80',
+    },
+  },
+}));
+
+jest.mock('../src/components/PrimaryButton', () => {
+  const { TouchableOpacity, Text } = require('react-native');
+  return ({ label, onPress }: { label: string; onPress: () => void }) => (
+    <TouchableOpacity onPress={onPress}>
+      <Text>{label}</Text>
+    </TouchableOpacity>
+  );
+});
+
+const onSimulate = jest.fn();
+
+beforeEach(() => {
+  onSimulate.mockClear();
+});
+
+function renderPanel(state: SimulationState) {
+  return render(<SimulationPanel state={state} onSimulate={onSimulate} />);
+}
+
+describe('SimulationPanel', () => {
+  describe('idle phase', () => {
+    it('shows Simulate button', () => {
+      renderPanel({ phase: 'idle' });
+      expect(screen.getByText('Simulate')).toBeTruthy();
+    });
+
+    it('calls onSimulate when Simulate pressed', () => {
+      renderPanel({ phase: 'idle' });
+      fireEvent.press(screen.getByText('Simulate'));
+      expect(onSimulate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('loading phase', () => {
+    it('shows loading indicator', () => {
+      renderPanel({ phase: 'loading' });
+      expect(screen.getByText('loading')).toBeTruthy();
+    });
+
+    it('shows Simulating text', () => {
+      renderPanel({ phase: 'loading' });
+      expect(screen.getByText('Simulating…')).toBeTruthy();
+    });
+  });
+
+  describe('error phase', () => {
+    it('shows error message', () => {
+      renderPanel({ phase: 'error', message: 'API error 401: Unauthorized' });
+      expect(screen.getByText('API error 401: Unauthorized')).toBeTruthy();
+    });
+
+    it('shows Retry button', () => {
+      renderPanel({ phase: 'error', message: 'fail' });
+      expect(screen.getByText('Retry')).toBeTruthy();
+    });
+
+    it('calls onSimulate when Retry pressed', () => {
+      renderPanel({ phase: 'error', message: 'fail' });
+      fireEvent.press(screen.getByText('Retry'));
+      expect(onSimulate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('result phase — success', () => {
+    const successResult: SimulationResult = {
+      status: 'success',
+      assetChanges: [],
+      traceUrl: 'https://dashboard.tenderly.co/acme/proj/simulation/abc',
+    };
+
+    it('shows Success chip', () => {
+      renderPanel({ phase: 'result', data: successResult });
+      expect(screen.getByText('Success')).toBeTruthy();
+    });
+
+    it('shows trace link', () => {
+      renderPanel({ phase: 'result', data: successResult });
+      expect(screen.getByText('View trace →')).toBeTruthy();
+    });
+
+    it('opens trace URL when trace link pressed', () => {
+      const openURL = jest
+        .spyOn(Linking, 'openURL')
+        .mockResolvedValue(undefined);
+      renderPanel({ phase: 'result', data: successResult });
+      fireEvent.press(screen.getByText('View trace →'));
+      expect(openURL).toHaveBeenCalledWith(successResult.traceUrl);
+      openURL.mockRestore();
+    });
+
+    it('hides trace link when traceUrl is empty', () => {
+      renderPanel({
+        phase: 'result',
+        data: { ...successResult, traceUrl: '' },
+      });
+      expect(screen.queryByText('View trace →')).toBeNull();
+    });
+  });
+
+  describe('result phase — reverted', () => {
+    const revertedResult: SimulationResult = {
+      status: 'reverted',
+      revertReason: 'execution reverted',
+      assetChanges: [],
+      traceUrl: '',
+    };
+
+    it('shows Reverted chip', () => {
+      renderPanel({ phase: 'result', data: revertedResult });
+      expect(screen.getByText('Reverted')).toBeTruthy();
+    });
+
+    it('shows revert reason', () => {
+      renderPanel({ phase: 'result', data: revertedResult });
+      expect(screen.getByText('execution reverted')).toBeTruthy();
+    });
+
+    it('does not show revert reason when null', () => {
+      renderPanel({
+        phase: 'result',
+        data: { ...revertedResult, revertReason: null },
+      });
+      expect(screen.queryByText('execution reverted')).toBeNull();
+    });
+  });
+
+  describe('asset changes', () => {
+    it('shows token symbol and amount', () => {
+      const result: SimulationResult = {
+        status: 'success',
+        assetChanges: [
+          {
+            tokenSymbol: 'USDC',
+            tokenAddress: '0xusdc',
+            from: '0xaaaa000000000000000000000000000000000001',
+            to: '0xbbbb000000000000000000000000000000000002',
+            amount: '1',
+          },
+        ],
+        traceUrl: '',
+      };
+      renderPanel({ phase: 'result', data: result });
+      expect(screen.getByText('USDC')).toBeTruthy();
+      expect(screen.getByText('1')).toBeTruthy();
+    });
+
+    it('shows from→to addresses truncated', () => {
+      const result: SimulationResult = {
+        status: 'success',
+        assetChanges: [
+          {
+            tokenSymbol: 'ETH',
+            tokenAddress: '',
+            from: '0xaaaa000000000000000000000000000000000001',
+            to: '0xbbbb000000000000000000000000000000000002',
+            amount: '0.5',
+          },
+        ],
+        traceUrl: '',
+      };
+      renderPanel({ phase: 'result', data: result });
+      expect(screen.getByText(/0xaaaa.*0001/)).toBeTruthy();
+    });
+
+    it('shows Asset changes label when changes present', () => {
+      const result: SimulationResult = {
+        status: 'success',
+        assetChanges: [
+          {
+            tokenSymbol: 'ETH',
+            tokenAddress: '',
+            from: '0x1111111111111111111111111111111111111111',
+            to: '0x2222222222222222222222222222222222222222',
+            amount: '1',
+          },
+        ],
+        traceUrl: '',
+      };
+      renderPanel({ phase: 'result', data: result });
+      expect(screen.getByText('Asset changes')).toBeTruthy();
+    });
+
+    it('hides Asset changes section when empty', () => {
+      renderPanel({
+        phase: 'result',
+        data: { status: 'success', assetChanges: [], traceUrl: '' },
+      });
+      expect(screen.queryByText('Asset changes')).toBeNull();
+    });
+  });
+});

--- a/__tests__/TenderlySettingsSection.test.tsx
+++ b/__tests__/TenderlySettingsSection.test.tsx
@@ -1,0 +1,280 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+
+import TenderlySettingsSection from '../src/components/settings/tenderly/TenderlySettingsSection.online';
+import TenderlySettingsSectionOffline from '../src/components/settings/tenderly/TenderlySettingsSection.offline';
+
+const mockLoadTenderlyConfig = jest.fn();
+const mockSaveTenderlyEnabled = jest.fn();
+const mockSaveTenderlyCredentials = jest.fn();
+
+jest.mock('../src/storage/tenderly.online', () => ({
+  loadTenderlyConfig: (...args: any[]) => mockLoadTenderlyConfig(...args),
+  saveTenderlyEnabled: (...args: any[]) => mockSaveTenderlyEnabled(...args),
+  saveTenderlyCredentials: (...args: any[]) =>
+    mockSaveTenderlyCredentials(...args),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text, Switch } = require('react-native');
+  return {
+    Text: ({ children, onPress, ...props }: any) => (
+      <Text onPress={onPress} {...props}>
+        {children}
+      </Text>
+    ),
+    Switch,
+  };
+});
+
+jest.mock('../src/theme', () => ({
+  __esModule: true,
+  default: {
+    colors: {
+      primary: '#FF6400',
+      onSurface: '#fff',
+      onSurfaceVariant: '#aaa',
+      onSurfaceMuted: '#888',
+      onSurfaceSubtle: '#666',
+      onSurfaceDisabled: '#444',
+      surfaceVariant: '#2d2d2d',
+      error: '#E95460',
+      success: '#1C8A80',
+    },
+  },
+}));
+
+const EMPTY_CONFIG = {
+  enabled: false,
+  credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+};
+
+const FULL_CONFIG = {
+  enabled: true,
+  credentials: {
+    accountSlug: 'acme',
+    projectSlug: 'proj',
+    apiKey: 'key123',
+  },
+};
+
+describe('TenderlySettingsSection.online', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveTenderlyEnabled.mockResolvedValue(undefined);
+    mockSaveTenderlyCredentials.mockResolvedValue(undefined);
+  });
+
+  it('renders nothing while loading', () => {
+    mockLoadTenderlyConfig.mockReturnValue(new Promise(() => {}));
+    const { toJSON } = render(<TenderlySettingsSection />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('shows toggle off when disabled on mount', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(EMPTY_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+    expect(screen.getByRole('switch').props.value).toBe(false);
+  });
+
+  it('hides credential inputs when disabled', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(EMPTY_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+    expect(screen.queryByPlaceholderText('my-account')).toBeNull();
+  });
+
+  it('shows toggle on and credential inputs when enabled', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-account')).toBeTruthy(),
+    );
+    expect(screen.getByRole('switch').props.value).toBe(true);
+    expect(screen.getByPlaceholderText('my-project')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Enter API key')).toBeTruthy();
+  });
+
+  it('calls saveTenderlyEnabled when toggle pressed', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(EMPTY_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+    fireEvent(screen.getByRole('switch'), 'valueChange', true);
+    expect(mockSaveTenderlyEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('shows Save button when account slug is edited', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-account')).toBeTruthy(),
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText('my-account'),
+      'new-account',
+    );
+    expect(screen.getAllByText('Save').length).toBeGreaterThan(0);
+  });
+
+  it('calls saveTenderlyCredentials when Save pressed', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-account')).toBeTruthy(),
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText('my-account'),
+      'new-account',
+    );
+    fireEvent.press(screen.getAllByText('Save')[0]);
+    expect(mockSaveTenderlyCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ accountSlug: 'new-account' }),
+    );
+  });
+
+  it('shows Tenderly registration link when enabled', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByText('Create a free Tenderly account →')).toBeTruthy(),
+    );
+  });
+
+  it('shows privacy note', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(EMPTY_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/transaction data.*sent to Tenderly/i),
+      ).toBeTruthy(),
+    );
+  });
+
+  it('shows component after load failure (catch path)', async () => {
+    mockLoadTenderlyConfig.mockRejectedValue(new Error('storage error'));
+    render(<TenderlySettingsSection />);
+    await waitFor(() => expect(screen.getByRole('switch')).toBeTruthy());
+    expect(screen.getByRole('switch').props.value).toBe(false);
+  });
+
+  it('reverts project slug to saved value', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-project')).toBeTruthy(),
+    );
+    fireEvent.changeText(screen.getByPlaceholderText('my-project'), 'changed');
+    fireEvent.press(screen.getAllByText('Revert')[0]);
+    expect(screen.getByPlaceholderText('my-project').props.value).toBe('proj');
+  });
+
+  it('saves project slug when Save pressed', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-project')).toBeTruthy(),
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText('my-project'),
+      'new-project',
+    );
+    fireEvent.press(screen.getAllByText('Save')[0]);
+    expect(mockSaveTenderlyCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ projectSlug: 'new-project' }),
+    );
+  });
+
+  it('saves api key when Save pressed', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter API key')).toBeTruthy(),
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Enter API key'),
+      'newkey',
+    );
+    fireEvent.press(screen.getAllByText('Save')[0]);
+    expect(mockSaveTenderlyCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'newkey' }),
+    );
+  });
+
+  it('reverts api key to saved value', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter API key')).toBeTruthy(),
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Enter API key'),
+      'changed',
+    );
+    fireEvent.press(screen.getAllByText('Revert')[0]);
+    expect(screen.getByPlaceholderText('Enter API key').props.value).toBe(
+      'key123',
+    );
+  });
+
+  it('second save uses updated saved state from first save', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('my-account')).toBeTruthy(),
+    );
+
+    // Save accountSlug first
+    fireEvent.changeText(
+      screen.getByPlaceholderText('my-account'),
+      'new-account',
+    );
+    fireEvent.press(screen.getAllByText('Save')[0]);
+    await waitFor(() =>
+      expect(mockSaveTenderlyCredentials).toHaveBeenCalledTimes(1),
+    );
+
+    // Now save projectSlug — second call must include the updated accountSlug
+    fireEvent.changeText(
+      screen.getByPlaceholderText('my-project'),
+      'new-project',
+    );
+    fireEvent.press(screen.getAllByText('Save')[0]);
+    await waitFor(() =>
+      expect(mockSaveTenderlyCredentials).toHaveBeenCalledTimes(2),
+    );
+
+    expect(mockSaveTenderlyCredentials).toHaveBeenLastCalledWith({
+      accountSlug: 'new-account',
+      projectSlug: 'new-project',
+      apiKey: 'key123',
+    });
+  });
+
+  it('opens Tenderly registration URL when link pressed', async () => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+    mockLoadTenderlyConfig.mockResolvedValue(FULL_CONFIG);
+    render(<TenderlySettingsSection />);
+    await waitFor(() =>
+      expect(screen.getByText('Create a free Tenderly account →')).toBeTruthy(),
+    );
+    fireEvent.press(screen.getByText('Create a free Tenderly account →'));
+    expect(openURL).toHaveBeenCalledWith(
+      'https://dashboard.tenderly.co/register',
+    );
+    openURL.mockRestore();
+  });
+});
+
+describe('TenderlySettingsSection.offline', () => {
+  it('renders null', () => {
+    const { toJSON } = render(<TenderlySettingsSectionOffline />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -9,6 +9,29 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   default: { getItem: jest.fn(), setItem: jest.fn() },
 }));
 
+jest.mock('../src/components/NFCBottomSheet', () => () => null);
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    pinError: null,
+    result: null,
+    start: jest.fn(),
+    cancel: jest.fn(),
+    submitPin: jest.fn(),
+    reset: jest.fn(),
+    retry: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+jest.mock('../src/hooks/useTenderlyConfig.online', () => ({
+  useTenderlyConfig: jest.fn(() => ({ credentials: null })),
+}));
+jest.mock('../src/utils/tenderly/client.online', () => ({
+  simulateTransaction: jest.fn(),
+}));
+
 const mockRespondError = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../src/hooks/useWalletConnectSession.online', () => ({

--- a/__tests__/TxDataPanel.test.tsx
+++ b/__tests__/TxDataPanel.test.tsx
@@ -1,14 +1,56 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
+
+import { useTenderlyConfig } from '../src/hooks/useTenderlyConfig.online';
 
 import TxDataPanel from '../src/components/SignRequestDetail/eth/DataTabPanel/TxDataPanel';
 import type { ParsedTx } from '../src/utils/txParser';
 import type { EthSignRequest } from '../src/types';
+import type { SimulationResult } from '../src/utils/tenderly/client.online';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/components/NFCBottomSheet', () => () => null);
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: () => ({
+    phase: 'idle',
+    status: '',
+    cardName: null,
+    pinError: null,
+    result: null,
+    start: jest.fn(),
+    cancel: jest.fn(),
+    submitPin: jest.fn(),
+    reset: jest.fn(),
+    retry: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+
+const mockCredentials = {
+  accountSlug: 'acme',
+  projectSlug: 'proj',
+  apiKey: 'key123',
+};
+
+jest.mock('../src/hooks/useTenderlyConfig.online', () => ({
+  useTenderlyConfig: jest.fn(() => ({ credentials: null })),
+}));
+
+const mockSimulate = jest.fn<Promise<SimulationResult>, []>();
+jest.mock('../src/utils/tenderly/client.online', () => ({
+  simulateTransaction: (...args: unknown[]) => mockSimulate(...(args as [])),
+}));
 
 jest.mock('react-native-paper', () => {
   const { Text, TouchableOpacity, View } = require('react-native');
   return {
     Text: ({ children, ...props }: any) => <Text {...props}>{children}</Text>,
+    ActivityIndicator: () => <Text>loading</Text>,
     SegmentedButtons: ({
       buttons,
       onValueChange,
@@ -33,7 +75,19 @@ jest.mock('react-native-paper', () => {
 
 jest.mock('../src/theme', () => ({
   __esModule: true,
-  default: { colors: { onSurfaceVariant: '#aaa', negative: '#f00' } },
+  default: {
+    colors: {
+      primary: '#FF6400',
+      onSurface: '#fff',
+      onSurfaceVariant: '#aaa',
+      onSurfaceMuted: '#888',
+      onSurfaceSubtle: '#666',
+      onSurfaceDisabled: '#444',
+      surfaceVariant: '#2d2d2d',
+      error: '#E95460',
+      success: '#1C8A80',
+    },
+  },
 }));
 
 jest.mock('../src/components/InfoRow', () => {
@@ -51,6 +105,15 @@ jest.mock(
   },
 );
 
+jest.mock('../src/components/PrimaryButton', () => {
+  const { Text, TouchableOpacity } = require('react-native');
+  return ({ label, onPress }: { label: string; onPress: () => void }) => (
+    <TouchableOpacity onPress={onPress}>
+      <Text>{label}</Text>
+    </TouchableOpacity>
+  );
+});
+
 const CALLDATA =
   '0xa9059cbb000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000de0b6b3a7640000';
 
@@ -58,11 +121,13 @@ const request: EthSignRequest = {
   signData: CALLDATA,
   dataType: 1,
   derivationPath: "m/44'/60'/0'/0",
+  address: '0xAbCd000000000000000000000000000000000001',
 };
 
 const txWithDecoded: ParsedTx = {
   to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   data: CALLDATA,
+  valueWei: '0',
   decodedCall: {
     kind: 'erc20-transfer',
     to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -74,6 +139,7 @@ const txWithDecoded: ParsedTx = {
 const txWithoutDecoded: ParsedTx = {
   to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   data: CALLDATA,
+  valueWei: '0',
   decodedCall: { kind: 'unknown-call', selector: '0xa9059cbb' },
   fees: { kind: 'unknown' },
 };
@@ -83,7 +149,17 @@ const txNoData: ParsedTx = {
   fees: { kind: 'unknown' },
 };
 
+// Contract creation — no to address
+const txNoTo: ParsedTx = {
+  fees: { kind: 'unknown' },
+};
+
 describe('TxDataPanel', () => {
+  beforeEach(() => {
+    (useTenderlyConfig as jest.Mock).mockReturnValue({ credentials: null });
+    mockSimulate.mockReset();
+  });
+
   describe('with no tx.data', () => {
     it('shows Digests tab with null digest (no calldata)', () => {
       render(<TxDataPanel tx={txNoData} request={request} chainId={1} />);
@@ -91,6 +167,7 @@ describe('TxDataPanel', () => {
       expect(screen.queryByText(/Calldata Digest:/)).toBeNull();
     });
   });
+
   describe('with decoded call', () => {
     it('shows Decoded tab by default and renders decoded section', () => {
       render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
@@ -130,6 +207,106 @@ describe('TxDataPanel', () => {
       );
       fireEvent.press(screen.getByText('Raw'));
       expect(screen.getByText(new RegExp(CALLDATA))).toBeTruthy();
+    });
+  });
+
+  describe('Simulation tab', () => {
+    it('absent when credentials null', () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({ credentials: null });
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      expect(screen.queryByText('Simulation')).toBeNull();
+    });
+
+    it('present when credentials set and tx has to address', () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      expect(screen.getByText('Simulation')).toBeTruthy();
+    });
+
+    it('absent when tx has no to address', () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      render(<TxDataPanel tx={txNoTo} request={request} chainId={1} />);
+      expect(screen.queryByText('Simulation')).toBeNull();
+    });
+
+    it('shows Simulate button in idle state', () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      fireEvent.press(screen.getByText('Simulation'));
+      expect(screen.getByText('Simulate')).toBeTruthy();
+    });
+
+    it('shows loader then result after successful simulation', async () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      const result: SimulationResult = {
+        status: 'success',
+        assetChanges: [],
+        traceUrl: 'https://dashboard.tenderly.co/acme/proj/simulation/abc',
+      };
+      mockSimulate.mockResolvedValue(result);
+
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      fireEvent.press(screen.getByText('Simulation'));
+      fireEvent.press(screen.getByText('Simulate'));
+
+      expect(screen.getByText('loading')).toBeTruthy();
+
+      await act(async () => {});
+
+      expect(screen.getByText('Success')).toBeTruthy();
+      expect(screen.getByText('View trace →')).toBeTruthy();
+    });
+
+    it('shows error and retry on simulation failure', async () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      mockSimulate.mockRejectedValue(new Error('API error 401: Unauthorized'));
+
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      fireEvent.press(screen.getByText('Simulation'));
+      fireEvent.press(screen.getByText('Simulate'));
+
+      await act(async () => {});
+
+      expect(screen.getByText('API error 401: Unauthorized')).toBeTruthy();
+      expect(screen.getByText('Retry')).toBeTruthy();
+    });
+
+    it('result persists when switching tabs and back', async () => {
+      (useTenderlyConfig as jest.Mock).mockReturnValue({
+        credentials: mockCredentials,
+      });
+      const result: SimulationResult = {
+        status: 'reverted',
+        revertReason: 'execution reverted',
+        assetChanges: [],
+        traceUrl: '',
+      };
+      mockSimulate.mockResolvedValue(result);
+
+      render(<TxDataPanel tx={txWithDecoded} request={request} chainId={1} />);
+      fireEvent.press(screen.getByText('Simulation'));
+      fireEvent.press(screen.getByText('Simulate'));
+
+      await act(async () => {});
+
+      expect(screen.getByText('Reverted')).toBeTruthy();
+
+      // switch away and back
+      fireEvent.press(screen.getByText('Decoded'));
+      fireEvent.press(screen.getByText('Simulation'));
+
+      expect(screen.getByText('Reverted')).toBeTruthy();
+      expect(screen.getByText('execution reverted')).toBeTruthy();
     });
   });
 });

--- a/__tests__/ensSettings.test.ts
+++ b/__tests__/ensSettings.test.ts
@@ -12,21 +12,34 @@ import {
   saveEnsRpcUrl as saveOffline,
 } from '../src/storage/ensSettings.offline';
 
-const mockGetItem = jest.fn();
-const mockSetItem = jest.fn();
+const mockAsyncGetItem = jest.fn();
+const mockAsyncSetItem = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
   default: {
-    getItem: (...args: any[]) => mockGetItem(...args),
-    setItem: (...args: any[]) => mockSetItem(...args),
+    getItem: (...args: any[]) => mockAsyncGetItem(...args),
+    setItem: (...args: any[]) => mockAsyncSetItem(...args),
+  },
+}));
+
+const mockSecureGetItem = jest.fn();
+const mockSecureSetItem = jest.fn();
+
+jest.mock('react-native-encrypted-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: any[]) => mockSecureGetItem(...args),
+    setItem: (...args: any[]) => mockSecureSetItem(...args),
   },
 }));
 
 describe('ensSettings.online', () => {
   beforeEach(() => {
-    mockGetItem.mockReset();
-    mockSetItem.mockReset();
+    mockAsyncGetItem.mockReset();
+    mockAsyncSetItem.mockReset();
+    mockSecureGetItem.mockReset();
+    mockSecureSetItem.mockReset();
   });
 
   it('DEFAULT_ENS_RPC_URL is PublicNode', () => {
@@ -35,14 +48,14 @@ describe('ensSettings.online', () => {
 
   describe('loadEnsSettings', () => {
     it('returns enabled=false and empty rpcUrl when nothing stored', async () => {
-      mockGetItem.mockResolvedValue(null);
+      mockAsyncGetItem.mockResolvedValue(null);
+      mockSecureGetItem.mockResolvedValue(null);
       expect(await loadEnsSettings()).toEqual({ enabled: false, rpcUrl: '' });
     });
 
     it('returns enabled=true and stored URL', async () => {
-      mockGetItem
-        .mockResolvedValueOnce('true')
-        .mockResolvedValueOnce('https://custom.rpc');
+      mockAsyncGetItem.mockResolvedValue('true');
+      mockSecureGetItem.mockResolvedValue('https://custom.rpc');
       expect(await loadEnsSettings()).toEqual({
         enabled: true,
         rpcUrl: 'https://custom.rpc',
@@ -50,9 +63,8 @@ describe('ensSettings.online', () => {
     });
 
     it('returns enabled=false when flag is not "true"', async () => {
-      mockGetItem
-        .mockResolvedValueOnce('false')
-        .mockResolvedValueOnce('https://custom.rpc');
+      mockAsyncGetItem.mockResolvedValue('false');
+      mockSecureGetItem.mockResolvedValue('https://custom.rpc');
       expect(await loadEnsSettings()).toEqual({
         enabled: false,
         rpcUrl: 'https://custom.rpc',
@@ -60,47 +72,53 @@ describe('ensSettings.online', () => {
     });
 
     it('returns defaults when storage throws', async () => {
-      mockGetItem.mockRejectedValue(new Error('storage failure'));
+      mockAsyncGetItem.mockRejectedValue(new Error('storage failure'));
+      mockSecureGetItem.mockRejectedValue(new Error('storage failure'));
       expect(await loadEnsSettings()).toEqual({ enabled: false, rpcUrl: '' });
     });
   });
 
   describe('saveEnsEnabled', () => {
-    it('stores "true" when enabled', async () => {
-      mockSetItem.mockResolvedValue(undefined);
+    it('stores "true" in AsyncStorage when enabled', async () => {
+      mockAsyncSetItem.mockResolvedValue(undefined);
       await saveEnsEnabled(true);
-      expect(mockSetItem).toHaveBeenCalledWith('ens_enabled', 'true');
+      expect(mockAsyncSetItem).toHaveBeenCalledWith('ens_enabled', 'true');
+      expect(mockSecureSetItem).not.toHaveBeenCalled();
     });
 
-    it('stores "false" when disabled', async () => {
-      mockSetItem.mockResolvedValue(undefined);
+    it('stores "false" in AsyncStorage when disabled', async () => {
+      mockAsyncSetItem.mockResolvedValue(undefined);
       await saveEnsEnabled(false);
-      expect(mockSetItem).toHaveBeenCalledWith('ens_enabled', 'false');
+      expect(mockAsyncSetItem).toHaveBeenCalledWith('ens_enabled', 'false');
+      expect(mockSecureSetItem).not.toHaveBeenCalled();
     });
   });
 
   describe('saveEnsRpcUrl', () => {
-    it('stores the URL', async () => {
-      mockSetItem.mockResolvedValue(undefined);
+    it('stores the URL in EncryptedStorage', async () => {
+      mockSecureSetItem.mockResolvedValue(undefined);
       await saveEnsRpcUrl('https://custom.rpc');
-      expect(mockSetItem).toHaveBeenCalledWith(
+      expect(mockSecureSetItem).toHaveBeenCalledWith(
         'ens_rpc_url',
         'https://custom.rpc',
       );
+      expect(mockAsyncSetItem).not.toHaveBeenCalled();
     });
 
     it('stores empty string', async () => {
-      mockSetItem.mockResolvedValue(undefined);
+      mockSecureSetItem.mockResolvedValue(undefined);
       await saveEnsRpcUrl('');
-      expect(mockSetItem).toHaveBeenCalledWith('ens_rpc_url', '');
+      expect(mockSecureSetItem).toHaveBeenCalledWith('ens_rpc_url', '');
     });
   });
 });
 
 describe('ensSettings.offline', () => {
   beforeEach(() => {
-    mockGetItem.mockReset();
-    mockSetItem.mockReset();
+    mockAsyncGetItem.mockReset();
+    mockAsyncSetItem.mockReset();
+    mockSecureGetItem.mockReset();
+    mockSecureSetItem.mockReset();
   });
 
   it('DEFAULT_ENS_RPC_URL is empty', () => {
@@ -109,16 +127,19 @@ describe('ensSettings.offline', () => {
 
   it('loadEnsSettings returns disabled with empty URL', async () => {
     expect(await loadSettingsOffline()).toEqual({ enabled: false, rpcUrl: '' });
-    expect(mockGetItem).not.toHaveBeenCalled();
+    expect(mockAsyncGetItem).not.toHaveBeenCalled();
+    expect(mockSecureGetItem).not.toHaveBeenCalled();
   });
 
   it('saveEnsEnabled is a no-op', async () => {
     await saveEnabledOffline(true);
-    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(mockAsyncSetItem).not.toHaveBeenCalled();
+    expect(mockSecureSetItem).not.toHaveBeenCalled();
   });
 
   it('saveEnsRpcUrl is a no-op', async () => {
     await saveOffline('https://any.rpc');
-    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(mockAsyncSetItem).not.toHaveBeenCalled();
+    expect(mockSecureSetItem).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/tenderlyClient.test.ts
+++ b/__tests__/tenderlyClient.test.ts
@@ -1,0 +1,242 @@
+import {
+  simulateTransaction,
+  type SimulationParams,
+} from '../src/utils/tenderly/client.online';
+
+import { simulateTransaction as simulateOffline } from '../src/utils/tenderly/client.offline';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const CREDS = { accountSlug: 'acme', projectSlug: 'proj', apiKey: 'key123' };
+
+const PARAMS: SimulationParams = {
+  from: '0xaaaa000000000000000000000000000000000001',
+  to: '0xbbbb000000000000000000000000000000000002',
+  valueWei: '0',
+  data: '0x',
+  gasLimit: '21000',
+  chainId: 1,
+};
+
+function mockOkResponse(body: object) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockErrorResponse(status: number, text: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    text: () => Promise.resolve(text),
+  });
+}
+
+function makeTxBody({
+  status = true,
+  simulationId = 'sim-id-123',
+  assetChanges = [] as object[],
+  errorMessage = null as string | null,
+} = {}) {
+  return {
+    simulation: { id: simulationId },
+    transaction: {
+      status,
+      transaction_info: {
+        asset_changes: assetChanges,
+      },
+      error_info: errorMessage ? { error_message: errorMessage } : undefined,
+    },
+  };
+}
+
+describe('tenderlyClient.online — simulateTransaction', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('calls the correct Tenderly URL', async () => {
+    mockOkResponse(makeTxBody());
+    await simulateTransaction(CREDS, PARAMS);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.tenderly.co/api/v1/account/acme/project/proj/simulate',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('sends X-Access-Key header', async () => {
+    mockOkResponse(makeTxBody());
+    await simulateTransaction(CREDS, PARAMS);
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers['X-Access-Key']).toBe('key123');
+  });
+
+  it('sends correct body fields', async () => {
+    mockOkResponse(makeTxBody());
+    await simulateTransaction(CREDS, PARAMS);
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.network_id).toBe('1');
+    expect(body.from).toBe(PARAMS.from);
+    expect(body.to).toBe(PARAMS.to);
+    expect(body.gas).toBe(21000);
+    expect(body.save).toBe(false);
+  });
+
+  it('returns success result when tx.status is true', async () => {
+    mockOkResponse(makeTxBody({ status: true, simulationId: 'abc' }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.status).toBe('success');
+    expect(result.traceUrl).toContain('abc');
+  });
+
+  it('returns reverted result when tx.status is false', async () => {
+    mockOkResponse(
+      makeTxBody({ status: false, errorMessage: 'insufficient balance' }),
+    );
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.status).toBe('reverted');
+    if (result.status === 'reverted') {
+      expect(result.revertReason).toBe('insufficient balance');
+    }
+  });
+
+  it('returns null revertReason when error_info is absent', async () => {
+    mockOkResponse(makeTxBody({ status: false }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    if (result.status === 'reverted') {
+      expect(result.revertReason).toBeNull();
+    }
+  });
+
+  it('maps asset changes correctly', async () => {
+    const change = {
+      token_info: {
+        symbol: 'USDC',
+        contract_address: '0xusdc',
+        decimals: 6,
+      },
+      from: '0xaaaa',
+      to: '0xbbbb',
+      amount: '1',
+    };
+    mockOkResponse(makeTxBody({ assetChanges: [change] }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.assetChanges).toHaveLength(1);
+    expect(result.assetChanges[0]).toEqual({
+      tokenSymbol: 'USDC',
+      tokenAddress: '0xusdc',
+      from: '0xaaaa',
+      to: '0xbbbb',
+      amount: '1',
+    });
+  });
+
+  it('builds trace URL from simulation id', async () => {
+    mockOkResponse(makeTxBody({ simulationId: 'xyz789' }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.traceUrl).toBe(
+      'https://dashboard.tenderly.co/acme/proj/simulation/xyz789',
+    );
+  });
+
+  it('returns empty traceUrl when simulation id is missing', async () => {
+    mockOkResponse({
+      simulation: {},
+      transaction: { status: true, transaction_info: { asset_changes: [] } },
+    });
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.traceUrl).toBe('');
+  });
+
+  it('throws on non-ok HTTP response', async () => {
+    mockErrorResponse(401, 'Unauthorized');
+    await expect(simulateTransaction(CREDS, PARAMS)).rejects.toThrow(
+      'Tenderly API error 401',
+    );
+  });
+
+  it('throws on non-ok response and includes status text', async () => {
+    mockErrorResponse(403, 'Forbidden');
+    await expect(simulateTransaction(CREDS, PARAMS)).rejects.toThrow('403');
+  });
+
+  it('uses "0x" when data is empty string', async () => {
+    mockOkResponse(makeTxBody());
+    await simulateTransaction(CREDS, { ...PARAMS, data: '' });
+    const [, options] = mockFetch.mock.calls[0];
+    expect(JSON.parse(options.body).input).toBe('0x');
+  });
+
+  it('falls back to "?" for missing token symbol in asset change', async () => {
+    const change = {
+      token_info: {},
+      from: '0xaaaa',
+      to: '0xbbbb',
+      amount: '1',
+    };
+    mockOkResponse(makeTxBody({ assetChanges: [change] }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.assetChanges[0].tokenSymbol).toBe('?');
+  });
+
+  it('falls back to empty string for missing token address', async () => {
+    const change = {
+      token_info: {},
+      from: '0xaaaa',
+      to: '0xbbbb',
+      amount: '1',
+    };
+    mockOkResponse(makeTxBody({ assetChanges: [change] }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.assetChanges[0].tokenAddress).toBe('');
+  });
+
+  it('falls back to "0" for missing amount', async () => {
+    const change = {
+      token_info: { symbol: 'ETH', contract_address: '' },
+      from: '0xaaaa',
+      to: '0xbbbb',
+    };
+    mockOkResponse(makeTxBody({ assetChanges: [change] }));
+    const result = await simulateTransaction(CREDS, PARAMS);
+    expect(result.assetChanges[0].amount).toBe('0');
+  });
+
+  it('uses empty string when text() throws on error response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.reject(new Error('read failed')),
+    });
+    await expect(simulateTransaction(CREDS, PARAMS)).rejects.toThrow(
+      'Tenderly API error 500: ',
+    );
+  });
+
+  it('throws "Simulation timed out" when fetch is aborted', async () => {
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    mockFetch.mockRejectedValueOnce(abortErr);
+    await expect(simulateTransaction(CREDS, PARAMS)).rejects.toThrow(
+      'Simulation timed out',
+    );
+  });
+
+  it('re-throws non-abort fetch errors as-is', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network failure'));
+    await expect(simulateTransaction(CREDS, PARAMS)).rejects.toThrow(
+      'network failure',
+    );
+  });
+});
+
+describe('tenderlyClient.offline — simulateTransaction', () => {
+  it('throws "offline"', async () => {
+    await expect(simulateOffline({} as any, {} as any)).rejects.toThrow(
+      'offline',
+    );
+  });
+});

--- a/__tests__/tenderlyStorage.test.ts
+++ b/__tests__/tenderlyStorage.test.ts
@@ -1,0 +1,175 @@
+import {
+  loadTenderlyConfig,
+  saveTenderlyCredentials,
+  saveTenderlyEnabled,
+} from '../src/storage/tenderly.online';
+
+import {
+  loadTenderlyConfig as loadOffline,
+  saveTenderlyCredentials as saveCredsOffline,
+  saveTenderlyEnabled as saveEnabledOffline,
+} from '../src/storage/tenderly.offline';
+
+const mockAsyncGetItem = jest.fn();
+const mockAsyncSetItem = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: any[]) => mockAsyncGetItem(...args),
+    setItem: (...args: any[]) => mockAsyncSetItem(...args),
+  },
+}));
+
+const mockSecureGetItem = jest.fn();
+const mockSecureSetItem = jest.fn();
+
+jest.mock('react-native-encrypted-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: any[]) => mockSecureGetItem(...args),
+    setItem: (...args: any[]) => mockSecureSetItem(...args),
+  },
+}));
+
+describe('tenderly.online storage', () => {
+  beforeEach(() => {
+    mockAsyncGetItem.mockReset();
+    mockAsyncSetItem.mockReset();
+    mockSecureGetItem.mockReset();
+    mockSecureSetItem.mockReset();
+  });
+
+  describe('loadTenderlyConfig', () => {
+    it('returns disabled with empty credentials when nothing stored', async () => {
+      mockAsyncGetItem.mockResolvedValue(null);
+      mockSecureGetItem.mockResolvedValue(null);
+      expect(await loadTenderlyConfig()).toEqual({
+        enabled: false,
+        credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+      });
+    });
+
+    it('returns enabled=true and stored credentials', async () => {
+      mockAsyncGetItem.mockResolvedValue('true');
+      mockSecureGetItem
+        .mockResolvedValueOnce('my-account')
+        .mockResolvedValueOnce('my-project')
+        .mockResolvedValueOnce('my-api-key');
+      expect(await loadTenderlyConfig()).toEqual({
+        enabled: true,
+        credentials: {
+          accountSlug: 'my-account',
+          projectSlug: 'my-project',
+          apiKey: 'my-api-key',
+        },
+      });
+    });
+
+    it('trims whitespace from credential values', async () => {
+      mockAsyncGetItem.mockResolvedValue('true');
+      mockSecureGetItem
+        .mockResolvedValueOnce('  my-account  ')
+        .mockResolvedValueOnce('  my-project  ')
+        .mockResolvedValueOnce('  key  ');
+      const config = await loadTenderlyConfig();
+      expect(config.credentials).toEqual({
+        accountSlug: 'my-account',
+        projectSlug: 'my-project',
+        apiKey: 'key',
+      });
+    });
+
+    it('returns enabled=false when flag is not "true"', async () => {
+      mockAsyncGetItem.mockResolvedValue('false');
+      mockSecureGetItem
+        .mockResolvedValueOnce('acme')
+        .mockResolvedValueOnce('proj')
+        .mockResolvedValueOnce('key');
+      const config = await loadTenderlyConfig();
+      expect(config.enabled).toBe(false);
+    });
+
+    it('returns defaults when storage throws', async () => {
+      mockAsyncGetItem.mockRejectedValue(new Error('storage failure'));
+      mockSecureGetItem.mockRejectedValue(new Error('storage failure'));
+      expect(await loadTenderlyConfig()).toEqual({
+        enabled: false,
+        credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+      });
+    });
+  });
+
+  describe('saveTenderlyEnabled', () => {
+    it('stores "true" in AsyncStorage when enabled', async () => {
+      mockAsyncSetItem.mockResolvedValue(undefined);
+      await saveTenderlyEnabled(true);
+      expect(mockAsyncSetItem).toHaveBeenCalledWith('tenderly_enabled', 'true');
+      expect(mockSecureSetItem).not.toHaveBeenCalled();
+    });
+
+    it('stores "false" in AsyncStorage when disabled', async () => {
+      mockAsyncSetItem.mockResolvedValue(undefined);
+      await saveTenderlyEnabled(false);
+      expect(mockAsyncSetItem).toHaveBeenCalledWith(
+        'tenderly_enabled',
+        'false',
+      );
+      expect(mockSecureSetItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveTenderlyCredentials', () => {
+    it('stores all three credential fields in EncryptedStorage', async () => {
+      mockSecureSetItem.mockResolvedValue(undefined);
+      await saveTenderlyCredentials({
+        accountSlug: 'acme',
+        projectSlug: 'proj',
+        apiKey: 'key123',
+      });
+      expect(mockSecureSetItem).toHaveBeenCalledWith(
+        'tenderly_account_slug',
+        'acme',
+      );
+      expect(mockSecureSetItem).toHaveBeenCalledWith(
+        'tenderly_project_slug',
+        'proj',
+      );
+      expect(mockSecureSetItem).toHaveBeenCalledWith(
+        'tenderly_api_key',
+        'key123',
+      );
+      expect(mockAsyncSetItem).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('tenderly.offline storage', () => {
+  beforeEach(() => {
+    mockAsyncGetItem.mockReset();
+    mockAsyncSetItem.mockReset();
+    mockSecureGetItem.mockReset();
+    mockSecureSetItem.mockReset();
+  });
+
+  it('loadTenderlyConfig returns disabled with empty credentials', async () => {
+    expect(await loadOffline()).toEqual({
+      enabled: false,
+      credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+    });
+    expect(mockAsyncGetItem).not.toHaveBeenCalled();
+    expect(mockSecureGetItem).not.toHaveBeenCalled();
+  });
+
+  it('saveTenderlyEnabled is a no-op', async () => {
+    await saveEnabledOffline(true);
+    expect(mockAsyncSetItem).not.toHaveBeenCalled();
+    expect(mockSecureSetItem).not.toHaveBeenCalled();
+  });
+
+  it('saveTenderlyCredentials is a no-op', async () => {
+    await saveCredsOffline({ accountSlug: 'a', projectSlug: 'b', apiKey: 'c' });
+    expect(mockAsyncSetItem).not.toHaveBeenCalled();
+    expect(mockSecureSetItem).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/txParser.test.ts
+++ b/__tests__/txParser.test.ts
@@ -121,6 +121,18 @@ describe('parseTx', () => {
       expect(tx?.value).toBe('1 ETH');
     });
 
+    it('parses valueWei as decimal string', () => {
+      const hex = buildLegacyTxHex({ value: 1_000_000_000_000_000_000n });
+      const tx = parseTx(hex, 1);
+      expect(tx?.valueWei).toBe('1000000000000000000');
+    });
+
+    it('parses valueWei as "0" for zero value', () => {
+      const hex = buildLegacyTxHex({ value: 0n });
+      const tx = parseTx(hex, 1);
+      expect(tx?.valueWei).toBe('0');
+    });
+
     it('parses fees as legacy kind', () => {
       const hex = buildLegacyTxHex();
       const tx = parseTx(hex, 1);
@@ -156,6 +168,12 @@ describe('parseTx', () => {
       const hex = buildEIP2930TxHex();
       const tx = parseTx(hex, 1);
       expect(tx?.value).toMatch(/ETH/);
+    });
+
+    it('parses valueWei as decimal string', () => {
+      const hex = buildEIP2930TxHex({ value: 500_000_000_000_000_000n });
+      const tx = parseTx(hex, 1);
+      expect(tx?.valueWei).toBe('500000000000000000');
     });
 
     it('parses fees as legacy kind (gasPrice)', () => {
@@ -198,6 +216,7 @@ describe('parseTx', () => {
       const tx = parseTx(buildEIP1559TxHex(), 4);
       expect(tx?.to).toBe('0x0000000000000000000000000000000000000001');
       expect(tx?.value).toBe('1 wei');
+      expect(tx?.valueWei).toBe('1');
       expect(tx?.data).toBeUndefined();
       expect(tx?.fees.kind).toBe('eip1559');
       if (tx?.fees.kind === 'eip1559') {

--- a/__tests__/useSimulation.test.ts
+++ b/__tests__/useSimulation.test.ts
@@ -1,0 +1,263 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { EthSignRequest } from '../src/types';
+import type { ParsedTx } from '../src/utils/txParser';
+import type { SimulationResult } from '../src/utils/tenderly/client.online';
+
+// --- mocks ---
+
+const mockSimulate = jest.fn<Promise<SimulationResult>, any[]>();
+jest.mock('../src/utils/tenderly/client.online', () => ({
+  simulateTransaction: (...args: any[]) => mockSimulate(...args),
+}));
+
+const mockUseTenderlyConfig = jest.fn();
+jest.mock('../src/hooks/useTenderlyConfig.online', () => ({
+  useTenderlyConfig: () => mockUseTenderlyConfig(),
+}));
+
+const mockStart = jest.fn();
+const mockCancel = jest.fn();
+let mockPhase = 'idle';
+let mockResult: string | null = null;
+
+jest.mock('../src/hooks/keycard/useKeycardOperation', () => ({
+  useKeycardOp: () => ({
+    phase: mockPhase,
+    status: '',
+    cardName: null,
+    pinError: null,
+    result: mockResult,
+    start: mockStart,
+    cancel: mockCancel,
+    submitPin: jest.fn(),
+    reset: jest.fn(),
+    retry: jest.fn(),
+    proceedWithNonGenuine: jest.fn(),
+  }),
+}));
+
+jest.mock('../src/utils/ethereumAddress', () => ({
+  pubKeyToEthAddress: (_key: Uint8Array) => '0xDerived',
+}));
+
+// useSimulation imports keycard-sdk transitively via the op fn; mock it
+jest.mock('keycard-sdk', () => ({
+  __esModule: true,
+  default: {
+    BIP32KeyPair: {
+      extendedKey: () => ({ publicKey: new Uint8Array(33) }),
+    },
+  },
+}));
+
+// --- import after mocks ---
+import { useSimulation } from '../src/components/SignRequestDetail/eth/DataTabPanel/useSimulation';
+
+// --- fixtures ---
+
+const CREDS = { accountSlug: 'acme', projectSlug: 'proj', apiKey: 'key123' };
+
+const REQUEST: EthSignRequest = {
+  signData: '0xdeadbeef',
+  dataType: 1,
+  derivationPath: "m/44'/60'/0'/0",
+  address: '0xABCD000000000000000000000000000000000001',
+};
+
+const REQUEST_NO_ADDR: EthSignRequest = {
+  signData: '0xdeadbeef',
+  dataType: 1,
+  derivationPath: "m/44'/60'/0'/0",
+};
+
+const TX: ParsedTx = {
+  to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  data: '0x',
+  valueWei: '0',
+  fees: { kind: 'unknown' },
+};
+
+const TX_NO_TO: ParsedTx = { fees: { kind: 'unknown' } };
+
+const SUCCESS: SimulationResult = {
+  status: 'success',
+  assetChanges: [],
+  traceUrl: 'https://dashboard.tenderly.co/acme/proj/simulation/xyz',
+};
+
+// --- helpers ---
+
+function renderSim(
+  request: EthSignRequest = REQUEST,
+  tx: ParsedTx = TX,
+  chainId: number | undefined = 1,
+) {
+  return renderHook(
+    ({
+      req,
+      parsedTx,
+      cid,
+    }: {
+      req: EthSignRequest;
+      parsedTx: ParsedTx;
+      cid: number | undefined;
+    }) => useSimulation(req, parsedTx, cid),
+    { initialProps: { req: request, parsedTx: tx, cid: chainId } },
+  );
+}
+
+// --- tests ---
+
+describe('useSimulation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPhase = 'idle';
+    mockResult = null;
+    mockUseTenderlyConfig.mockReturnValue({ credentials: null });
+    mockSimulate.mockResolvedValue(SUCCESS);
+  });
+
+  describe('showSimulationTab', () => {
+    it('false when credentials null', () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: null });
+      const { result } = renderSim();
+      expect(result.current.showSimulationTab).toBe(false);
+    });
+
+    it('false when tx has no to address', () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderSim(REQUEST, TX_NO_TO);
+      expect(result.current.showSimulationTab).toBe(false);
+    });
+
+    it('false when chainId is undefined', () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderHook(() =>
+        useSimulation(REQUEST, TX, undefined),
+      );
+      expect(result.current.showSimulationTab).toBe(false);
+    });
+
+    it('true when credentials set, tx has to, chainId known', () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderSim();
+      expect(result.current.showSimulationTab).toBe(true);
+    });
+  });
+
+  describe('handleSimulate with cached address', () => {
+    it('calls simulateTransaction directly', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderSim(REQUEST); // REQUEST has address
+      await act(async () => {
+        result.current.handleSimulate();
+      });
+      expect(mockSimulate).toHaveBeenCalledWith(
+        CREDS,
+        expect.objectContaining({ from: REQUEST.address }),
+      );
+    });
+
+    it('sets simulationState to result on success', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderSim();
+      await act(async () => {
+        result.current.handleSimulate();
+      });
+      await waitFor(() =>
+        expect(result.current.simulationState.phase).toBe('result'),
+      );
+    });
+
+    it('sets simulationState to error on failure', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      mockSimulate.mockRejectedValue(new Error('API error 401'));
+      const { result } = renderSim();
+      await act(async () => {
+        result.current.handleSimulate();
+      });
+      await waitFor(() =>
+        expect(result.current.simulationState.phase).toBe('error'),
+      );
+      expect(
+        (result.current.simulationState as { phase: 'error'; message: string })
+          .message,
+      ).toBe('API error 401');
+    });
+  });
+
+  describe('handleSimulate without cached address', () => {
+    it('calls addressOp.start() when no cached address', () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result } = renderSim(REQUEST_NO_ADDR);
+      act(() => {
+        result.current.handleSimulate();
+      });
+      expect(mockStart).toHaveBeenCalledTimes(1);
+      expect(mockSimulate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCancelNfc', () => {
+    it('calls cancelAddress', () => {
+      const { result } = renderSim();
+      act(() => {
+        result.current.handleCancelNfc();
+      });
+      expect(mockCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reset effect', () => {
+    it('resets simulationState to idle when tx.to changes', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      const { result, rerender } = renderSim(REQUEST, TX);
+      // run a simulation to move out of idle
+      await act(async () => {
+        result.current.handleSimulate();
+      });
+      await waitFor(() =>
+        expect(result.current.simulationState.phase).toBe('result'),
+      );
+      // change tx.to
+      rerender({
+        req: REQUEST,
+        parsedTx: { ...TX, to: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' },
+        cid: 1,
+      });
+      await waitFor(() =>
+        expect(result.current.simulationState.phase).toBe('idle'),
+      );
+    });
+  });
+
+  describe('address-done effect', () => {
+    it('caches derived address and runs simulation when addressOp completes', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: CREDS });
+      mockPhase = 'done';
+      mockResult = '0xDerivedAddress';
+
+      const { result } = renderSim(REQUEST_NO_ADDR);
+
+      await waitFor(() =>
+        expect(result.current.simulationState.phase).toBe('result'),
+      );
+      expect(mockSimulate).toHaveBeenCalledWith(
+        CREDS,
+        expect.objectContaining({ from: '0xDerivedAddress' }),
+      );
+    });
+  });
+
+  describe('runSimulation guards', () => {
+    it('does not call simulateTransaction when credentials null', async () => {
+      mockUseTenderlyConfig.mockReturnValue({ credentials: null });
+      const { result } = renderSim();
+      await act(async () => {
+        result.current.handleSimulate();
+      });
+      expect(mockSimulate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/useTenderlyConfig.test.ts
+++ b/__tests__/useTenderlyConfig.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useTenderlyConfig } from '../src/hooks/useTenderlyConfig.online';
+import { useTenderlyConfig as useTenderlyConfigOffline } from '../src/hooks/useTenderlyConfig.offline';
+
+const mockLoadTenderlyConfig = jest.fn();
+
+jest.mock('../src/storage/tenderly.online', () => ({
+  loadTenderlyConfig: (...args: any[]) => mockLoadTenderlyConfig(...args),
+}));
+
+const CREDS = { accountSlug: 'acme', projectSlug: 'proj', apiKey: 'key123' };
+
+describe('useTenderlyConfig.online', () => {
+  beforeEach(() => {
+    mockLoadTenderlyConfig.mockReset();
+  });
+
+  it('returns null credentials initially', () => {
+    mockLoadTenderlyConfig.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useTenderlyConfig());
+    expect(result.current.credentials).toBeNull();
+  });
+
+  it('returns null when disabled', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue({
+      enabled: false,
+      credentials: CREDS,
+    });
+    const { result } = renderHook(() => useTenderlyConfig());
+    await waitFor(() => expect(mockLoadTenderlyConfig).toHaveBeenCalled());
+    expect(result.current.credentials).toBeNull();
+  });
+
+  it('returns null when any credential field is empty', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue({
+      enabled: true,
+      credentials: { accountSlug: '', projectSlug: 'proj', apiKey: 'key' },
+    });
+    const { result } = renderHook(() => useTenderlyConfig());
+    await waitFor(() => expect(result.current.credentials).toBeNull());
+  });
+
+  it('returns credentials when enabled and all fields set', async () => {
+    mockLoadTenderlyConfig.mockResolvedValue({
+      enabled: true,
+      credentials: CREDS,
+    });
+    const { result } = renderHook(() => useTenderlyConfig());
+    await waitFor(() => expect(result.current.credentials).toEqual(CREDS));
+  });
+
+  it('returns null when storage throws', async () => {
+    mockLoadTenderlyConfig.mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useTenderlyConfig());
+    // stays null after rejection (catch swallows error)
+    await waitFor(() => expect(mockLoadTenderlyConfig).toHaveBeenCalled());
+    expect(result.current.credentials).toBeNull();
+  });
+});
+
+describe('useTenderlyConfig.offline', () => {
+  it('always returns null credentials', () => {
+    const { result } = renderHook(() => useTenderlyConfigOffline());
+    expect(result.current.credentials).toBeNull();
+  });
+});

--- a/__tests__/walletConnectStorage.test.ts
+++ b/__tests__/walletConnectStorage.test.ts
@@ -1,18 +1,18 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-}));
-
 jest.mock('../src/utils/buildConfig', () => ({
   INTERNET_ENABLED: true,
   WC_PROJECT_ID: 'build-time-id',
 }));
 
-const mockGetItem = AsyncStorage.getItem as jest.Mock;
-const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockSecureGetItem = jest.fn();
+const mockSecureSetItem = jest.fn();
+
+jest.mock('react-native-encrypted-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: any[]) => mockSecureGetItem(...args),
+    setItem: (...args: any[]) => mockSecureSetItem(...args),
+  },
+}));
 
 import { loadWCProjectId, saveWCProjectId } from '../src/storage/walletConnect';
 
@@ -22,30 +22,33 @@ beforeEach(() => {
 
 describe('loadWCProjectId', () => {
   it('returns override when stored', async () => {
-    mockGetItem.mockResolvedValue('  custom-id  ');
+    mockSecureGetItem.mockResolvedValue('  custom-id  ');
     expect(await loadWCProjectId()).toBe('custom-id');
   });
 
   it('returns build-time ID when no override', async () => {
-    mockGetItem.mockResolvedValue(null);
+    mockSecureGetItem.mockResolvedValue(null);
     expect(await loadWCProjectId()).toBe('build-time-id');
   });
 
   it('returns build-time ID when override is blank', async () => {
-    mockGetItem.mockResolvedValue('   ');
+    mockSecureGetItem.mockResolvedValue('   ');
     expect(await loadWCProjectId()).toBe('build-time-id');
   });
 
-  it('returns build-time ID on AsyncStorage error', async () => {
-    mockGetItem.mockRejectedValue(new Error('storage error'));
+  it('returns build-time ID on EncryptedStorage error', async () => {
+    mockSecureGetItem.mockRejectedValue(new Error('storage error'));
     expect(await loadWCProjectId()).toBe('build-time-id');
   });
 });
 
 describe('saveWCProjectId', () => {
-  it('trims and stores the id', async () => {
-    mockSetItem.mockResolvedValue(undefined);
+  it('trims and stores the id in EncryptedStorage', async () => {
+    mockSecureSetItem.mockResolvedValue(undefined);
     await saveWCProjectId('  my-id  ');
-    expect(mockSetItem).toHaveBeenCalledWith('wc_project_id_override', 'my-id');
+    expect(mockSecureSetItem).toHaveBeenCalledWith(
+      'wc_project_id_override',
+      'my-id',
+    );
   });
 });

--- a/docs/adr/0004-tenderly-simulation.md
+++ b/docs/adr/0004-tenderly-simulation.md
@@ -1,0 +1,58 @@
+# 0004: Tenderly transaction simulation
+
+Date: 2026-05-21
+
+Status: Accepted
+
+## Context
+
+Users reviewing a transaction before signing can inspect calldata, fees, and digests, but cannot know whether the transaction will succeed or what assets will move without broadcasting it. A simulation step — sending the unsigned transaction to a third-party execution environment — lets users preview the outcome without committing to it.
+
+GapSign's offline build and air-gapped ethos prohibit ambient outbound calls. Any simulation feature must not weaken that promise for users who have not explicitly chosen it.
+
+Simulation requires at minimum: `from` address, `to` address, `value`, calldata, and `chainId`. The private key and the signed payload are never needed.
+
+## Decision
+
+Transaction simulation is:
+
+- **Online build only** — no simulation code, endpoint strings, or credentials are included in the offline APK.
+- **Opt-in** via a Settings toggle, consistent with ADR 0003. Disabled by default.
+- **User-credentialed** — users supply their own Tenderly account slug, project slug, and API key. No shared API key is embedded in the build.
+- **Tenderly** as the simulation provider (REST API at `api.tenderly.co`).
+- **Transaction-scoped** — simulation is offered only for ETH transactions (where `parseTx` produces a `to` address). Personal sign and EIP-712 typed-data requests do not support simulation.
+
+Data sent to Tenderly per simulation:
+
+| Field | Value |
+|-------|-------|
+| `from` | Signer's Ethereum address |
+| `to` | Transaction recipient address |
+| `input` | Transaction calldata |
+| `value` | Transaction value in Wei |
+| `gas` | Gas limit |
+| `network_id` | Chain ID |
+
+The signing key, mnemonic, and signed payload are never transmitted.
+
+The `from` address is taken from the sign request when available. When absent, the user is prompted to tap their Keycard — an extended public key is exported at the derivation path and the address is derived locally before the simulation call is made.
+
+## Rationale
+
+- **Tenderly**: widely used, free tier available, mature simulation API, user-supplied credentials avoid vendor lock-in or shared-key risk.
+- **User-supplied credentials**: the build contains no developer API key; each user controls their own Tenderly account and rate limits.
+- **Online-only build boundary**: simulation code is isolated behind the same `.online` / `.offline` Metro boundary as ENS and WalletConnect — the offline APK cannot reach simulation endpoints even if somehow invoked.
+- **Opt-in respects the air-gap ethos**: users who install the online build for its NFC and QR features should not have transaction data sent to a third-party service without deliberate setup.
+- **Signing proceeds regardless**: a simulation failure, timeout, or revert does not block signing. The user retains final authority over whether to sign.
+
+## Consequences
+
+- Transaction data (addresses, value, calldata, chainId) is sent to Tenderly's servers when simulation is enabled and the user taps Simulate. Users are informed of this in the Settings section.
+- Users without a Tenderly account must register at `dashboard.tenderly.co`; a direct link is provided in Settings.
+- The Simulation tab appears in `TxDataPanel` only when Tenderly is enabled and all three credentials are set.
+
+## Revisit if
+
+- An alternative simulation provider offers self-hosted or on-device simulation that removes the third-party trust requirement.
+- Tenderly changes its API in a breaking way or discontinues its free tier.
+- User demand emerges for simulating EIP-712 typed-data (e.g., permit execution preview) — this would require a different simulation approach.

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -97,13 +97,17 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
 
   return (
     <>
-      {showPinPad && (
-        <View
-          style={[StyleSheet.absoluteFill, { paddingBottom: insets.bottom }]}
-        >
+      <Modal
+        visible={showPinPad}
+        transparent={false}
+        statusBarTranslucent
+        animationType="slide"
+        onRequestClose={onCancel}
+      >
+        <View style={[styles.pinModal, { paddingBottom: insets.bottom }]}>
           <PinPad onComplete={submitPin!} error={pinError ?? undefined} />
         </View>
-      )}
+      </Modal>
 
       {showIOSError && (
         <NFCError
@@ -172,5 +176,9 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     backgroundColor: 'rgba(255,255,255,0.2)',
     marginBottom: 24,
+  },
+  pinModal: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
   },
 });

--- a/src/components/SignRequestDetail/eth/DataTabPanel/SimulationPanel.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/SimulationPanel.tsx
@@ -1,0 +1,184 @@
+import { Linking, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Text } from 'react-native-paper';
+
+import theme from '@/theme';
+
+import PrimaryButton from '@/components/PrimaryButton';
+
+import type {
+  AssetChange,
+  SimulationResult,
+} from '@/utils/tenderly/client.online';
+
+export type SimulationState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'result'; data: SimulationResult }
+  | { phase: 'error'; message: string };
+
+function AssetChangeRow({ change }: { change: AssetChange }) {
+  return (
+    <View style={styles.assetRow}>
+      <Text style={styles.assetSymbol}>{change.tokenSymbol}</Text>
+      <Text style={styles.assetAmount}>{change.amount}</Text>
+      <Text style={styles.assetAddresses} numberOfLines={1}>
+        {change.from.slice(0, 6)}…{change.from.slice(-4)} →{' '}
+        {change.to.slice(0, 6)}…{change.to.slice(-4)}
+      </Text>
+    </View>
+  );
+}
+
+export default function SimulationPanel({
+  state,
+  onSimulate,
+}: {
+  state: SimulationState;
+  onSimulate: () => void;
+}) {
+  if (state.phase === 'idle') {
+    return (
+      <View style={styles.centered}>
+        <PrimaryButton label="Simulate" onPress={onSimulate} />
+      </View>
+    );
+  }
+
+  if (state.phase === 'loading') {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color={theme.colors.primary} />
+        <Text style={styles.loadingText}>Simulating…</Text>
+      </View>
+    );
+  }
+
+  if (state.phase === 'error') {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{state.message}</Text>
+        <PrimaryButton label="Retry" onPress={onSimulate} />
+      </View>
+    );
+  }
+
+  const { data } = state;
+  const reverted = data.status === 'reverted';
+
+  return (
+    <View style={styles.result}>
+      <View
+        style={[
+          styles.chip,
+          reverted ? styles.chipReverted : styles.chipSuccess,
+        ]}
+      >
+        <Text
+          style={[
+            styles.chipText,
+            reverted ? styles.chipTextReverted : styles.chipTextSuccess,
+          ]}
+        >
+          {reverted ? 'Reverted' : 'Success'}
+        </Text>
+      </View>
+
+      {reverted && data.revertReason ? (
+        <Text style={styles.revertReason}>{data.revertReason}</Text>
+      ) : null}
+
+      {data.assetChanges.length > 0 && (
+        <View style={styles.assetSection}>
+          <Text style={styles.sectionLabel}>Asset changes</Text>
+          {data.assetChanges.map((c, i) => (
+            <AssetChangeRow key={i} change={c} />
+          ))}
+        </View>
+      )}
+
+      {data.traceUrl ? (
+        <Text
+          style={styles.traceLink}
+          onPress={() => Linking.openURL(data.traceUrl).catch(() => {})}
+        >
+          View trace →
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 16,
+  },
+  loadingText: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 14,
+  },
+  errorText: {
+    color: theme.colors.error,
+    fontSize: 13,
+    textAlign: 'center',
+  },
+  result: {
+    gap: 12,
+    paddingVertical: 8,
+  },
+  chip: {
+    alignSelf: 'flex-start',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  chipSuccess: {
+    backgroundColor: theme.colors.success + '33',
+  },
+  chipReverted: {
+    backgroundColor: theme.colors.error + '33',
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  chipTextSuccess: {
+    color: theme.colors.success,
+  },
+  chipTextReverted: {
+    color: theme.colors.error,
+  },
+  revertReason: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 13,
+  },
+  assetSection: {
+    gap: 6,
+  },
+  sectionLabel: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 12,
+  },
+  assetRow: {
+    gap: 2,
+  },
+  assetSymbol: {
+    color: theme.colors.onSurface,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  assetAmount: {
+    color: theme.colors.onSurfaceVariant,
+    fontSize: 13,
+  },
+  assetAddresses: {
+    color: theme.colors.onSurfaceSubtle,
+    fontSize: 11,
+    fontFamily: 'monospace',
+  },
+  traceLink: {
+    color: theme.colors.primary,
+    fontSize: 13,
+  },
+});

--- a/src/components/SignRequestDetail/eth/DataTabPanel/TxDataPanel.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/TxDataPanel.tsx
@@ -4,15 +4,17 @@ import { SegmentedButtons } from 'react-native-paper';
 
 import type { EthSignRequest } from '@/types';
 
-import DecodedCallSection from './DecodedCallSection';
+import NFCBottomSheet from '@/components/NFCBottomSheet';
 import InfoRow from '@/components/InfoRow';
-
 import { computeCalldataDigest } from '@/utils/erc8213';
 import type { ParsedTx } from '@/utils/txParser';
 
 import { DigestRow } from './shared';
+import DecodedCallSection from './DecodedCallSection';
+import SimulationPanel from './SimulationPanel';
+import { useSimulation } from './useSimulation';
 
-type Tab = 'decoded' | 'digests' | 'raw';
+type Tab = 'decoded' | 'digests' | 'raw' | 'simulation';
 
 export default function TxDataPanel({
   tx,
@@ -30,27 +32,36 @@ export default function TxDataPanel({
   const initialTab: Tab = hasDecodedCall ? 'decoded' : 'digests';
   const [tab, setTab] = useState<Tab>(initialTab);
 
-  useEffect(() => {
-    if (!hasDecodedCall && tab === 'decoded') {
-      setTab('digests');
-    }
-  }, [hasDecodedCall, tab]);
+  const {
+    showSimulationTab,
+    simulationState,
+    addressOp,
+    handleSimulate,
+    handleCancelNfc,
+  } = useSimulation(request, tx, chainId);
 
   const calldataDigest = useMemo(
     () => computeCalldataDigest(calldata),
     [calldata],
   );
 
-  const buttons = hasDecodedCall
-    ? [
-        { value: 'decoded', label: 'Decoded' },
-        { value: 'digests', label: 'Digests' },
-        { value: 'raw', label: 'Raw' },
-      ]
-    : [
-        { value: 'digests', label: 'Digests' },
-        { value: 'raw', label: 'Raw' },
-      ];
+  useEffect(() => {
+    if (!hasDecodedCall && tab === 'decoded') {
+      setTab('digests');
+    }
+    if (!showSimulationTab && tab === 'simulation') {
+      setTab(hasDecodedCall ? 'decoded' : 'digests');
+    }
+  }, [hasDecodedCall, showSimulationTab, tab]);
+
+  const buttons = [
+    ...(hasDecodedCall ? [{ value: 'decoded', label: 'Decoded' }] : []),
+    { value: 'digests', label: 'Digests' },
+    { value: 'raw', label: 'Raw' },
+    ...(showSimulationTab
+      ? [{ value: 'simulation', label: 'Simulation' }]
+      : []),
+  ];
 
   return (
     <View style={styles.panel}>
@@ -75,7 +86,14 @@ export default function TxDataPanel({
             <InfoRow label="Data" value={request.signData} />
           </View>
         )}
+        {tab === 'simulation' && showSimulationTab && (
+          <SimulationPanel
+            state={simulationState}
+            onSimulate={handleSimulate}
+          />
+        )}
       </View>
+      <NFCBottomSheet nfc={addressOp} onCancel={handleCancelNfc} />
     </View>
   );
 }

--- a/src/components/SignRequestDetail/eth/DataTabPanel/useSimulation.ts
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/useSimulation.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Keycard from 'keycard-sdk';
+
+import type { EthSignRequest } from '@/types';
+import type { ParsedTx } from '@/utils/txParser';
+
+import { useKeycardOp } from '@/hooks/keycard/useKeycardOperation';
+import { useTenderlyConfig } from '@/hooks/useTenderlyConfig.online';
+import { simulateTransaction } from '@/utils/tenderly/client.online';
+import { pubKeyToEthAddress } from '@/utils/ethereumAddress';
+
+import type { SimulationState } from './SimulationPanel';
+
+export function useSimulation(
+  request: EthSignRequest,
+  tx: ParsedTx,
+  chainId: number | undefined,
+) {
+  const { credentials } = useTenderlyConfig();
+
+  const [simulationState, setSimulationState] = useState<SimulationState>({
+    phase: 'idle',
+  });
+  const [cachedAddress, setCachedAddress] = useState<string | null>(
+    request.address ?? null,
+  );
+
+  useEffect(() => {
+    setCachedAddress(request.address ?? null);
+    setSimulationState({ phase: 'idle' });
+  }, [request.address, tx.to, tx.data, tx.valueWei, chainId]);
+
+  const simulationRunIdRef = useRef(0);
+
+  const derivationPathRef = useRef(request.derivationPath);
+  derivationPathRef.current = request.derivationPath;
+  const credentialsRef = useRef(credentials);
+  credentialsRef.current = credentials;
+  const txRef = useRef(tx);
+  txRef.current = tx;
+  const chainIdRef = useRef(chainId);
+  chainIdRef.current = chainId;
+
+  const runSimulation = useCallback(async (from: string) => {
+    const runId = ++simulationRunIdRef.current;
+    const creds = credentialsRef.current;
+    const currentTx = txRef.current;
+    if (!creds || !currentTx.to) return;
+    setSimulationState({ phase: 'loading' });
+    try {
+      const gasLimit =
+        currentTx.fees.kind !== 'unknown' ? currentTx.fees.gasLimit : '21000';
+      const result = await simulateTransaction(creds, {
+        from,
+        to: currentTx.to,
+        valueWei: currentTx.valueWei ?? '0',
+        data: currentTx.data ?? '0x',
+        gasLimit,
+        chainId: chainIdRef.current!,
+      });
+      if (runId !== simulationRunIdRef.current) return;
+      setSimulationState({ phase: 'result', data: result });
+    } catch (e) {
+      if (runId !== simulationRunIdRef.current) return;
+      setSimulationState({
+        phase: 'error',
+        message: e instanceof Error ? e.message : 'Simulation failed',
+      });
+    }
+  }, []);
+
+  const addressOp = useKeycardOp<string>(
+    useCallback(async cmdSet => {
+      const resp = await cmdSet.exportExtendedKey(
+        0,
+        derivationPathRef.current,
+        false,
+      );
+      resp.checkOK();
+      const key = Keycard.BIP32KeyPair.extendedKey(resp.data);
+      return pubKeyToEthAddress(key.publicKey!);
+    }, []),
+    { requiresPin: true },
+  );
+
+  const {
+    phase: addressPhase,
+    result: addressResult,
+    cancel: cancelAddress,
+  } = addressOp;
+
+  useEffect(() => {
+    if (addressPhase !== 'done' || !addressResult) return;
+    setCachedAddress(addressResult);
+    runSimulation(addressResult);
+  }, [addressPhase, addressResult, runSimulation]);
+
+  const handleSimulate = useCallback(() => {
+    if (cachedAddress) {
+      runSimulation(cachedAddress);
+    } else {
+      addressOp.start();
+    }
+  }, [cachedAddress, addressOp, runSimulation]);
+
+  const handleCancelNfc = useCallback(() => {
+    cancelAddress();
+  }, [cancelAddress]);
+
+  const showSimulationTab =
+    credentials !== null && tx.to !== undefined && chainId !== undefined;
+
+  return {
+    showSimulationTab,
+    simulationState,
+    addressOp,
+    handleSimulate,
+    handleCancelNfc,
+  };
+}

--- a/src/components/settings/TextInputSetting.tsx
+++ b/src/components/settings/TextInputSetting.tsx
@@ -17,6 +17,7 @@ export default function TextInputSetting({
   error,
   placeholder,
   keyboardType,
+  disableSave,
   onChangeText,
   onRevert,
   onSave,
@@ -28,8 +29,9 @@ export default function TextInputSetting({
   error?: string | null;
   placeholder?: string;
   keyboardType?: KeyboardTypeOptions;
+  disableSave?: boolean;
   onChangeText: (v: string) => void;
-  onRevert: () => void;
+  onRevert?: () => void;
   onSave: () => void;
 }) {
   return (
@@ -51,14 +53,17 @@ export default function TextInputSetting({
       {error ? <Text style={styles.error}>{error}</Text> : null}
       {(dirty || saving) && (
         <View style={styles.buttonRow}>
-          {dirty && !saving && (
+          {dirty && !saving && onRevert && (
             <Text style={styles.revertButton} onPress={onRevert}>
               Revert
             </Text>
           )}
           <Text
-            style={[styles.saveButton, saving && styles.saveButtonDisabled]}
-            onPress={saving ? undefined : onSave}
+            style={[
+              styles.saveButton,
+              (saving || disableSave) && styles.saveButtonDisabled,
+            ]}
+            onPress={saving || disableSave ? undefined : onSave}
           >
             {saving ? (
               <ActivityIndicator size="small" color={theme.colors.primary} />

--- a/src/components/settings/tenderly/TenderlySettingsSection.offline.tsx
+++ b/src/components/settings/tenderly/TenderlySettingsSection.offline.tsx
@@ -1,0 +1,3 @@
+export default function TenderlySettingsSection() {
+  return null;
+}

--- a/src/components/settings/tenderly/TenderlySettingsSection.online.tsx
+++ b/src/components/settings/tenderly/TenderlySettingsSection.online.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Linking, StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
+
+import theme from '../../../theme';
+
+import SettingsToggleRow from '../SettingsToggleRow';
+import TextInputSetting from '../TextInputSetting';
+
+import {
+  loadTenderlyConfig,
+  saveTenderlyCredentials,
+  saveTenderlyEnabled,
+  type TenderlyCredentials,
+} from '../../../storage/tenderly.online';
+
+const TENDERLY_REGISTER_URL = 'https://dashboard.tenderly.co/register';
+
+export default function TenderlySettingsSection() {
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [accountSlug, setAccountSlug] = useState('');
+  const [projectSlug, setProjectSlug] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [saved, setSaved] = useState<TenderlyCredentials>({
+    accountSlug: '',
+    projectSlug: '',
+    apiKey: '',
+  });
+  const savedRef = useRef(saved);
+  savedRef.current = saved;
+
+  useEffect(() => {
+    let cancelled = false;
+    loadTenderlyConfig()
+      .then(config => {
+        if (cancelled) return;
+        setEnabled(config.enabled);
+        setAccountSlug(config.credentials.accountSlug);
+        setProjectSlug(config.credentials.projectSlug);
+        setApiKey(config.credentials.apiKey);
+        setSaved(config.credentials);
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = useCallback(async (value: boolean) => {
+    setEnabled(value);
+    try {
+      await saveTenderlyEnabled(value);
+    } catch {
+      setEnabled(!value);
+    }
+  }, []);
+
+  const saveCredentials = useCallback(
+    async (patch: Partial<TenderlyCredentials>) => {
+      const creds = { ...savedRef.current, ...patch };
+      try {
+        await saveTenderlyCredentials(creds);
+        setSaved(creds);
+      } catch {
+        // leave UI state as-is; user can retry
+      }
+    },
+    [],
+  );
+
+  const accountSlugDirty = loaded && accountSlug !== saved.accountSlug;
+  const projectSlugDirty = loaded && projectSlug !== saved.projectSlug;
+  const apiKeyDirty = loaded && apiKey !== saved.apiKey;
+
+  if (!loaded) return null;
+
+  return (
+    <View style={styles.section}>
+      <SettingsToggleRow
+        label="Transaction simulation"
+        value={enabled}
+        onValueChange={handleToggle}
+      />
+      {enabled && (
+        <>
+          <TextInputSetting
+            label="Account slug"
+            value={accountSlug}
+            dirty={accountSlugDirty}
+            placeholder="my-account"
+            disableSave={accountSlug.trim() === ''}
+            onChangeText={setAccountSlug}
+            onRevert={
+              saved.accountSlug
+                ? () => setAccountSlug(saved.accountSlug)
+                : undefined
+            }
+            onSave={() => {
+              const v = accountSlug.trim();
+              setAccountSlug(v);
+              saveCredentials({ accountSlug: v });
+            }}
+          />
+          <TextInputSetting
+            label="Project slug"
+            value={projectSlug}
+            dirty={projectSlugDirty}
+            placeholder="my-project"
+            disableSave={projectSlug.trim() === ''}
+            onChangeText={setProjectSlug}
+            onRevert={
+              saved.projectSlug
+                ? () => setProjectSlug(saved.projectSlug)
+                : undefined
+            }
+            onSave={() => {
+              const v = projectSlug.trim();
+              setProjectSlug(v);
+              saveCredentials({ projectSlug: v });
+            }}
+          />
+          <TextInputSetting
+            label="API key"
+            value={apiKey}
+            dirty={apiKeyDirty}
+            placeholder="Enter API key"
+            disableSave={apiKey.trim() === ''}
+            onChangeText={setApiKey}
+            onRevert={saved.apiKey ? () => setApiKey(saved.apiKey) : undefined}
+            onSave={() => {
+              const v = apiKey.trim();
+              setApiKey(v);
+              saveCredentials({ apiKey: v });
+            }}
+          />
+          <Text
+            style={styles.link}
+            onPress={() =>
+              Linking.openURL(TENDERLY_REGISTER_URL).catch(() => {})
+            }
+          >
+            Create a free Tenderly account →
+          </Text>
+        </>
+      )}
+      <Text style={styles.privacy}>
+        When simulation is active, transaction data (addresses, value, calldata,
+        chain ID) is sent to Tenderly. Your signing key is never transmitted.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    gap: 8,
+  },
+  link: {
+    color: theme.colors.primary,
+    fontSize: 13,
+  },
+  privacy: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 12,
+  },
+});

--- a/src/hooks/useTenderlyConfig.offline.ts
+++ b/src/hooks/useTenderlyConfig.offline.ts
@@ -1,0 +1,9 @@
+import type { TenderlyCredentials } from '@/storage/tenderly.offline';
+
+export type { TenderlyCredentials };
+
+export function useTenderlyConfig(): {
+  credentials: TenderlyCredentials | null;
+} {
+  return { credentials: null };
+}

--- a/src/hooks/useTenderlyConfig.online.ts
+++ b/src/hooks/useTenderlyConfig.online.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import {
+  loadTenderlyConfig,
+  type TenderlyCredentials,
+} from '@/storage/tenderly.online';
+
+export type { TenderlyCredentials };
+
+export function useTenderlyConfig(): {
+  credentials: TenderlyCredentials | null;
+} {
+  const [credentials, setCredentials] = useState<TenderlyCredentials | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    loadTenderlyConfig()
+      .then(config => {
+        if (cancelled) return;
+        const { enabled, credentials: creds } = config;
+        setCredentials(
+          enabled && creds.accountSlug && creds.projectSlug && creds.apiKey
+            ? creds
+            : null,
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { credentials };
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,5 +1,11 @@
 import React, { useLayoutEffect } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { DashboardAction, SettingsScreenProps } from '../navigation/types';
@@ -7,6 +13,7 @@ import theme from '../theme';
 
 import EnsSettingsSection from '../components/settings/ens/EnsSettingsSection.online';
 import PinPadSettingsSection from '../components/settings/PinPadSettingsSection';
+import TenderlySettingsSection from '../components/settings/tenderly/TenderlySettingsSection.online';
 import TokenImagesSettingsSection from '../components/settings/TokenImagesSettingsSection.online';
 import WalletConnectSettingsSection from '../components/settings/WalletConnectSettingsSection.online';
 
@@ -23,21 +30,34 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
   }, [navigation]);
 
   return (
-    <ScrollView
-      style={[styles.container, { paddingBottom: insets.bottom + 16 }]}
-      contentContainerStyle={styles.content}
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <View style={styles.section}>
-        <PinPadSettingsSection />
-        <TokenImagesSettingsSection />
-        <EnsSettingsSection />
-        <WalletConnectSettingsSection />
-      </View>
-    </ScrollView>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={[
+          styles.content,
+          { paddingBottom: insets.bottom + 16 },
+        ]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.section}>
+          <PinPadSettingsSection />
+          <TokenImagesSettingsSection />
+          <EnsSettingsSection />
+          <WalletConnectSettingsSection />
+          <TenderlySettingsSection />
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,

--- a/src/storage/ensSettings.online.ts
+++ b/src/storage/ensSettings.online.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import EncryptedStorage from 'react-native-encrypted-storage';
 
 export { DEFAULT_ENS_RPC_URL } from '../constants/ens';
 
@@ -14,7 +15,7 @@ export async function loadEnsSettings(): Promise<EnsSettings> {
   try {
     const [enabled, url] = await Promise.all([
       AsyncStorage.getItem(ENS_ENABLED_KEY),
-      AsyncStorage.getItem(ENS_RPC_URL_KEY),
+      EncryptedStorage.getItem(ENS_RPC_URL_KEY),
     ]);
     return {
       enabled: enabled === 'true',
@@ -30,5 +31,5 @@ export async function saveEnsEnabled(enabled: boolean): Promise<void> {
 }
 
 export async function saveEnsRpcUrl(url: string): Promise<void> {
-  await AsyncStorage.setItem(ENS_RPC_URL_KEY, url);
+  await EncryptedStorage.setItem(ENS_RPC_URL_KEY, url);
 }

--- a/src/storage/tenderly.offline.ts
+++ b/src/storage/tenderly.offline.ts
@@ -1,0 +1,23 @@
+export type TenderlyCredentials = {
+  accountSlug: string;
+  projectSlug: string;
+  apiKey: string;
+};
+
+export interface TenderlyConfig {
+  enabled: boolean;
+  credentials: TenderlyCredentials;
+}
+
+export async function loadTenderlyConfig(): Promise<TenderlyConfig> {
+  return {
+    enabled: false,
+    credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+  };
+}
+
+export async function saveTenderlyEnabled(_value: boolean): Promise<void> {}
+
+export async function saveTenderlyCredentials(
+  _c: TenderlyCredentials,
+): Promise<void> {}

--- a/src/storage/tenderly.online.ts
+++ b/src/storage/tenderly.online.ts
@@ -1,0 +1,56 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import EncryptedStorage from 'react-native-encrypted-storage';
+
+export type TenderlyCredentials = {
+  accountSlug: string;
+  projectSlug: string;
+  apiKey: string;
+};
+
+export interface TenderlyConfig {
+  enabled: boolean;
+  credentials: TenderlyCredentials;
+}
+
+const TENDERLY_ENABLED_KEY = 'tenderly_enabled';
+const TENDERLY_ACCOUNT_SLUG_KEY = 'tenderly_account_slug';
+const TENDERLY_PROJECT_SLUG_KEY = 'tenderly_project_slug';
+const TENDERLY_API_KEY_KEY = 'tenderly_api_key';
+
+export async function loadTenderlyConfig(): Promise<TenderlyConfig> {
+  try {
+    const [enabled, accountSlug, projectSlug, apiKey] = await Promise.all([
+      AsyncStorage.getItem(TENDERLY_ENABLED_KEY),
+      EncryptedStorage.getItem(TENDERLY_ACCOUNT_SLUG_KEY),
+      EncryptedStorage.getItem(TENDERLY_PROJECT_SLUG_KEY),
+      EncryptedStorage.getItem(TENDERLY_API_KEY_KEY),
+    ]);
+    return {
+      enabled: enabled === 'true',
+      credentials: {
+        accountSlug: accountSlug?.trim() ?? '',
+        projectSlug: projectSlug?.trim() ?? '',
+        apiKey: apiKey?.trim() ?? '',
+      },
+    };
+  } catch {
+    return {
+      enabled: false,
+      credentials: { accountSlug: '', projectSlug: '', apiKey: '' },
+    };
+  }
+}
+
+export async function saveTenderlyEnabled(value: boolean): Promise<void> {
+  await AsyncStorage.setItem(TENDERLY_ENABLED_KEY, value ? 'true' : 'false');
+}
+
+export async function saveTenderlyCredentials(
+  c: TenderlyCredentials,
+): Promise<void> {
+  await Promise.all([
+    EncryptedStorage.setItem(TENDERLY_ACCOUNT_SLUG_KEY, c.accountSlug),
+    EncryptedStorage.setItem(TENDERLY_PROJECT_SLUG_KEY, c.projectSlug),
+    EncryptedStorage.setItem(TENDERLY_API_KEY_KEY, c.apiKey),
+  ]);
+}

--- a/src/storage/walletConnect.ts
+++ b/src/storage/walletConnect.ts
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import EncryptedStorage from 'react-native-encrypted-storage';
 
 import { WC_PROJECT_ID } from '@/utils/buildConfig';
 
@@ -6,7 +6,7 @@ const WC_PROJECT_ID_OVERRIDE_KEY = 'wc_project_id_override';
 
 export async function loadWCProjectId(): Promise<string> {
   try {
-    const override = await AsyncStorage.getItem(WC_PROJECT_ID_OVERRIDE_KEY);
+    const override = await EncryptedStorage.getItem(WC_PROJECT_ID_OVERRIDE_KEY);
     if (override && override.trim()) {
       return override.trim();
     }
@@ -17,5 +17,5 @@ export async function loadWCProjectId(): Promise<string> {
 }
 
 export async function saveWCProjectId(id: string): Promise<void> {
-  await AsyncStorage.setItem(WC_PROJECT_ID_OVERRIDE_KEY, id.trim());
+  await EncryptedStorage.setItem(WC_PROJECT_ID_OVERRIDE_KEY, id.trim());
 }

--- a/src/utils/tenderly/client.offline.ts
+++ b/src/utils/tenderly/client.offline.ts
@@ -1,0 +1,38 @@
+export type TenderlyCredentials = {
+  accountSlug: string;
+  projectSlug: string;
+  apiKey: string;
+};
+
+export type AssetChange = {
+  tokenSymbol: string;
+  tokenAddress: string;
+  from: string;
+  to: string;
+  amount: string;
+};
+
+export type SimulationResult =
+  | { status: 'success'; assetChanges: AssetChange[]; traceUrl: string }
+  | {
+      status: 'reverted';
+      revertReason: string | null;
+      assetChanges: AssetChange[];
+      traceUrl: string;
+    };
+
+export type SimulationParams = {
+  from: string;
+  to: string;
+  valueWei: string;
+  data: string;
+  gasLimit: string;
+  chainId: number;
+};
+
+export async function simulateTransaction(
+  _credentials: TenderlyCredentials,
+  _params: SimulationParams,
+): Promise<SimulationResult> {
+  throw new Error('offline');
+}

--- a/src/utils/tenderly/client.online.ts
+++ b/src/utils/tenderly/client.online.ts
@@ -1,0 +1,112 @@
+import type { TenderlyCredentials } from '@/storage/tenderly.online';
+
+const TIMEOUT_MS = 30_000;
+
+export type AssetChange = {
+  tokenSymbol: string;
+  tokenAddress: string;
+  from: string;
+  to: string;
+  amount: string;
+};
+
+export type SimulationResult =
+  | { status: 'success'; assetChanges: AssetChange[]; traceUrl: string }
+  | {
+      status: 'reverted';
+      revertReason: string | null;
+      assetChanges: AssetChange[];
+      traceUrl: string;
+    };
+
+export type SimulationParams = {
+  from: string;
+  to: string;
+  valueWei: string;
+  data: string;
+  gasLimit: string;
+  chainId: number;
+};
+
+export async function simulateTransaction(
+  credentials: TenderlyCredentials,
+  params: SimulationParams,
+): Promise<SimulationResult> {
+  const { accountSlug, projectSlug, apiKey } = credentials;
+  const url = `https://api.tenderly.co/api/v1/account/${accountSlug}/project/${projectSlug}/simulate`;
+
+  const body = {
+    network_id: params.chainId.toString(),
+    from: params.from,
+    to: params.to,
+    input: params.data || '0x',
+    value: params.valueWei,
+    gas: parseInt(params.gasLimit, 10),
+    gas_price: '0',
+    save: false,
+    save_if_fails: false,
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Access-Key': apiKey,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal as unknown as RequestInit['signal'],
+    });
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error('Simulation timed out');
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Tenderly API error ${response.status}: ${text}`);
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+  const tx = json.transaction as Record<string, unknown> | undefined;
+  const sim = json.simulation as Record<string, unknown> | undefined;
+  const simulationId: string = sim?.id != null ? String(sim.id) : '';
+  const traceUrl = simulationId
+    ? `https://dashboard.tenderly.co/${accountSlug}/${projectSlug}/simulation/${simulationId}`
+    : '';
+
+  const txInfo = tx?.transaction_info as Record<string, unknown> | undefined;
+  const rawChanges = Array.isArray(txInfo?.asset_changes)
+    ? (txInfo.asset_changes as Record<string, unknown>[])
+    : [];
+  const assetChanges: AssetChange[] = rawChanges.map(c => ({
+    tokenSymbol: String(
+      (c.token_info as Record<string, unknown>)?.symbol ?? '?',
+    ),
+    tokenAddress: String(
+      (c.token_info as Record<string, unknown>)?.contract_address ?? '',
+    ),
+    from: String(c.from ?? ''),
+    to: String(c.to ?? ''),
+    amount: String(c.amount ?? '0'),
+  }));
+
+  if (tx?.status === true) {
+    return { status: 'success', assetChanges, traceUrl };
+  }
+  const errInfo = tx?.error_info as Record<string, unknown> | undefined;
+  return {
+    status: 'reverted',
+    revertReason:
+      errInfo?.error_message != null ? String(errInfo.error_message) : null,
+    assetChanges,
+    traceUrl,
+  };
+}

--- a/src/utils/txParser.ts
+++ b/src/utils/txParser.ts
@@ -313,6 +313,7 @@ export function decodeCalldata(dataHex: string): DecodedCall | null {
 export type ParsedTx = {
   to?: string;
   value?: string; // in ETH, e.g. "0.01"
+  valueWei?: string; // raw value in Wei as decimal string, for simulation
   data?: string; // hex calldata
   decodedCall?: DecodedCall;
   nonce?: number;
@@ -404,6 +405,7 @@ function parseLegacy(bytes: Buffer, symbol: string): ParsedTx {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
+    valueWei: bufToBigInt(assertBytes(value, 'value')).toString(),
     data: dataHex,
     decodedCall: dataHex ? decodeCalldata(dataHex) ?? undefined : undefined,
     fees: {
@@ -448,6 +450,7 @@ function parseEIP1559(bytes: Buffer, symbol: string): ParsedTx {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
+    valueWei: bufToBigInt(assertBytes(value, 'value')).toString(),
     data: dataHexEip1559,
     decodedCall: dataHexEip1559
       ? decodeCalldata(dataHexEip1559) ?? undefined
@@ -487,6 +490,7 @@ function parseEIP2930(bytes: Buffer, symbol: string): ParsedTx {
     nonce: Number(bufToBigInt(assertBytes(nonce, 'nonce'))),
     to: toAddress(assertBytes(to, 'to')),
     value: weiToNative(bufToBigInt(assertBytes(value, 'value')), symbol),
+    valueWei: bufToBigInt(assertBytes(value, 'value')).toString(),
     data: dataHexEip2930,
     decodedCall: dataHexEip2930
       ? decodeCalldata(dataHexEip2930) ?? undefined


### PR DESCRIPTION
## Summary

- Adds an opt-in Tenderly simulation tab to the transaction review screen; shows success/revert status, asset changes, and a trace link before signing
- Credentials (account slug, project slug, API key) are fully user-supplied — no embedded key; configured in Settings with a link to register
- When the sign request lacks a `from` address, tapping Simulate resolves it via NFC (`exportExtendedKey` at the derivation path); address is cached for subsequent retries
- Simulation is online-only (build boundary); signing is never blocked by simulation outcome
- Fixes Settings inputs hidden by keyboard (`KeyboardAvoidingView` added to `SettingsScreen`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional online Tenderly transaction simulation for ETH transactions (off by default). Requires your Tenderly credentials and appears as a Simulation tab when available.
  * Simulation panel with Simulate action, loading state, success/reverted results, asset-change details, optional revert reason, and "View trace" link.

* **Changed**
  * PIN entry now displays as a full-screen modal.
  * Settings screen wrapped to avoid keyboard overlap; Tenderly settings now allow enabling, editing, saving, reverting credentials, and include a registration link and privacy note.

* **Documentation**
  * Added ADR describing simulation design and user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mmlado/GapSign/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->