### PR TITLE
feat: handle NFC availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Handle NFC availability
+
 ### Changed
 
 - Release APKs are now named `keycard-pal-<flavor>-<buildType>-<abi>.apk` instead of `app-<flavor>-<buildType>-<abi>.apk`

--- a/__tests__/NFCError.test.tsx
+++ b/__tests__/NFCError.test.tsx
@@ -54,6 +54,49 @@ describe('NFCError', () => {
     });
   });
 
+  describe('openNFCSettings button', () => {
+    it('shows "Open NFC Settings" button when openNFCSettings is provided', () => {
+      render(
+        <NFCError
+          status="NFC off"
+          openNFCSettings={jest.fn()}
+          onCancel={onCancel}
+        />,
+      );
+      expect(screen.getByText('Open NFC Settings')).toBeTruthy();
+    });
+
+    it('hides "Try again" when openNFCSettings is provided (even with retry)', () => {
+      render(
+        <NFCError
+          status="NFC off"
+          openNFCSettings={jest.fn()}
+          retry={onRetry}
+          onCancel={onCancel}
+        />,
+      );
+      expect(screen.queryByText('Try again')).toBeNull();
+    });
+
+    it('calls openNFCSettings when the button is pressed', () => {
+      const openNFCSettings = jest.fn();
+      render(
+        <NFCError
+          status="NFC off"
+          openNFCSettings={openNFCSettings}
+          onCancel={onCancel}
+        />,
+      );
+      fireEvent.press(screen.getByText('Open NFC Settings'));
+      expect(openNFCSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show "Open NFC Settings" when prop is not provided', () => {
+      render(<NFCError status="err" onCancel={onCancel} />);
+      expect(screen.queryByText('Open NFC Settings')).toBeNull();
+    });
+  });
+
   describe('retry button', () => {
     it('shows "Try again" button when retry prop is provided', () => {
       render(<NFCError status="err" retry={onRetry} onCancel={onCancel} />);

--- a/__tests__/NFCSheet.test.tsx
+++ b/__tests__/NFCSheet.test.tsx
@@ -14,6 +14,51 @@ beforeEach(() => {
 });
 
 describe('NFCSheet', () => {
+  describe('openNFCSettings', () => {
+    it('shows "Open NFC Settings" button when openNFCSettings is provided', () => {
+      render(
+        <NFCSheet
+          variant="error"
+          status="NFC off"
+          onCancel={onCancel}
+          openNFCSettings={jest.fn()}
+        />,
+      );
+      expect(screen.getByText('Open NFC Settings')).toBeTruthy();
+    });
+
+    it('hides retry hint when openNFCSettings is provided', () => {
+      render(
+        <NFCSheet
+          variant="error"
+          status="NFC off"
+          onCancel={onCancel}
+          openNFCSettings={jest.fn()}
+        />,
+      );
+      expect(screen.queryByText('Tap your card to try again')).toBeNull();
+    });
+
+    it('calls openNFCSettings when the button is pressed', () => {
+      const openNFCSettings = jest.fn();
+      render(
+        <NFCSheet
+          variant="error"
+          status="NFC off"
+          onCancel={onCancel}
+          openNFCSettings={openNFCSettings}
+        />,
+      );
+      fireEvent.press(screen.getByText('Open NFC Settings'));
+      expect(openNFCSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show "Open NFC Settings" button when openNFCSettings is not provided', () => {
+      render(<NFCSheet variant="error" status="err" onCancel={onCancel} />);
+      expect(screen.queryByText('Open NFC Settings')).toBeNull();
+    });
+  });
+
   describe('retry hint', () => {
     it('shows "Tap your card to try again" when variant is error', () => {
       render(<NFCSheet variant="error" status="Bad MAC" onCancel={onCancel} />);

--- a/__tests__/useFactoryReset.test.ts
+++ b/__tests__/useFactoryReset.test.ts
@@ -37,6 +37,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => Promise.resolve(true),
+      openNFCSettings: () => Promise.resolve(true),
     },
     NFCCardChannel: class {},
   },

--- a/__tests__/useInitCard.test.ts
+++ b/__tests__/useInitCard.test.ts
@@ -37,6 +37,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => Promise.resolve(true),
+      openNFCSettings: () => Promise.resolve(true),
     },
     NFCCardChannel: class {},
   },

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-bitwise */
 
 import { act, renderHook } from '@testing-library/react-native';
+import { AppState } from 'react-native';
 import {
   useKeycardOp,
   useKeycardOperation,
@@ -17,10 +18,12 @@ let capturedOnConnected: (() => Promise<void>) | null = null;
 let capturedOnDisconnected: (() => void) | null = null;
 let capturedOnCancelled: (() => void) | null = null;
 let capturedOnTimeout: (() => void) | null = null;
+let capturedAppStateListener: ((state: string) => void) | null = null;
 
 const mockStartNFC = jest.fn();
 const mockStopNFC = jest.fn();
 const mockStopNFCWithError = jest.fn();
+const mockIsNFCEnabled = jest.fn();
 
 jest.mock('react-native-keycard', () => ({
   __esModule: true,
@@ -45,6 +48,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => mockIsNFCEnabled(),
+      openNFCSettings: () => Promise.resolve(true),
     },
     NFCCardChannel: class {},
   },
@@ -108,13 +113,22 @@ describe('useKeycardOperation', () => {
     mockStartNFC.mockResolvedValue(undefined);
     mockStopNFC.mockResolvedValue(undefined);
     mockStopNFCWithError.mockResolvedValue(undefined);
+    mockIsNFCEnabled.mockResolvedValue(true);
     mockStartNFC.mockClear();
     mockStopNFC.mockClear();
     mockStopNFCWithError.mockClear();
+    mockIsNFCEnabled.mockClear();
     capturedOnConnected = null;
     capturedOnDisconnected = null;
     capturedOnCancelled = null;
     capturedOnTimeout = null;
+    capturedAppStateListener = null;
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_event: string, cb: (state: string) => void) => {
+        capturedAppStateListener = cb;
+        return { remove: jest.fn() };
+      },
+    );
     mockCheckGenuine.mockClear();
     mockLoadPairing.mockClear();
   });
@@ -155,6 +169,28 @@ describe('useKeycardOperation', () => {
       expect(result.current.phase).toBe('pin_entry');
       expect(mockStartNFC).not.toHaveBeenCalled();
     });
+
+    it('falls back to pin_entry when isNFCEnabled check throws', async () => {
+      mockIsNFCEnabled.mockRejectedValue(new Error('check failed'));
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      await act(async () => {});
+      expect(result.current.phase).toBe('pin_entry');
+      expect(mockStartNFC).not.toHaveBeenCalled();
+    });
+
+    it('shows NFC error instead of PIN pad when NFC is disabled', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      await act(async () => {});
+      expect(result.current.phase).toBe('error');
+      expect(mockStartNFC).not.toHaveBeenCalled(); // NFC reader not started (disabled)
+    });
   });
 
   describe('retry', () => {
@@ -176,6 +212,25 @@ describe('useKeycardOperation', () => {
         result.current.retry();
       });
       expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+    });
+
+    it('shows PIN pad instead of starting NFC when PIN required but not yet entered', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      await act(async () => {});
+      // NFC was disabled — error shown, PIN never entered
+      expect(result.current.phase).toBe('error');
+      mockStartNFC.mockClear();
+
+      // Simulate NFC becoming available; retry should route to PIN pad
+      await act(async () => {
+        result.current.retry();
+      });
+      expect(result.current.phase).toBe('pin_entry');
+      expect(mockStartNFC).not.toHaveBeenCalled();
     });
   });
 
@@ -497,6 +552,34 @@ describe('useKeycardOperation', () => {
     });
   });
 
+  describe('empty PIN guard', () => {
+    beforeEach(() => {
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => makeMockCmdSet());
+    });
+
+    it('enters error phase when card connects before PIN is entered', async () => {
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: true });
+      });
+      expect(result.current.phase).toBe('pin_entry');
+
+      await act(async () => {
+        result.current.submitPin('');
+      });
+      expect(result.current.phase).toBe('nfc');
+
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'Enter your PIN first — tap Retry to continue.',
+      );
+    });
+  });
+
   describe('clearPinError', () => {
     it('is exposed and callable without side effects when no error exists', async () => {
       const { result } = renderHook(() => useKeycardOperation<string>());
@@ -580,10 +663,50 @@ describe('useKeycardOperation', () => {
   });
 });
 
+describe('onNFCAvailableRef', () => {
+  beforeEach(() => {
+    mockStartNFC.mockResolvedValue(undefined);
+    mockIsNFCEnabled.mockResolvedValue(true);
+    mockStartNFC.mockClear();
+    mockIsNFCEnabled.mockClear();
+    capturedAppStateListener = null;
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_event: string, cb: (state: string) => void) => {
+        capturedAppStateListener = cb;
+        return { remove: jest.fn() };
+      },
+    );
+  });
+
+  it('starts NFC directly when NFC re-enables and PIN is not required', async () => {
+    mockIsNFCEnabled.mockResolvedValue(false);
+    const { result } = renderHook(() => useKeycardOperation<string>());
+
+    await act(async () => {
+      result.current.execute(jest.fn(), { requiresPin: false });
+    });
+    await act(async () => {});
+    expect(result.current.phase).toBe('error');
+
+    mockIsNFCEnabled.mockResolvedValue(true);
+    mockStartNFC.mockClear();
+
+    await act(async () => {
+      capturedAppStateListener?.('active');
+    });
+    await act(async () => {});
+
+    expect(result.current.phase).toBe('nfc');
+    expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+  });
+});
+
 describe('useKeycardOp', () => {
   beforeEach(() => {
     mockStartNFC.mockResolvedValue(undefined);
+    mockIsNFCEnabled.mockResolvedValue(true);
     mockStartNFC.mockClear();
+    mockIsNFCEnabled.mockClear();
   });
 
   it('start() transitions to nfc when requiresPin is false', async () => {

--- a/__tests__/useNFCOperation.test.ts
+++ b/__tests__/useNFCOperation.test.ts
@@ -34,6 +34,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => Promise.resolve(true),
+      openNFCSettings: () => Promise.resolve(true),
     },
     NFCCardChannel: class {},
   },

--- a/__tests__/useNFCSession.test.ts
+++ b/__tests__/useNFCSession.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { useCallback } from 'react';
+import { AppState } from 'react-native';
 import useNFCSession from '../src/hooks/keycard/useNFCSession';
 
 // ---------------------------------------------------------------------------
@@ -14,6 +15,8 @@ let capturedOnTimeout: (() => void) | null = null;
 const mockStartNFC = jest.fn();
 const mockStopNFC = jest.fn();
 const mockStopNFCWithError = jest.fn();
+const mockIsNFCEnabled = jest.fn();
+const mockOpenNFCSettings = jest.fn();
 
 jest.mock('react-native-keycard', () => ({
   __esModule: true,
@@ -38,6 +41,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => mockIsNFCEnabled(),
+      openNFCSettings: () => mockOpenNFCSettings(),
     },
     NFCCardChannel: class {},
   },
@@ -58,6 +63,9 @@ jest.mock('keycard-sdk', () => ({
 // Tests
 // ---------------------------------------------------------------------------
 
+// AppState.addEventListener is a jest.fn() in the RN jest preset.
+let capturedAppStateListener: ((state: string) => void) | null = null;
+
 describe('useNFCSession', () => {
   let mockOnCardConnected: jest.Mock;
   let mockOnCardDisconnected: jest.Mock;
@@ -66,10 +74,14 @@ describe('useNFCSession', () => {
     mockStartNFC.mockResolvedValue(undefined);
     mockStopNFC.mockResolvedValue(undefined);
     mockStopNFCWithError.mockResolvedValue(undefined);
+    mockIsNFCEnabled.mockResolvedValue(true);
+    mockOpenNFCSettings.mockResolvedValue(true);
     mockSelect.mockResolvedValue({ sw: 0x9000 });
     mockStartNFC.mockClear();
     mockStopNFC.mockClear();
     mockStopNFCWithError.mockClear();
+    mockIsNFCEnabled.mockClear();
+    mockOpenNFCSettings.mockClear();
     mockSelect.mockClear();
     mockOnCardConnected = jest.fn().mockResolvedValue(undefined);
     mockOnCardDisconnected = jest.fn().mockResolvedValue(undefined);
@@ -77,6 +89,13 @@ describe('useNFCSession', () => {
     capturedOnDisconnected = null;
     capturedOnCancelled = null;
     capturedOnTimeout = null;
+    capturedAppStateListener = null;
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_event: string, cb: (state: string) => void) => {
+        capturedAppStateListener = cb;
+        return { remove: jest.fn() };
+      },
+    );
   });
 
   function makeHook() {
@@ -143,6 +162,278 @@ describe('useNFCSession', () => {
       expect(result.current.phase).toBe('error');
       expect(result.current.status).toBe('Failed to start NFC: timeout');
     });
+
+    it('sets error and does not open NFC when isNFCEnabled returns false on Android', async () => {
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        mockIsNFCEnabled.mockResolvedValue(false);
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+        expect(result.current.status).toBe(
+          'NFC is turned off. Enable it in Settings to continue.',
+        );
+        expect(mockStartNFC).not.toHaveBeenCalled();
+        expect(result.current.openNFCSettings).toBeDefined();
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('openNFCSettings is undefined on iOS when NFC is disabled', async () => {
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'ios';
+      try {
+        mockIsNFCEnabled.mockResolvedValue(false);
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+        expect(result.current.openNFCSettings).toBeUndefined();
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('proceeds normally when isNFCEnabled check throws', async () => {
+      mockIsNFCEnabled.mockRejectedValue(new Error('check failed'));
+      const { result } = makeHook();
+      await act(async () => {
+        result.current.startNFC();
+      });
+      await act(async () => {});
+      expect(result.current.phase).toBe('nfc');
+      expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+    });
+  });
+
+  describe('AppState NFC re-check', () => {
+    it('clears nfcDisabled and restarts NFC (default) when NFC becomes available', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+        expect(result.current.openNFCSettings).toBeDefined();
+
+        mockIsNFCEnabled.mockResolvedValue(true);
+        await act(async () => {
+          capturedAppStateListener?.('active');
+        });
+        await act(async () => {});
+
+        expect(result.current.openNFCSettings).toBeUndefined();
+        expect(result.current.phase).toBe('nfc');
+        expect(result.current.status).toBe('Tap your Keycard');
+        // doStartNFC only fires after re-enable (not during the initial disabled check)
+        expect(mockStartNFC).toHaveBeenCalledTimes(1);
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('calls onNFCAvailableRef handler instead of restarting NFC when one is set', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const { result } = makeHook();
+        const customHandler = jest.fn();
+        result.current.onNFCAvailableRef.current = customHandler;
+
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+
+        mockIsNFCEnabled.mockResolvedValue(true);
+        await act(async () => {
+          capturedAppStateListener?.('active');
+        });
+        await act(async () => {});
+
+        expect(customHandler).toHaveBeenCalledTimes(1);
+        expect(mockStartNFC).not.toHaveBeenCalled(); // NFC was disabled, custom handler ran instead
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('does not change state when app foregrounds but NFC is still disabled', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+
+        await act(async () => {
+          capturedAppStateListener?.('active');
+        });
+        await act(async () => {});
+
+        expect(result.current.openNFCSettings).toBeDefined();
+        expect(result.current.status).toBe(
+          'NFC is turned off. Enable it in Settings to continue.',
+        );
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('ignores AppState changes to non-active states while NFC is disabled', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+
+        mockIsNFCEnabled.mockResolvedValue(true);
+        mockStartNFC.mockClear();
+
+        await act(async () => {
+          capturedAppStateListener?.('background');
+        });
+        await act(async () => {});
+
+        expect(result.current.phase).toBe('error');
+        expect(mockStartNFC).not.toHaveBeenCalled();
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('does not crash when isNFCEnabled throws in AppState change handler', async () => {
+      mockIsNFCEnabled.mockResolvedValue(false);
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.phase).toBe('error');
+
+        mockIsNFCEnabled.mockRejectedValue(new Error('check failed'));
+
+        await act(async () => {
+          capturedAppStateListener?.('active');
+        });
+        await act(async () => {});
+
+        expect(result.current.phase).toBe('error');
+        expect(result.current.openNFCSettings).toBeDefined();
+      } finally {
+        Platform.OS = origOS;
+      }
+    });
+
+    it('does not register AppState listener when NFC is enabled', async () => {
+      const { result } = makeHook();
+      await act(async () => {
+        result.current.startNFC();
+      });
+      await act(async () => {});
+      expect(result.current.phase).toBe('nfc');
+      expect(capturedAppStateListener).toBeNull();
+    });
+  });
+
+  describe('startNFC generation guard', () => {
+    it('ignores stale isNFCEnabled callback when reset fires before it resolves', async () => {
+      let resolveEnabled!: (v: boolean) => void;
+      mockIsNFCEnabled.mockReturnValue(
+        new Promise<boolean>(res => {
+          resolveEnabled = res;
+        }),
+      );
+
+      const { result } = makeHook();
+      await act(async () => {
+        result.current.startNFC();
+      });
+      expect(result.current.phase).toBe('nfc');
+
+      // Reset before the isNFCEnabled promise resolves — bumps the generation
+      await act(async () => {
+        result.current.reset();
+      });
+      expect(result.current.phase).toBe('idle');
+
+      // Stale callback resolves (NFC is enabled) — must not call doStartNFC
+      mockStartNFC.mockClear();
+      await act(async () => {
+        resolveEnabled(true);
+      });
+      await act(async () => {});
+
+      expect(result.current.phase).toBe('idle');
+      expect(mockStartNFC).not.toHaveBeenCalled();
+    });
+
+    it('ignores stale isNFCEnabled callback when a second startNFC fires before first resolves', async () => {
+      let resolveFirst!: (v: boolean) => void;
+      mockIsNFCEnabled
+        .mockReturnValueOnce(
+          new Promise<boolean>(res => {
+            resolveFirst = res;
+          }),
+        )
+        .mockResolvedValue(true);
+
+      const { result } = makeHook();
+
+      // First startNFC — isNFCEnabled hangs
+      await act(async () => {
+        result.current.startNFC();
+      });
+
+      // Second startNFC — bumps generation
+      await act(async () => {
+        result.current.startNFC();
+      });
+      await act(async () => {}); // flush second isNFCEnabled (resolves true)
+      expect(result.current.phase).toBe('nfc');
+
+      mockStartNFC.mockClear();
+
+      // First stale callback now resolves (also enabled) — must not call doStartNFC again
+      await act(async () => {
+        resolveFirst(true);
+      });
+      await act(async () => {});
+
+      expect(mockStartNFC).not.toHaveBeenCalled();
+    });
   });
 
   describe('reset', () => {
@@ -157,6 +448,27 @@ describe('useNFCSession', () => {
       expect(result.current.phase).toBe('idle');
       expect(result.current.status).toBe('');
       expect(mockStopNFC).toHaveBeenCalled();
+    });
+
+    it('clears openNFCSettings on reset', async () => {
+      const Platform = require('react-native').Platform;
+      const origOS = Platform.OS;
+      Platform.OS = 'android';
+      try {
+        mockIsNFCEnabled.mockResolvedValue(false);
+        const { result } = makeHook();
+        await act(async () => {
+          result.current.startNFC();
+        });
+        await act(async () => {});
+        expect(result.current.openNFCSettings).toBeDefined();
+        await act(async () => {
+          result.current.reset();
+        });
+        expect(result.current.openNFCSettings).toBeUndefined();
+      } finally {
+        Platform.OS = origOS;
+      }
     });
   });
 

--- a/__tests__/usePairingSlots.test.ts
+++ b/__tests__/usePairingSlots.test.ts
@@ -26,6 +26,8 @@ jest.mock('react-native-keycard', () => ({
       startNFC: (msg: string) => mockStartNFC(msg),
       stopNFC: () => mockStopNFC(),
       stopNFCWithError: (msg: string) => mockStopNFCWithError(msg),
+      isNFCEnabled: () => Promise.resolve(true),
+      openNFCSettings: () => Promise.resolve(true),
     },
     NFCCardChannel: class {},
   },

--- a/src/components/NFCBottomSheet/NFCError.tsx
+++ b/src/components/NFCBottomSheet/NFCError.tsx
@@ -8,6 +8,7 @@ import theme from '../../theme';
 type Props = {
   status: string;
   retry?: () => void;
+  openNFCSettings?: () => void;
   onCancel: () => void;
   paddingBottom?: number;
 };
@@ -15,6 +16,7 @@ type Props = {
 export default function NFCError({
   status,
   retry,
+  openNFCSettings,
   onCancel,
   paddingBottom = 24,
 }: Props) {
@@ -27,7 +29,14 @@ export default function NFCError({
       <Text variant="bodyMedium" style={styles.status}>
         {status}
       </Text>
-      {retry && (
+      {openNFCSettings && (
+        <Pressable style={styles.retryButton} onPress={openNFCSettings}>
+          <Text variant="labelLarge" style={styles.retryLabel}>
+            Open NFC Settings
+          </Text>
+        </Pressable>
+      )}
+      {!openNFCSettings && retry && (
         <Pressable style={styles.retryButton} onPress={retry}>
           <Text variant="labelLarge" style={styles.retryLabel}>
             Try again

--- a/src/components/NFCBottomSheet/NFCSheet.tsx
+++ b/src/components/NFCBottomSheet/NFCSheet.tsx
@@ -12,6 +12,7 @@ type Props = {
   status: string;
   cardName?: string | null;
   onCancel: () => void;
+  openNFCSettings?: () => void;
 };
 
 function PulseRing({ delay, size }: { delay: number; size: number }) {
@@ -64,6 +65,7 @@ export default function NFCSheet({
   status,
   cardName,
   onCancel,
+  openNFCSettings,
 }: Props) {
   const NfcIcon =
     variant === 'success'
@@ -94,10 +96,22 @@ export default function NFCSheet({
         {status}
       </Text>
 
-      {variant === 'error' && (
+      {variant === 'error' && !openNFCSettings && (
         <Text variant="bodyMedium" style={styles.retryHint}>
           Tap your card to try again
         </Text>
+      )}
+
+      {variant === 'error' && openNFCSettings && (
+        <Pressable
+          style={styles.settingsButton}
+          android_ripple={{ color: theme.colors.secondaryRipple }}
+          onPress={openNFCSettings}
+        >
+          <Text variant="labelLarge" style={styles.settingsText}>
+            Open NFC Settings
+          </Text>
+        </Pressable>
       )}
 
       {variant !== 'success' && (
@@ -151,5 +165,15 @@ const styles = StyleSheet.create({
     color: theme.colors.onSurfaceMuted,
     textAlign: 'center',
     marginBottom: 8,
+  },
+  settingsButton: {
+    paddingVertical: 14,
+    paddingHorizontal: 40,
+    borderRadius: 28,
+    backgroundColor: theme.colors.primary,
+    marginBottom: 8,
+  },
+  settingsText: {
+    color: theme.colors.onSurface,
   },
 });

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -25,6 +25,7 @@ export type NFCOperation = {
   submitPin?: (pin: string) => void;
   proceedWithNonGenuine?: () => void;
   retry?: () => void;
+  openNFCSettings?: () => void;
 };
 
 type Props = {
@@ -43,6 +44,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
     submitPin,
     proceedWithNonGenuine,
     retry,
+    openNFCSettings,
   } = nfc;
   const insets = useSafeAreaInsets();
   const slideAnim = useRef(new Animated.Value(400)).current;
@@ -113,6 +115,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
         <NFCError
           status={status}
           retry={retry}
+          openNFCSettings={openNFCSettings}
           onCancel={onCancel}
           paddingBottom={insets.bottom + 24}
         />
@@ -147,6 +150,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
                 status={status}
                 cardName={cardName}
                 onCancel={onCancel}
+                openNFCSettings={openNFCSettings}
               />
             </Animated.View>
           </View>

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import Keycard from 'keycard-sdk';
+import RNKeycard from 'react-native-keycard';
 import { WrongPINException } from 'keycard-sdk/dist/apdu-exception';
 import { Commandset } from 'keycard-sdk/dist/commandset';
 
@@ -41,6 +42,7 @@ export interface UseKeycardOperation<T> {
   reset: () => void;
   retry: () => void;
   proceedWithNonGenuine: () => void;
+  openNFCSettings: (() => void) | undefined;
 }
 
 export function useKeycardOperation<T>(): UseKeycardOperation<T> {
@@ -125,6 +127,12 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       cmdSet: Commandset,
       setStatus: (status: string) => void,
     ): Promise<T | null> => {
+      // Guard: PIN was required but user returned from NFC Settings before entering it.
+      // SELECT already ran (harmless); stop here to avoid sending verifyPIN('').
+      if (requiresPinRef.current && !pinRef.current) {
+        throw new Error('Enter your PIN first — tap Retry to continue.');
+      }
+
       const appInfo = cmdSet.applicationInfo;
       if (!appInfo) {
         throw new Error('No application info in SELECT response');
@@ -181,12 +189,24 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     start: startNFC,
     cancel: nfcCancel,
     reset: nfcReset,
+    openNFCSettings,
+    onNFCAvailableRef,
   } = useNFCOperation<T | null>(handleCardConnected);
+
+  // When the user returns from NFC Settings with NFC now enabled, go straight
+  // to PIN entry (if PIN hasn't been entered yet) or restart NFC directly.
+  onNFCAvailableRef.current = () => {
+    if (requiresPinRef.current && !pinRef.current) {
+      setWaitingForPin(true);
+    } else {
+      startNFC();
+    }
+  };
 
   // 'genuine_warning' takes priority over all other phase overrides.
   const phase: Phase = showGenuineWarning
     ? 'genuine_warning'
-    : (waitingForPin && nfcPhase === 'idle') ||
+    : (waitingForPin && (nfcPhase === 'idle' || nfcPhase === 'error')) ||
       (pinError !== null && nfcPhase === 'error')
     ? 'pin_entry'
     : nfcPhase;
@@ -200,9 +220,22 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
 
       if (!requiresPinRef.current) {
         startNFC();
-      } else {
-        setWaitingForPin(true);
+        return;
       }
+
+      // Check NFC before showing the PIN pad so users don't enter their PIN
+      // only to be told NFC is disabled immediately after.
+      RNKeycard.Core.isNFCEnabled()
+        .then(enabled => {
+          if (enabled) {
+            setWaitingForPin(true);
+          } else {
+            startNFC(); // startNFC handles the NFC-disabled error + openNFCSettings
+          }
+        })
+        .catch(() => {
+          setWaitingForPin(true); // can't check — fall back to PIN entry
+        });
     },
     [startNFC],
   );
@@ -231,9 +264,14 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     startNFC();
   }, [startNFC]);
 
-  // Re-starts NFC without PIN re-entry — uses the cached PIN from the previous attempt.
+  // Re-starts NFC. If PIN hasn't been entered yet (e.g. NFC was off before PIN entry),
+  // show the PIN pad instead of starting NFC directly.
   const retry = useCallback(() => {
     if (!operationRef.current) return;
+    if (requiresPinRef.current && !pinRef.current) {
+      setWaitingForPin(true);
+      return;
+    }
     startNFC();
   }, [startNFC]);
 
@@ -271,6 +309,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     reset,
     retry,
     proceedWithNonGenuine,
+    openNFCSettings,
   };
 }
 

--- a/src/hooks/keycard/useNFCOperation.ts
+++ b/src/hooks/keycard/useNFCOperation.ts
@@ -11,6 +11,8 @@ export interface UseNFCOperation<T> {
   start: () => void;
   cancel: () => void;
   reset: () => void;
+  openNFCSettings: (() => void) | undefined;
+  onNFCAvailableRef: { current: (() => void) | null };
 }
 
 export function useNFCOperation<T>(
@@ -40,6 +42,8 @@ export function useNFCOperation<T>(
     status,
     startNFC,
     reset: nfcReset,
+    openNFCSettings,
+    onNFCAvailableRef,
   } = useNFCSession(handleCardConnected, handleCardDisconnected);
 
   const cancel = useCallback(() => {
@@ -53,5 +57,14 @@ export function useNFCOperation<T>(
     setResult(null);
   }, [nfcReset]);
 
-  return { phase, status, result, start: startNFC, cancel, reset };
+  return {
+    phase,
+    status,
+    result,
+    start: startNFC,
+    cancel,
+    reset,
+    openNFCSettings,
+    onNFCAvailableRef,
+  };
 }

--- a/src/hooks/keycard/useNFCSession.ts
+++ b/src/hooks/keycard/useNFCSession.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import RNKeycard from 'react-native-keycard';
 import Keycard from 'keycard-sdk';
 import { Commandset } from 'keycard-sdk/dist/commandset';
@@ -11,6 +11,10 @@ export interface UseNFCSessionOperation {
   status: string;
   startNFC: () => void;
   reset: () => void;
+  openNFCSettings: (() => void) | undefined;
+  /** Override the action taken when NFC becomes available after being disabled.
+   *  If null, the default is to restart the NFC reader directly. */
+  onNFCAvailableRef: { current: (() => void) | null };
 }
 
 export default function useNFCSession(
@@ -22,11 +26,14 @@ export default function useNFCSession(
 ): UseNFCSessionOperation {
   const [phase, setPhase] = useState<Phase>('idle');
   const [status, setStatus] = useState('');
+  const [nfcDisabled, setNfcDisabled] = useState(false);
+  const onNFCAvailableRef = useRef<(() => void) | null>(null);
   const phaseRef = useRef(phase);
   phaseRef.current = phase;
   const disconnectedRef = useRef(false);
   const realErrorRef = useRef(false);
   const inFlightRef = useRef(false);
+  const startAttemptRef = useRef(0);
 
   const handleCardConnected = useCallback(async () => {
     if (phaseRef.current !== 'nfc' && phaseRef.current !== 'error') {
@@ -132,12 +139,7 @@ export default function useNFCSession(
     };
   }, [handleCardConnected, handleCardDisconnected]);
 
-  const startNFC = useCallback(() => {
-    disconnectedRef.current = false;
-    realErrorRef.current = false;
-    inFlightRef.current = false;
-    setStatus('Tap your Keycard');
-    setPhase('nfc');
+  const doStartNFC = useCallback(() => {
     RNKeycard.Core.startNFC('Tap your Keycard')
       .then((result: any) => {
         if (result && result.isSuccess === false) {
@@ -152,11 +154,76 @@ export default function useNFCSession(
       });
   }, []);
 
+  // When the user returns from the NFC settings screen with NFC now enabled,
+  // invoke the registered handler (e.g. show PIN pad) or restart NFC directly.
+  useEffect(() => {
+    if (!nfcDisabled) return;
+    const sub = AppState.addEventListener('change', nextState => {
+      if (nextState !== 'active') return;
+      RNKeycard.Core.isNFCEnabled()
+        .then(enabled => {
+          if (!enabled) return;
+          setNfcDisabled(false);
+          const handler = onNFCAvailableRef.current;
+          if (handler) {
+            handler();
+          } else {
+            setStatus('Tap your Keycard');
+            setPhase('nfc');
+            doStartNFC();
+          }
+        })
+        .catch(() => {});
+    });
+    return () => sub.remove();
+  }, [nfcDisabled, doStartNFC]);
+
+  const startNFC = useCallback(() => {
+    const attempt = ++startAttemptRef.current;
+    disconnectedRef.current = false;
+    realErrorRef.current = false;
+    inFlightRef.current = false;
+
+    // Open the NFC sheet immediately so there is no empty-screen gap while the
+    // async isNFCEnabled() check runs. If NFC is off, we transition to 'error'
+    // inside the already-visible sheet.
+    setStatus('Tap your Keycard');
+    setPhase('nfc');
+
+    RNKeycard.Core.isNFCEnabled()
+      .then(enabled => {
+        if (attempt !== startAttemptRef.current) return;
+        if (!enabled) {
+          setNfcDisabled(true);
+          setStatus('NFC is turned off. Enable it in Settings to continue.');
+          setPhase('error');
+          return;
+        }
+        setNfcDisabled(false);
+        doStartNFC();
+      })
+      .catch(() => {
+        if (attempt !== startAttemptRef.current) return;
+        // isNFCEnabled() check failed — proceed and let startNFC surface the real error
+        setNfcDisabled(false);
+        doStartNFC();
+      });
+  }, [doStartNFC]);
+
   const reset = useCallback(() => {
+    startAttemptRef.current++;
     RNKeycard.Core.stopNFC().catch(() => {});
     setPhase('idle');
     setStatus('');
+    setNfcDisabled(false);
   }, []);
 
-  return { phase, status, startNFC, reset };
+  const openNFCSettings: (() => void) | undefined =
+    nfcDisabled && Platform.OS === 'android'
+      ? () => {
+          RNKeycard.Core.openNFCSettings().catch(() => {});
+        }
+      : undefined;
+
+  return { phase, status, startNFC, reset, openNFCSettings, onNFCAvailableRef };
 }

--- a/src/screens/PairingSlotsScreen.tsx
+++ b/src/screens/PairingSlotsScreen.tsx
@@ -106,8 +106,9 @@ export default function PairingSlotsScreen({
       cancelUnpair();
     } else {
       cancelCheck();
+      navigation.goBack();
     }
-  }, [isUnpairing, cancelUnpair, cancelCheck]);
+  }, [isUnpairing, cancelUnpair, cancelCheck, navigation]);
 
   // Build the NFCOperation object passed to NFCBottomSheet.
   // The check flow maps 'checking' → 'nfc' so the bottom sheet shows.


### PR DESCRIPTION
- Handle NFC availability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFC availability detection before operations
  * "Open NFC Settings" button when NFC is disabled
  * Cancelling from Pairing Slots now returns to the previous screen

* **Documentation**
  * CHANGELOG updated with NFC availability note
  * Release APK naming convention updated

* **Tests**
  * Expanded tests for NFC availability, settings flow, and platform behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->