### PR TITLE
feat: custom pairing password when default pairing fails (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Handle NFC availability
+- Prompt for custom pairing password when default pairing fails; loop on wrong password with error feedback; show friendly message when pairing slots are full
 
 ### Changed
 

--- a/__tests__/NFCBottomSheet.test.tsx
+++ b/__tests__/NFCBottomSheet.test.tsx
@@ -179,6 +179,68 @@ describe('NFCBottomSheet — Android sheet', () => {
     });
   });
 
+  describe('pairing_password phase', () => {
+    const submitPairingPassword = jest.fn();
+
+    beforeEach(() => {
+      submitPairingPassword.mockClear();
+    });
+
+    it('shows the pairing password title', () => {
+      renderSheet(
+        makeNfc('pairing_password', { submitPairingPassword }),
+      );
+      expect(screen.getByText('Custom pairing password')).toBeTruthy();
+    });
+
+    it('shows Cancel and Continue buttons', () => {
+      renderSheet(
+        makeNfc('pairing_password', { submitPairingPassword }),
+      );
+      expect(screen.getByText('Cancel')).toBeTruthy();
+      expect(screen.getByText('Continue')).toBeTruthy();
+    });
+
+    it('calls onCancel when Cancel is pressed', () => {
+      renderSheet(
+        makeNfc('pairing_password', { submitPairingPassword }),
+      );
+      fireEvent.press(screen.getByText('Cancel'));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows error message when pairingPasswordError is provided', () => {
+      renderSheet(
+        makeNfc('pairing_password', {
+          submitPairingPassword,
+          pairingPasswordError: 'Wrong pairing password. Try again.',
+        }),
+      );
+      expect(
+        screen.getByText('Wrong pairing password. Try again.'),
+      ).toBeTruthy();
+    });
+
+    it('calls submitPairingPassword with the entered password', () => {
+      renderSheet(
+        makeNfc('pairing_password', { submitPairingPassword }),
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText('Pairing password'),
+        'mySecret',
+      );
+      fireEvent.press(screen.getByText('Continue'));
+      expect(submitPairingPassword).toHaveBeenCalledWith('mySecret');
+    });
+
+    it('does not show the NFC icon area', () => {
+      renderSheet(
+        makeNfc('pairing_password', { submitPairingPassword }),
+      );
+      expect(screen.queryByText('Tap your Keycard')).toBeNull();
+    });
+  });
+
   describe('pin_entry phase', () => {
     it('renders PinPad instead of the bottom sheet', () => {
       const submitPin = jest.fn();

--- a/__tests__/PairingPasswordEntry.test.tsx
+++ b/__tests__/PairingPasswordEntry.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import PairingPasswordEntry from '../src/components/NFCBottomSheet/PairingPasswordEntry';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-paper', () => {
+  const { Text } = require('react-native');
+  return { MD3DarkTheme: { colors: {} }, Text };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const onSubmit = jest.fn();
+const onCancel = jest.fn();
+
+function renderEntry(
+  props: Partial<React.ComponentProps<typeof PairingPasswordEntry>> = {},
+) {
+  return render(
+    <PairingPasswordEntry
+      error={null}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  onSubmit.mockClear();
+  onCancel.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PairingPasswordEntry', () => {
+  it('renders title and body text', () => {
+    renderEntry();
+    expect(screen.getByText('Custom pairing password')).toBeTruthy();
+    expect(screen.getByText(/non-default pairing password/)).toBeTruthy();
+  });
+
+  it('renders a TextInput with secureTextEntry', () => {
+    renderEntry();
+    const input = screen.getByPlaceholderText('Pairing password');
+    expect(input.props.secureTextEntry).toBe(true);
+  });
+
+  it('Continue button is disabled when input is empty', () => {
+    renderEntry();
+    fireEvent.press(screen.getByText('Continue'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('calls onSubmit with trimmed password when Continue is pressed', () => {
+    renderEntry();
+    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), 'myPassword');
+    fireEvent.press(screen.getByText('Continue'));
+    expect(onSubmit).toHaveBeenCalledWith('myPassword');
+  });
+
+  it('trims whitespace before submitting', () => {
+    renderEntry();
+    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), '  secret  ');
+    fireEvent.press(screen.getByText('Continue'));
+    expect(onSubmit).toHaveBeenCalledWith('secret');
+  });
+
+  it('does not call onSubmit when input is only whitespace', () => {
+    renderEntry();
+    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), '   ');
+    fireEvent.press(screen.getByText('Continue'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when Cancel is pressed', () => {
+    renderEntry();
+    fireEvent.press(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error message when error prop is provided', () => {
+    renderEntry({ error: 'Wrong pairing password. Try again.' });
+    expect(screen.getByText('Wrong pairing password. Try again.')).toBeTruthy();
+  });
+
+  it('does not show error when error prop is null', () => {
+    renderEntry({ error: null });
+    expect(screen.queryByText('Wrong pairing password. Try again.')).toBeNull();
+  });
+});

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -580,6 +580,196 @@ describe('useKeycardOperation', () => {
     });
   });
 
+  describe('pairing password', () => {
+    beforeEach(() => {
+      mockLoadPairing.mockResolvedValue(null);
+      mockCheckGenuine.mockResolvedValue(true);
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => makeMockCmdSet());
+    });
+
+    async function triggerCardConnect(_hook: UseKeycardOperation<string>) {
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+    }
+
+    it('enters pairing_password phase when autoPair throws cryptogram error', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Invalid card cryptogram')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+      expect(result.current.pairingPasswordError).toBeNull();
+    });
+
+    it('transitions to nfc and calls startNFC after submitPairingPassword', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Invalid card cryptogram')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+
+      mockStartNFC.mockClear();
+      await act(async () => {
+        result.current.submitPairingPassword('custom123');
+      });
+      expect(result.current.phase).toBe('nfc');
+      expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
+    });
+
+    it('sets pairingPasswordError on second tap with wrong custom password', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Invalid card cryptogram')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+
+      await act(async () => {
+        result.current.submitPairingPassword('custom123');
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+      expect(result.current.pairingPasswordError).toBe(
+        'Wrong pairing password. Try again.',
+      );
+    });
+
+    it('returns to idle on cancel from pairing_password', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Invalid card cryptogram')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: false });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+
+      await act(async () => {
+        result.current.cancel();
+      });
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.pairingPasswordError).toBeNull();
+    });
+
+    it('enters error phase with friendly slots-full message on step-2 error', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Pairing failed on step 2')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: false });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'This Keycard has no free pairing slots. Use another device to unpair a slot first.',
+      );
+    });
+
+    it('enters error phase with friendly slots-full message on step-1 error', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest
+          .fn()
+          .mockRejectedValue(new APDUException('Pairing failed on step 1')),
+      }));
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn(), { requiresPin: false });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('error');
+      expect(result.current.status).toBe(
+        'This Keycard has no free pairing slots. Use another device to unpair a slot first.',
+      );
+    });
+
+    it('completes operation when custom password succeeds on retry', async () => {
+      const { APDUException } = require('keycard-sdk/dist/apdu-exception');
+      const Keycard = require('keycard-sdk').default;
+      let callCount = 0;
+      Keycard.Commandset.mockImplementation(() => ({
+        ...makeMockCmdSet(),
+        autoPair: jest.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.reject(new APDUException('Invalid card cryptogram'));
+          }
+          return Promise.resolve(undefined);
+        }),
+      }));
+
+      const mockOp = jest.fn().mockResolvedValue('done');
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(mockOp, { requiresPin: false });
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('pairing_password');
+
+      await act(async () => {
+        result.current.submitPairingPassword('custom123');
+      });
+      await triggerCardConnect(result.current);
+      expect(result.current.phase).toBe('done');
+      expect(result.current.result).toBe('done');
+      expect(mockOp).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('clearPinError', () => {
     it('is exposed and callable without side effects when no error exists', async () => {
       const { result } = renderHook(() => useKeycardOperation<string>());

--- a/docs/adr/0005-pairing-password-two-tap-retry.md
+++ b/docs/adr/0005-pairing-password-two-tap-retry.md
@@ -1,0 +1,40 @@
+# ADR 0005: Two-tap retry for custom pairing password
+
+**Date:** 2026-06-07
+**Status:** Accepted
+
+## Context
+
+When `autoPair` is called with the default pairing secret and the card was paired with a custom pairing password, the SDK throws `APDUException("Error: Invalid card cryptogram")` mid-session. The user needs to supply their custom pairing password and retry.
+
+The alternative — retrying `autoPair` in the same NFC session immediately after the error — is not viable: the error propagates up through `handleCardConnected`, which ends the NFC session via `useNFCSession`. There is no "keep session alive for more input" path in the React Native NFC layer.
+
+## Decision
+
+Custom pairing password entry follows the same two-tap pattern as `genuine_warning`:
+
+1. First tap: detect the cryptogram mismatch, return `null` from `handleCardConnected`, set `phase = 'pairing_password'`.
+2. Show a full-screen `PairingPasswordEntry` modal — same structure as PIN entry.
+3. User submits password → stored in a ref → `startNFC()` called.
+4. Second tap: `autoPair` called with the custom password string (SDK derives the pairing secret via PBKDF2-HMAC-SHA256 internally).
+5. On success: pairing saved to AsyncStorage as normal; custom password ref cleared.
+6. On failure: `pairingPasswordError` set, stay in `pairing_password` phase, user can retry.
+
+Detection: `e instanceof APDUException && e.message.includes('Invalid card cryptogram')`. The SW code is not usable here — the cryptogram mismatch is verified client-side by the SDK before step 2, so the exception has `sw === 0`.
+
+## Rationale
+
+- Mirrors the `genuine_warning` pattern already in the codebase — same state machine shape, same NFC restart.
+- Custom pairing password is only needed once. After successful `autoPair`, the pairing is stored in AsyncStorage; future sessions load it and bypass `autoPair` entirely. The password is never persisted.
+- The two-tap UX is acceptable: the first tap informs the user their card uses a custom password; the second tap completes pairing.
+
+## Consequences
+
+- `Phase` gains a `'pairing_password'` value.
+- `UseKeycardOperation` gains `pairingPasswordError: string | null` and `submitPairingPassword: (password: string) => void`.
+- `NFCBottomSheet` gains a `PairingPasswordEntry` component rendered inside the existing bottom sheet Modal (same pattern as `genuine_warning`, not `pin_entry`). On iOS, `showSheet` is always false — only the bottom sheet Modal is used for post-tap interrupts, so `pairing_password` must follow `genuine_warning`'s modal path to work on both platforms.
+- "Pairing slots full" error (`autoPair` step 2 failure) is caught separately and surfaced as a human-readable message rather than a raw APDU error string.
+
+## Revisit if
+
+- The React Native NFC layer gains support for keeping a session alive across async UI interactions — at that point in-session retry becomes viable and eliminates the second tap.

--- a/src/components/NFCBottomSheet/PairingPasswordEntry.tsx
+++ b/src/components/NFCBottomSheet/PairingPasswordEntry.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import theme from '@/theme';
+
+import { Icons } from '@/assets/icons';
+import PrimaryButton from '@/components/PrimaryButton';
+
+type Props = {
+  error: string | null;
+  onSubmit: (password: string) => void;
+  onCancel: () => void;
+};
+
+export default function PairingPasswordEntry({
+  error,
+  onSubmit,
+  onCancel,
+}: Props) {
+  const [password, setPassword] = useState('');
+  const insets = useSafeAreaInsets();
+
+  const handleSubmit = () => {
+    const trimmed = password.trim();
+    if (trimmed.length > 0) {
+      onSubmit(trimmed);
+    }
+  };
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingBottom: Math.max(insets.bottom, 16) + 8 },
+      ]}
+    >
+      <View style={styles.content}>
+        <Icons.nfcActivate
+          width={64}
+          height={64}
+          color={theme.colors.primary}
+        />
+        <Text variant="headlineSmall" style={styles.title}>
+          Custom pairing password
+        </Text>
+        <Text variant="bodyMedium" style={styles.body}>
+          Your Keycard uses a non-default pairing password. Enter it to continue
+          — you will need to tap your card again.
+        </Text>
+
+        <TextInput
+          style={styles.input}
+          secureTextEntry
+          autoFocus
+          placeholder="Pairing password"
+          placeholderTextColor={theme.colors.onSurfacePlaceholder}
+          value={password}
+          onChangeText={setPassword}
+          onSubmitEditing={handleSubmit}
+          returnKeyType="done"
+        />
+
+        {error !== null && (
+          <Text variant="bodySmall" style={styles.error}>
+            {error}
+          </Text>
+        )}
+      </View>
+
+      <View style={styles.buttons}>
+        <PrimaryButton
+          label="Continue"
+          onPress={handleSubmit}
+          disabled={password.trim().length === 0}
+        />
+        <Pressable
+          style={styles.cancelButton}
+          android_ripple={{ color: 'rgba(255,255,255,0.1)' }}
+          onPress={onCancel}
+        >
+          <Text variant="labelLarge" style={styles.cancelText}>
+            Cancel
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 16,
+  },
+  title: {
+    color: theme.colors.onSurface,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  body: {
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  input: {
+    width: '100%',
+    backgroundColor: theme.colors.surfaceVariant,
+    borderRadius: 12,
+    color: theme.colors.onSurface,
+    fontSize: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginTop: 8,
+  },
+  error: {
+    color: theme.colors.error,
+    textAlign: 'center',
+  },
+  buttons: {
+    gap: 8,
+    width: '100%',
+  },
+  cancelButton: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  cancelText: {
+    color: theme.colors.onSurfaceDisabled,
+  },
+});

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -9,11 +9,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import theme from '../../theme';
-import PinPad from '../PinPad';
+import theme from '@/theme';
+
+import PinPad from '@/components/PinPad';
+
 import GenuineWarning from './GenuineWarning';
 import NFCError from './NFCError';
 import NFCSheet from './NFCSheet';
+import PairingPasswordEntry from './PairingPasswordEntry';
 
 export type NFCVariant = 'scanning' | 'success' | 'error' | 'genuine_warning';
 
@@ -23,6 +26,8 @@ export type NFCOperation = {
   cardName?: string | null;
   pinError?: string | null;
   submitPin?: (pin: string) => void;
+  pairingPasswordError?: string | null;
+  submitPairingPassword?: (password: string) => void;
   proceedWithNonGenuine?: () => void;
   retry?: () => void;
   openNFCSettings?: () => void;
@@ -42,6 +47,8 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
     cardName,
     pinError,
     submitPin,
+    pairingPasswordError,
+    submitPairingPassword,
     proceedWithNonGenuine,
     retry,
     openNFCSettings,
@@ -52,6 +59,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
 
   const showPinPad = phase === 'pin_entry';
   const showGenuineWarning = phase === 'genuine_warning';
+  const showPairingPassword = phase === 'pairing_password';
   const showIOSError = Platform.OS === 'ios' && phase === 'error';
   const showSheet =
     Platform.OS === 'android' &&
@@ -73,7 +81,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
       setModalVisible(false);
       return;
     }
-    if (showSheet || showGenuineWarning) {
+    if (showSheet || showGenuineWarning || showPairingPassword) {
       setModalVisible(true);
     }
     Animated.spring(slideAnim, {
@@ -82,11 +90,11 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
       tension: 60,
       friction: 12,
     }).start(({ finished }) => {
-      if (finished && !showSheet && !showGenuineWarning) {
+      if (finished && !showSheet && !showGenuineWarning && !showPairingPassword) {
         setModalVisible(false);
       }
     });
-  }, [showSheet, showGenuineWarning, showIOSError, slideAnim]);
+  }, [showSheet, showGenuineWarning, showPairingPassword, showIOSError, slideAnim]);
 
   const variant: NFCVariant =
     phase === 'genuine_warning'
@@ -132,6 +140,12 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
           <GenuineWarning
             onCancel={onCancel}
             onProceed={proceedWithNonGenuine}
+          />
+        ) : showPairingPassword && submitPairingPassword ? (
+          <PairingPasswordEntry
+            error={pairingPasswordError ?? null}
+            onSubmit={submitPairingPassword}
+            onCancel={onCancel}
           />
         ) : (
           <View style={styles.overlay}>

--- a/src/hooks/keycard/useGenuineCheck.ts
+++ b/src/hooks/keycard/useGenuineCheck.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from 'react';
+import { Commandset } from 'keycard-sdk/dist/commandset';
+
+import { checkGenuine } from '@/utils/genuineCheck';
+
+export function useGenuineCheck() {
+  const [showGenuineWarning, setShowGenuineWarning] = useState(false);
+  const approvedNonGenuineUidsRef = useRef<Set<string>>(new Set());
+  const pendingUidRef = useRef<string | null>(null);
+
+  // Returns true if the operation should proceed, false if interrupted for user decision.
+  const checkOrSkipGenuine = useCallback(
+    async (
+      cmdSet: Commandset,
+      uid: string,
+      hasExistingPairing: boolean,
+      setStatus: (s: string) => void,
+    ): Promise<boolean> => {
+      if (hasExistingPairing || approvedNonGenuineUidsRef.current.has(uid)) {
+        return true;
+      }
+      setStatus('Verifying card...');
+      const isGenuine = await checkGenuine(cmdSet);
+      if (!isGenuine) {
+        console.log('[Keycard] Genuine check failed — showing warning');
+        pendingUidRef.current = uid;
+        setShowGenuineWarning(true);
+        return false;
+      }
+      console.log('[Keycard] Genuine check passed');
+      return true;
+    },
+    [],
+  );
+
+  // Approves the pending UID and calls onRestart to retry the NFC operation.
+  const proceedWithNonGenuine = useCallback((onRestart: () => void) => {
+    const uid = pendingUidRef.current;
+    if (uid) {
+      approvedNonGenuineUidsRef.current.add(uid);
+      pendingUidRef.current = null;
+    }
+    setShowGenuineWarning(false);
+    onRestart();
+  }, []);
+
+  const resetGenuineState = useCallback(() => {
+    setShowGenuineWarning(false);
+    pendingUidRef.current = null;
+  }, []);
+
+  return { showGenuineWarning, checkOrSkipGenuine, proceedWithNonGenuine, resetGenuineState };
+}

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -1,19 +1,20 @@
 import { useCallback, useRef, useState } from 'react';
 import Keycard from 'keycard-sdk';
-import RNKeycard from 'react-native-keycard';
 import { WrongPINException } from 'keycard-sdk/dist/apdu-exception';
 import { Commandset } from 'keycard-sdk/dist/commandset';
+import RNKeycard from 'react-native-keycard';
 
-import { PAIRING_PASSWORD } from '../../constants/keycard';
-import { loadPairing, savePairing } from '../../storage/pairingStorage';
-import { checkGenuine } from '../../utils/genuineCheck';
-import { toHex } from '../../utils/hex';
-import { displayKeycardName, parseKeycardName } from '../../utils/keycardName';
+import { loadPairing } from '@/storage/pairingStorage';
+import { toHex } from '@/utils/hex';
+import { displayKeycardName, parseKeycardName } from '@/utils/keycardName';
+import { useGenuineCheck } from './useGenuineCheck';
 import { useNFCOperation } from './useNFCOperation';
+import { usePairing } from './usePairing';
 
 export type Phase =
   | 'idle'
   | 'pin_entry'
+  | 'pairing_password'
   | 'nfc'
   | 'genuine_warning'
   | 'done'
@@ -35,8 +36,10 @@ export interface UseKeycardOperation<T> {
   cardName: string | null;
   result: T | null;
   pinError: string | null;
+  pairingPasswordError: string | null;
   execute: (op: KeycardOperationFn<T>, options?: ExecuteOptions) => void;
   submitPin: (pin: string) => void;
+  submitPairingPassword: (password: string) => void;
   clearPinError: () => void;
   cancel: () => void;
   reset: () => void;
@@ -49,63 +52,76 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const [waitingForPin, setWaitingForPin] = useState(false);
   const [pinError, setPinError] = useState<string | null>(null);
   const [cardName, setCardName] = useState<string | null>(null);
-  const [showGenuineWarning, setShowGenuineWarning] = useState(false);
 
   const pinRef = useRef('');
   const operationRef = useRef<KeycardOperationFn<T> | null>(null);
   const requiresPinRef = useRef(true);
   const requiresMasterKeyRef = useRef(true);
   const operationRunningRef = useRef(false);
-  const approvedNonGenuineUidsRef = useRef<Set<string>>(new Set());
-  const pendingUidRef = useRef<string | null>(null);
+
+  const {
+    showGenuineWarning,
+    checkOrSkipGenuine,
+    proceedWithNonGenuine: _proceedWithNonGenuine,
+    resetGenuineState,
+  } = useGenuineCheck();
+
+  const {
+    waitingForPairingPassword,
+    pairingPasswordError,
+    runAutoPair,
+    submitPairingPassword: _submitPairingPassword,
+    resetPairingState,
+  } = usePairing();
+
+  const verifyPin = useCallback(
+    async (cmdSet: Commandset, setStatus: (s: string) => void): Promise<void> => {
+      setStatus('Verifying PIN...');
+      const pinResp = await cmdSet.verifyPIN(pinRef.current);
+      console.log(
+        `[Keycard] verifyPIN SW: 0x${pinResp.sw.toString(16).toUpperCase()}`,
+      );
+      try {
+        pinResp.checkAuthOK();
+      } catch (e) {
+        if (e instanceof WrongPINException) {
+          const attempts = e.getRetryAttempts();
+          if (attempts === 0) {
+            throw new Error('Card is locked. Use Unblock Card option.');
+          }
+          setPinError(`PIN is not valid. ${attempts} attempts left.`);
+        }
+        pinRef.current = '';
+        throw e;
+      }
+    },
+    [],
+  );
 
   const doPairAndExecute = useCallback(
     async (
       cmdSet: Commandset,
       uid: string,
+      existingPairing: InstanceType<typeof Keycard.Pairing> | null,
       setStatus: (s: string) => void,
     ): Promise<T | null> => {
-      const existingPairing = await loadPairing(uid);
       if (existingPairing) {
         console.log(
           `[Keycard] Pairing found in storage (index: ${existingPairing.pairingIndex})`,
         );
         cmdSet.setPairing(existingPairing);
-        setStatus('Opening secure channel...');
       } else {
         console.log('[Keycard] No pairing found — running autoPair');
         setStatus('Pairing with card...');
-        await cmdSet.autoPair(PAIRING_PASSWORD);
-        const pairing = cmdSet.getPairing();
-        console.log(
-          `[Keycard] autoPair OK (index: ${pairing.pairingIndex}) — saving to storage`,
-        );
-        await savePairing(uid, pairing);
-        setStatus('Opening secure channel...');
+        const paired = await runAutoPair(cmdSet, uid);
+        if (!paired) return null;
       }
-
+      setStatus('Opening secure channel...');
       await cmdSet.autoOpenSecureChannel();
       console.log('[Keycard] Secure channel open');
 
       if (requiresPinRef.current) {
-        setStatus('Verifying PIN...');
-        const pinResp = await cmdSet.verifyPIN(pinRef.current);
-        console.log(
-          `[Keycard] verifyPIN SW: 0x${pinResp.sw.toString(16).toUpperCase()}`,
-        );
-        try {
-          pinResp.checkAuthOK();
-        } catch (e) {
-          if (e instanceof WrongPINException) {
-            const attempts = e.getRetryAttempts();
-            if (attempts === 0) {
-              throw new Error('Card is locked. Use Unblock Card option.');
-            }
-            setPinError(`PIN is not valid. ${attempts} attempts left.`);
-          }
-          pinRef.current = '';
-          throw e;
-        }
+        await verifyPin(cmdSet, setStatus);
       }
 
       if (operationRunningRef.current || !operationRef.current) {
@@ -119,7 +135,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
         operationRunningRef.current = false;
       }
     },
-    [],
+    [runAutoPair, verifyPin],
   );
 
   const handleCardConnected = useCallback(
@@ -163,23 +179,17 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       setStatus(`Connected to ${displayKeycardName(name)}`);
 
       const existingPairing = await loadPairing(uid);
-      if (!existingPairing && !approvedNonGenuineUidsRef.current.has(uid)) {
-        setStatus('Verifying card...');
-        const isGenuine = await checkGenuine(cmdSet);
-        if (!isGenuine) {
-          console.log('[Keycard] Genuine check failed — showing warning');
-          pendingUidRef.current = uid;
-          setShowGenuineWarning(true);
-          // Return null: useNFCSession will set nfcPhase='done',
-          // but our phase computation overrides it to 'genuine_warning'.
-          return null;
-        }
-        console.log('[Keycard] Genuine check passed');
-      }
+      const shouldProceed = await checkOrSkipGenuine(
+        cmdSet,
+        uid,
+        !!existingPairing,
+        setStatus,
+      );
+      if (!shouldProceed) return null;
 
-      return await doPairAndExecute(cmdSet, uid, setStatus);
+      return await doPairAndExecute(cmdSet, uid, existingPairing, setStatus);
     },
-    [doPairAndExecute],
+    [checkOrSkipGenuine, doPairAndExecute],
   );
 
   const {
@@ -206,6 +216,9 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   // 'genuine_warning' takes priority over all other phase overrides.
   const phase: Phase = showGenuineWarning
     ? 'genuine_warning'
+    : waitingForPairingPassword ||
+      (pairingPasswordError !== null && nfcPhase === 'error')
+    ? 'pairing_password'
     : (waitingForPin && (nfcPhase === 'idle' || nfcPhase === 'error')) ||
       (pinError !== null && nfcPhase === 'error')
     ? 'pin_entry'
@@ -217,6 +230,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       requiresPinRef.current = options.requiresPin ?? true;
       requiresMasterKeyRef.current = options.requiresMasterKey ?? true;
       operationRunningRef.current = false;
+      resetPairingState();
 
       if (!requiresPinRef.current) {
         startNFC();
@@ -237,7 +251,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
           setWaitingForPin(true); // can't check — fall back to PIN entry
         });
     },
-    [startNFC],
+    [startNFC, resetPairingState],
   );
 
   const submitPin = useCallback(
@@ -250,19 +264,20 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     [startNFC],
   );
 
+  const submitPairingPassword = useCallback(
+    (password: string) => {
+      _submitPairingPassword(password, startNFC);
+    },
+    [_submitPairingPassword, startNFC],
+  );
+
   const clearPinError = useCallback(() => {
     setPinError(null);
   }, []);
 
   const proceedWithNonGenuine = useCallback(() => {
-    const uid = pendingUidRef.current;
-    if (uid) {
-      approvedNonGenuineUidsRef.current.add(uid);
-      pendingUidRef.current = null;
-    }
-    setShowGenuineWarning(false);
-    startNFC();
-  }, [startNFC]);
+    _proceedWithNonGenuine(startNFC);
+  }, [_proceedWithNonGenuine, startNFC]);
 
   // Re-starts NFC. If PIN hasn't been entered yet (e.g. NFC was off before PIN entry),
   // show the PIN pad instead of starting NFC directly.
@@ -279,12 +294,12 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     setWaitingForPin(false);
     setPinError(null);
     setCardName(null);
-    setShowGenuineWarning(false);
-    pendingUidRef.current = null;
     pinRef.current = '';
     operationRef.current = null;
     operationRunningRef.current = false;
-  }, []);
+    resetGenuineState();
+    resetPairingState();
+  }, [resetGenuineState, resetPairingState]);
 
   const cancel = useCallback(() => {
     nfcCancel();
@@ -302,8 +317,10 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     cardName,
     result,
     pinError,
+    pairingPasswordError,
     execute,
     submitPin,
+    submitPairingPassword,
     clearPinError,
     cancel,
     reset,

--- a/src/hooks/keycard/usePairing.ts
+++ b/src/hooks/keycard/usePairing.ts
@@ -1,0 +1,78 @@
+import { useCallback, useRef, useState } from 'react';
+import { APDUException } from 'keycard-sdk/dist/apdu-exception';
+import { Commandset } from 'keycard-sdk/dist/commandset';
+
+import { PAIRING_PASSWORD } from '@/constants/keycard';
+import { savePairing } from '@/storage/pairingStorage';
+
+export function usePairing() {
+  const [waitingForPairingPassword, setWaitingForPairingPassword] =
+    useState(false);
+  const [pairingPasswordError, setPairingPasswordError] = useState<
+    string | null
+  >(null);
+  const customPairingPasswordRef = useRef<string | null>(null);
+
+  // Runs autoPair. Returns true on success (pairing saved), false if interrupted for password entry.
+  const runAutoPair = useCallback(
+    async (cmdSet: Commandset, uid: string): Promise<boolean> => {
+      const password = customPairingPasswordRef.current;
+      try {
+        await cmdSet.autoPair(password ?? PAIRING_PASSWORD);
+      } catch (e) {
+        if (
+          e instanceof APDUException &&
+          e.message.includes('Invalid card cryptogram')
+        ) {
+          if (customPairingPasswordRef.current !== null) {
+            setPairingPasswordError('Wrong pairing password. Try again.');
+          }
+          setWaitingForPairingPassword(true);
+          return false;
+        }
+        if (
+          e instanceof APDUException &&
+          (e.message.includes('Pairing failed on step 1') ||
+            e.message.includes('Pairing failed on step 2'))
+        ) {
+          throw new Error(
+            'This Keycard has no free pairing slots. Use another device to unpair a slot first.',
+          );
+        }
+        throw e;
+      }
+      const pairing = cmdSet.getPairing();
+      console.log(
+        `[Keycard] autoPair OK (index: ${pairing.pairingIndex}) — saving to storage`,
+      );
+      await savePairing(uid, pairing);
+      return true;
+    },
+    [],
+  );
+
+  // Stores the custom password and calls onRestart to retry the NFC operation.
+  const submitPairingPassword = useCallback(
+    (password: string, onRestart: () => void) => {
+      customPairingPasswordRef.current = password;
+      setPairingPasswordError(null);
+      setWaitingForPairingPassword(false);
+      onRestart();
+    },
+    [],
+  );
+
+  const resetPairingState = useCallback(() => {
+    setWaitingForPairingPassword(false);
+    setPairingPasswordError(null);
+    customPairingPasswordRef.current = null;
+  }, []);
+
+  return {
+    waitingForPairingPassword,
+    pairingPasswordError,
+    runAutoPair,
+    submitPairingPassword,
+    resetPairingState,
+  };
+}


### PR DESCRIPTION
## Summary

- When `autoPair` fails with a cryptogram error (card has a custom pairing password), show `PairingPasswordEntry` inside the bottom sheet modal and retry with a second tap
- Wrong custom password loops back to the prompt with an error; correct password stores the pairing and skips `autoPair` on all future taps
- Pairing slots full (step-1/step-2 APDU error) surfaces a friendly `phase='error'` message instead of a raw exception
- Extracted `useGenuineCheck` and `usePairing` from `useKeycardOperation` to reduce inline complexity; `verifyPin` moved to a local callback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced NFC pairing: Improved handling of NFC availability, custom pairing password support when default pairing fails, password retry with error feedback, and friendly notifications when pairing slots are full.

* **Tests**
  * Added comprehensive test coverage for pairing password entry and retry flow.

* **Documentation**
  * Added architectural documentation for the pairing password two-tap retry mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->