### PR TITLE
feat: show master fingerprint as card name fallback (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Handle NFC availability
 - Prompt for custom pairing password when default pairing fails; loop on wrong password with error feedback; show friendly message when pairing slots are full
+- Show the master fingerprint (8 hex chars) as the active card's name when the card has no stored name, matching keycard-shell; display only, never written to the card
 
 ### Changed
 

--- a/__tests__/NFCSheet.test.tsx
+++ b/__tests__/NFCSheet.test.tsx
@@ -159,6 +159,33 @@ describe('NFCSheet', () => {
       );
       expect(screen.getByText('Unnamed card')).toBeTruthy();
     });
+
+    it('shows the master fingerprint when an unnamed card has one', () => {
+      render(
+        <NFCSheet
+          variant="scanning"
+          status="test"
+          cardName=""
+          cardFingerprint={0x1a2b3c4d}
+          onCancel={onCancel}
+        />,
+      );
+      expect(screen.getByText('1a2b3c4d')).toBeTruthy();
+    });
+
+    it('prefers the card name over the fingerprint when both are present', () => {
+      render(
+        <NFCSheet
+          variant="scanning"
+          status="test"
+          cardName="My Card"
+          cardFingerprint={0x1a2b3c4d}
+          onCancel={onCancel}
+        />,
+      );
+      expect(screen.getByText('My Card')).toBeTruthy();
+      expect(screen.queryByText('1a2b3c4d')).toBeNull();
+    });
   });
 
   describe('status text', () => {

--- a/__tests__/keycardName.test.ts
+++ b/__tests__/keycardName.test.ts
@@ -3,6 +3,7 @@
 import {
   displayKeycardName,
   encodeKeycardName,
+  formatFingerprint,
   mergeKeycardNameMetadata,
   parseKeycardName,
   validateKeycardName,
@@ -106,5 +107,20 @@ describe('keycardName', () => {
     expect(displayKeycardName('Main card')).toBe('Main card');
     expect(displayKeycardName('')).toBe('Unnamed card');
     expect(displayKeycardName(null)).toBe('Unnamed card');
+  });
+
+  it('formats a master fingerprint as 8 lowercase hex chars', () => {
+    expect(formatFingerprint(0x1a2b3c4d)).toBe('1a2b3c4d');
+    expect(formatFingerprint(0x000000ff)).toBe('000000ff');
+    expect(formatFingerprint(0)).toBe('00000000');
+    // Sign-bit-set values must stay unsigned (>>> 0).
+    expect(formatFingerprint(0xfeed1234)).toBe('feed1234');
+  });
+
+  it('falls back to the fingerprint when the card name is blank', () => {
+    expect(displayKeycardName('Main card', 0x1a2b3c4d)).toBe('Main card');
+    expect(displayKeycardName('', 0x1a2b3c4d)).toBe('1a2b3c4d');
+    expect(displayKeycardName(null, 0x1a2b3c4d)).toBe('1a2b3c4d');
+    expect(displayKeycardName('', null)).toBe('Unnamed card');
   });
 });

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -60,7 +60,14 @@ jest.mock('keycard-sdk', () => ({
   default: {
     Commandset: jest.fn(),
     Certificate: { verifyIdentity: jest.fn() },
+    BIP32KeyPair: {
+      fromTLV: jest.fn(() => ({ publicKey: new Uint8Array([0x01]) })),
+    },
   },
+}));
+
+jest.mock('../src/utils/cryptoAccount', () => ({
+  pubKeyFingerprint: jest.fn(() => 0x1a2b3c4d),
 }));
 
 jest.mock('../src/utils/genuineCheck', () => ({
@@ -577,6 +584,118 @@ describe('useKeycardOperation', () => {
       expect(result.current.status).toBe(
         'Enter your PIN first — tap Retry to continue.',
       );
+    });
+  });
+
+  describe('master fingerprint fallback', () => {
+    beforeEach(() => {
+      mockLoadPairing.mockResolvedValue(null);
+      mockCheckGenuine.mockResolvedValue(true);
+    });
+
+    const makeUnnamedCmdSet = (overrides = {}) => ({
+      ...makeMockCmdSet(),
+      getData: jest.fn().mockResolvedValue({
+        sw: 0x9000,
+        data: new Uint8Array([0x20 | 0]), // length-0 name = unnamed card
+      }),
+      exportKey: jest
+        .fn()
+        .mockResolvedValue({
+          data: new Uint8Array([0x02]),
+          checkOK: jest.fn(),
+        }),
+      ...overrides,
+    });
+
+    async function triggerCardConnect() {
+      await act(async () => {
+        await capturedOnConnected?.();
+      });
+    }
+
+    it('derives and exposes the fingerprint for an unnamed card', async () => {
+      const cmdSet = makeUnnamedCmdSet();
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => cmdSet);
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect();
+
+      expect(cmdSet.exportKey).toHaveBeenCalledWith(0, true, 'm', false);
+      expect(result.current.cardName).toBe('');
+      expect(result.current.cardFingerprint).toBe(0x1a2b3c4d);
+    });
+
+    it('skips the fingerprint export for a named card', async () => {
+      const cmdSet = {
+        ...makeMockCmdSet(),
+        exportKey: jest.fn(),
+      };
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => cmdSet);
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+        });
+      });
+      await triggerCardConnect();
+
+      expect(cmdSet.exportKey).not.toHaveBeenCalled();
+      expect(result.current.cardFingerprint).toBeNull();
+    });
+
+    it('skips the fingerprint export when the card has no master key', async () => {
+      const cmdSet = makeUnnamedCmdSet({
+        applicationInfo: {
+          instanceUID: new Uint8Array([0xaa, 0xbb]),
+          initializedCard: true,
+          freePairingSlots: 5,
+          hasMasterKey: () => false,
+        },
+      });
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => cmdSet);
+
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(jest.fn().mockResolvedValue('result'), {
+          requiresPin: false,
+          requiresMasterKey: false,
+        });
+      });
+      await triggerCardConnect();
+
+      expect(cmdSet.exportKey).not.toHaveBeenCalled();
+      expect(result.current.cardFingerprint).toBeNull();
+    });
+
+    it('continues the operation when the fingerprint export fails', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const cmdSet = makeUnnamedCmdSet({
+        exportKey: jest.fn().mockRejectedValue(new Error('export boom')),
+      });
+      const Keycard = require('keycard-sdk').default;
+      Keycard.Commandset.mockImplementation(() => cmdSet);
+
+      const mockOp = jest.fn().mockResolvedValue('done');
+      const { result } = renderHook(() => useKeycardOperation<string>());
+      await act(async () => {
+        result.current.execute(mockOp, { requiresPin: false });
+      });
+      await triggerCardConnect();
+
+      expect(mockOp).toHaveBeenCalledTimes(1);
+      expect(result.current.result).toBe('done');
+      expect(result.current.cardFingerprint).toBeNull();
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/components/NFCBottomSheet/NFCSheet.tsx
+++ b/src/components/NFCBottomSheet/NFCSheet.tsx
@@ -11,6 +11,7 @@ type Props = {
   variant: NFCVariant;
   status: string;
   cardName?: string | null;
+  cardFingerprint?: number | null;
   onCancel: () => void;
   openNFCSettings?: () => void;
 };
@@ -64,6 +65,7 @@ export default function NFCSheet({
   variant,
   status,
   cardName,
+  cardFingerprint,
   onCancel,
   openNFCSettings,
 }: Props) {
@@ -90,7 +92,7 @@ export default function NFCSheet({
       <Text variant="titleLarge" style={styles.title}>
         {cardName === undefined || cardName === null
           ? 'Tap your Keycard'
-          : displayKeycardName(cardName)}
+          : displayKeycardName(cardName, cardFingerprint)}
       </Text>
       <Text variant="bodyMedium" style={styles.status}>
         {status}

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -24,6 +24,7 @@ export type NFCOperation = {
   phase: string;
   status: string;
   cardName?: string | null;
+  cardFingerprint?: number | null;
   pinError?: string | null;
   submitPin?: (pin: string) => void;
   pairingPasswordError?: string | null;
@@ -45,6 +46,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
     phase,
     status,
     cardName,
+    cardFingerprint,
     pinError,
     submitPin,
     pairingPasswordError,
@@ -90,11 +92,22 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
       tension: 60,
       friction: 12,
     }).start(({ finished }) => {
-      if (finished && !showSheet && !showGenuineWarning && !showPairingPassword) {
+      if (
+        finished &&
+        !showSheet &&
+        !showGenuineWarning &&
+        !showPairingPassword
+      ) {
         setModalVisible(false);
       }
     });
-  }, [showSheet, showGenuineWarning, showPairingPassword, showIOSError, slideAnim]);
+  }, [
+    showSheet,
+    showGenuineWarning,
+    showPairingPassword,
+    showIOSError,
+    slideAnim,
+  ]);
 
   const variant: NFCVariant =
     phase === 'genuine_warning'
@@ -163,6 +176,7 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
                 variant={variant}
                 status={status}
                 cardName={cardName}
+                cardFingerprint={cardFingerprint}
                 onCancel={onCancel}
                 openNFCSettings={openNFCSettings}
               />

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -5,6 +5,7 @@ import { Commandset } from 'keycard-sdk/dist/commandset';
 import RNKeycard from 'react-native-keycard';
 
 import { loadPairing } from '@/storage/pairingStorage';
+import { pubKeyFingerprint } from '@/utils/cryptoAccount';
 import { toHex } from '@/utils/hex';
 import { displayKeycardName, parseKeycardName } from '@/utils/keycardName';
 import { useGenuineCheck } from './useGenuineCheck';
@@ -34,6 +35,7 @@ export interface UseKeycardOperation<T> {
   phase: Phase;
   status: string;
   cardName: string | null;
+  cardFingerprint: number | null;
   result: T | null;
   pinError: string | null;
   pairingPasswordError: string | null;
@@ -52,6 +54,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   const [waitingForPin, setWaitingForPin] = useState(false);
   const [pinError, setPinError] = useState<string | null>(null);
   const [cardName, setCardName] = useState<string | null>(null);
+  const [cardFingerprint, setCardFingerprint] = useState<number | null>(null);
 
   const pinRef = useRef('');
   const operationRef = useRef<KeycardOperationFn<T> | null>(null);
@@ -75,7 +78,10 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   } = usePairing();
 
   const verifyPin = useCallback(
-    async (cmdSet: Commandset, setStatus: (s: string) => void): Promise<void> => {
+    async (
+      cmdSet: Commandset,
+      setStatus: (s: string) => void,
+    ): Promise<void> => {
       setStatus('Verifying PIN...');
       const pinResp = await cmdSet.verifyPIN(pinRef.current);
       console.log(
@@ -104,6 +110,8 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       uid: string,
       existingPairing: InstanceType<typeof Keycard.Pairing> | null,
       setStatus: (s: string) => void,
+      name: string,
+      hasMasterKey: boolean,
     ): Promise<T | null> => {
       if (existingPairing) {
         console.log(
@@ -122,6 +130,24 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
 
       if (requiresPinRef.current) {
         await verifyPin(cmdSet, setStatus);
+      }
+
+      // Unnamed card: derive the master fingerprint for display, mirroring
+      // keycard-shell's `name[0] ? name : fingerprint` fallback. Display only —
+      // never written back to the card. Failure is non-fatal: the operation
+      // continues and the card stays shown as "Unnamed card".
+      if (name === '' && hasMasterKey) {
+        try {
+          const masterResp = await cmdSet.exportKey(0, true, 'm', false);
+          masterResp.checkOK();
+          const fingerprint = pubKeyFingerprint(
+            Keycard.BIP32KeyPair.fromTLV(masterResp.data).publicKey,
+          );
+          setCardFingerprint(fingerprint);
+          setStatus(`Connected to ${displayKeycardName(name, fingerprint)}`);
+        } catch (e) {
+          console.warn('[Keycard] master fingerprint export failed', e);
+        }
       }
 
       if (operationRunningRef.current || !operationRef.current) {
@@ -187,7 +213,14 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
       );
       if (!shouldProceed) return null;
 
-      return await doPairAndExecute(cmdSet, uid, existingPairing, setStatus);
+      return await doPairAndExecute(
+        cmdSet,
+        uid,
+        existingPairing,
+        setStatus,
+        name,
+        appInfo.hasMasterKey(),
+      );
     },
     [checkOrSkipGenuine, doPairAndExecute],
   );
@@ -294,6 +327,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     setWaitingForPin(false);
     setPinError(null);
     setCardName(null);
+    setCardFingerprint(null);
     pinRef.current = '';
     operationRef.current = null;
     operationRunningRef.current = false;
@@ -315,6 +349,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
     phase,
     status,
     cardName,
+    cardFingerprint,
     result,
     pinError,
     pairingPasswordError,

--- a/src/utils/keycardName.ts
+++ b/src/utils/keycardName.ts
@@ -67,6 +67,19 @@ export function mergeKeycardNameMetadata(
   return new Uint8Array([...encodedName, ...current.slice(metadataOffset)]);
 }
 
-export function displayKeycardName(name?: string | null): string {
-  return name && name.length > 0 ? name : 'Unnamed card';
+export function formatFingerprint(fingerprint: number): string {
+  return (fingerprint >>> 0).toString(16).padStart(8, '0');
+}
+
+export function displayKeycardName(
+  name?: string | null,
+  fingerprint?: number | null,
+): string {
+  if (name && name.length > 0) {
+    return name;
+  }
+  if (fingerprint != null) {
+    return formatFingerprint(fingerprint);
+  }
+  return 'Unnamed card';
 }


### PR DESCRIPTION
When the tapped card has no stored name, derive the BIP32 master fingerprint (exportKey on m over the open secure channel) and show it as 8 hex chars, mirroring keycard-shell's `name[0] ? name : fingerprint`. Display only — never written to the card. Export is skipped for named cards and cards with no master key, and failure is non-fatal.