### PR TITLE
fix: bundle online flavor in iOS archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Release APKs are now named `keycard-pal-<flavor>-<buildType>-<abi>.apk` instead of `app-<flavor>-<buildType>-<abi>.apk`
 
+### Fixed
+
+- iOS archives were bundling the offline flavor because Metro's online/offline resolver requires the `ONLINE_BUILD=true` env var; export it from `ios/.xcode.env` so all iOS builds (dev and Archive) resolve to `.online` settings sections
+
 ## [1.7.0] - 2026-06-06
 
 ### Added

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -9,3 +9,6 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
+
+# iOS has no offline flavor; force Metro's online/offline resolver to use .online variants.
+export ONLINE_BUILD=true


### PR DESCRIPTION
Metro's resolver maps `.online` to `.offline` unless ONLINE_BUILD=true. Export it from ios/.xcode.env so dev and Archive builds resolve to `.online` variants; otherwise TestFlight ships offline Settings stubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an iOS build issue where archived builds could bundle the wrong app variant. iOS builds now consistently use the correct online configuration.
* **Documentation**
  * Updated the changelog to note the iOS archive fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->