### PR TITLE
fix: add title bar to PIN-entry screen (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Title bar with a back affordance on the PIN-entry screen, matching every other screen and giving iOS a way to dismiss
+
 ## [1.8.0] - 2026-06-30
 
 ### Added

--- a/__tests__/NFCBottomSheet.test.tsx
+++ b/__tests__/NFCBottomSheet.test.tsx
@@ -8,9 +8,13 @@ import type { NFCOperation } from '../src/components/NFCBottomSheet';
 // Mocks
 // ---------------------------------------------------------------------------
 
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = require('react-native');
+  return {
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+    SafeAreaView: View,
+  };
+});
 
 jest.mock('react-native-paper', () => {
   const { Text } = require('react-native');
@@ -187,24 +191,18 @@ describe('NFCBottomSheet — Android sheet', () => {
     });
 
     it('shows the pairing password title', () => {
-      renderSheet(
-        makeNfc('pairing_password', { submitPairingPassword }),
-      );
+      renderSheet(makeNfc('pairing_password', { submitPairingPassword }));
       expect(screen.getByText('Custom pairing password')).toBeTruthy();
     });
 
     it('shows Cancel and Continue buttons', () => {
-      renderSheet(
-        makeNfc('pairing_password', { submitPairingPassword }),
-      );
+      renderSheet(makeNfc('pairing_password', { submitPairingPassword }));
       expect(screen.getByText('Cancel')).toBeTruthy();
       expect(screen.getByText('Continue')).toBeTruthy();
     });
 
     it('calls onCancel when Cancel is pressed', () => {
-      renderSheet(
-        makeNfc('pairing_password', { submitPairingPassword }),
-      );
+      renderSheet(makeNfc('pairing_password', { submitPairingPassword }));
       fireEvent.press(screen.getByText('Cancel'));
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
@@ -222,9 +220,7 @@ describe('NFCBottomSheet — Android sheet', () => {
     });
 
     it('calls submitPairingPassword with the entered password', () => {
-      renderSheet(
-        makeNfc('pairing_password', { submitPairingPassword }),
-      );
+      renderSheet(makeNfc('pairing_password', { submitPairingPassword }));
       fireEvent.changeText(
         screen.getByPlaceholderText('Pairing password'),
         'mySecret',
@@ -234,9 +230,7 @@ describe('NFCBottomSheet — Android sheet', () => {
     });
 
     it('does not show the NFC icon area', () => {
-      renderSheet(
-        makeNfc('pairing_password', { submitPairingPassword }),
-      );
+      renderSheet(makeNfc('pairing_password', { submitPairingPassword }));
       expect(screen.queryByText('Tap your Keycard')).toBeNull();
     });
   });
@@ -252,6 +246,19 @@ describe('NFCBottomSheet — Android sheet', () => {
       const submitPin = jest.fn();
       renderSheet(makeNfc('pin_entry', { submitPin }));
       expect(screen.queryByText('Tap your Keycard')).toBeNull();
+    });
+
+    it('shows the Enter PIN title bar', () => {
+      const submitPin = jest.fn();
+      renderSheet(makeNfc('pin_entry', { submitPin }));
+      expect(screen.getByText('Enter PIN')).toBeTruthy();
+    });
+
+    it('calls onCancel when the back button is pressed', () => {
+      const submitPin = jest.fn();
+      renderSheet(makeNfc('pin_entry', { submitPin }));
+      fireEvent.press(screen.getByLabelText('Go back'));
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -26,6 +26,7 @@ function mdi(name: MaterialDesignIconsIconName, defaultColor: string) {
 export const Icons = {
   scan: ScanIcon,
   keycard: KeycardIcon,
+  arrowLeft: mdi('arrow-left', theme.colors.onSurface),
   backspace: mdi('backspace-outline', theme.colors.onSurface),
   chevronRight: mdi('chevron-right', theme.colors.onSurface),
   close: mdi('close', theme.colors.onSurface),

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -4,12 +4,20 @@ import {
   BackHandler,
   Modal,
   Platform,
+  Pressable,
   StyleSheet,
+  Text,
   View,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+  type Edge,
+} from 'react-native-safe-area-context';
 
 import theme from '@/theme';
+
+import { Icons } from '@/assets/icons';
 
 import PinPad from '@/components/PinPad';
 
@@ -17,6 +25,9 @@ import GenuineWarning from './GenuineWarning';
 import NFCError from './NFCError';
 import NFCSheet from './NFCSheet';
 import PairingPasswordEntry from './PairingPasswordEntry';
+
+/** Keeps the PIN modal inside the same bounds as a normal navigation screen. */
+const PIN_MODAL_EDGES: readonly Edge[] = ['top', 'bottom', 'left', 'right'];
 
 export type NFCVariant = 'scanning' | 'success' | 'error' | 'genuine_warning';
 
@@ -127,9 +138,21 @@ export default function NFCBottomSheet({ nfc, onCancel, showOnDone }: Props) {
         animationType="slide"
         onRequestClose={onCancel}
       >
-        <View style={[styles.pinModal, { paddingBottom: insets.bottom }]}>
+        <SafeAreaView style={styles.pinModal} edges={PIN_MODAL_EDGES}>
+          <View style={styles.header}>
+            <Pressable
+              onPress={onCancel}
+              hitSlop={12}
+              style={styles.headerBack}
+              accessibilityRole="button"
+              accessibilityLabel="Go back"
+            >
+              <Icons.arrowLeft />
+            </Pressable>
+            <Text style={styles.headerTitle}>Enter PIN</Text>
+          </View>
           <PinPad onComplete={submitPin!} error={pinError ?? undefined} />
-        </View>
+        </SafeAreaView>
       </Modal>
 
       {showIOSError && (
@@ -212,5 +235,25 @@ const styles = StyleSheet.create({
   pinModal: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  header: {
+    height: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.colors.background,
+  },
+  headerBack: {
+    position: 'absolute',
+    left: 8,
+    bottom: 0,
+    height: 56,
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  headerTitle: {
+    color: theme.colors.onSurface,
+    fontSize: 17,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
PIN pad lives in a full-screen Modal, not a navigation screen, so it got no React Navigation header — no title, and no dismiss affordance on iOS.

- Render a header row inside the modal: centered "Enter PIN" title plus a left arrow-left back button wired to onCancel
- Wrap modal content in SafeAreaView (all four edges) so it occupies the same bounds as a navigation screen instead of drawing edge-to-edge
- Add Icons.arrowLeft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a title bar to the PIN-entry screen with an “Enter PIN” title.
  * Added a back button to dismiss the PIN-entry screen.
  * Improved PIN-entry layout for safe-area support across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->