### PR TITLE
feat: rename apk

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Generate APK checksums
         run: |
           mkdir -p android/app/build/outputs/apk/release
-          find android/app/build/outputs/apk -name "app-*-release.apk" \
+          find android/app/build/outputs/apk -name "keycard-pal-*-release-*.apk" \
             | sort | xargs sha256sum > android/app/build/outputs/apk/release/SHA256SUMS.txt
 
       - name: Generate release notes
@@ -122,8 +122,8 @@ jobs:
           tag_name: ${{ steps.ver.outputs.tag }}
           body_path: android/app/build/outputs/apk/release/RELEASE_NOTES.md
           files: |
-            android/app/build/outputs/apk/full/release/app-*-release.apk
-            android/app/build/outputs/apk/offline/release/app-*-release.apk
+            android/app/build/outputs/apk/full/release/keycard-pal-*-release-*.apk
+            android/app/build/outputs/apk/offline/release/keycard-pal-*-release-*.apk
             android/app/build/outputs/apk/release/SHA256SUMS.txt
 
   fdroid:
@@ -157,8 +157,8 @@ jobs:
             | grep -v "^${RELEASE_TAG}$" \
             | while read tag; do
                 gh release download "$tag" \
-                  --pattern "app-offline-*-release.apk" \
-                  --pattern "app-full-*-release.apk" \
+                  --pattern "keycard-pal-offline-*-release-*.apk" \
+                  --pattern "keycard-pal-full-*-release-*.apk" \
                   --dir fdroid/repo/ \
                   --clobber 2>/dev/null || true
               done
@@ -170,8 +170,8 @@ jobs:
         run: |
           mkdir -p new-apks/
           gh release download "$RELEASE_TAG" \
-            --pattern "app-offline-*-release.apk" \
-            --pattern "app-full-*-release.apk" \
+            --pattern "keycard-pal-offline-*-release-*.apk" \
+            --pattern "keycard-pal-full-*-release-*.apk" \
             --dir new-apks/
           count=$(find new-apks -maxdepth 1 -name "*.apk" | wc -l)
           if [ "$count" -eq 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Release APKs are now named `keycard-pal-<flavor>-<buildType>-<abi>.apk` instead of `app-<flavor>-<buildType>-<abi>.apk`
+
 ## [1.7.0] - 2026-06-06
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -175,6 +175,13 @@ afterEvaluate {
     }
 
     android.applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            def abi = output.getFilter(com.android.build.OutputFile.ABI) ?: "universal"
+            outputFileName = "keycard-pal-${variant.flavorName}-${variant.buildType.name}-${abi}.apk"
+        }
+    }
+
+    android.applicationVariants.all { variant ->
         def isFull = variant.productFlavors.any { it.name == "full" }
         def taskName = "createBundle${variant.name.capitalize()}JsAndAssets"
         tasks.matching { it.name == taskName }.configureEach {


### PR DESCRIPTION
- Release APKs are now named `keycard-pal-<flavor>-<buildType>-<abi>.apk` instead of `app-<flavor>-<buildType>-<abi>.apk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android release artifact naming convention for APK files to use `keycard-pal-*` pattern in release workflows and build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->