### PR TITLE
feat: open SeedQR scanner from icon inside seed-phrase input (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Title bar with a back affordance on the PIN-entry screen, matching every other screen and giving iOS a way to dismiss
 
+### Changed
+
+- SeedQR scanning now opens from a QR icon inside the seed-phrase input instead of a separate "Scan SeedQR" button
+
 ## [1.8.0] - 2026-06-30
 
 ### Added

--- a/__tests__/MnemonicScreen.test.tsx
+++ b/__tests__/MnemonicScreen.test.tsx
@@ -183,9 +183,9 @@ describe('MnemonicScreen', () => {
       expect(screen.getByText('Continue')).toBeTruthy();
     });
 
-    it('renders Scan SeedQR button', async () => {
+    it('renders SeedQR scan icon inside the seed-phrase input', async () => {
       renderScreen();
-      expect(screen.getByText('Scan SeedQR')).toBeTruthy();
+      expect(screen.getByTestId('scan-seedqr-button')).toBeTruthy();
     });
   });
 
@@ -316,7 +316,7 @@ describe('MnemonicScreen', () => {
     it('shows camera overlay when Scan SeedQR is pressed', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       expect(screen.getByTestId('camera')).toBeTruthy();
     });
@@ -324,7 +324,7 @@ describe('MnemonicScreen', () => {
     it('fills word input and dismisses overlay after valid scan', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       triggerScan(VALID_12_HEX);
       expect(screen.queryByTestId('camera')).toBeNull();
@@ -334,7 +334,7 @@ describe('MnemonicScreen', () => {
     it('shows error message for invalid QR payload', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       triggerScan('notahex!!!');
       expect(screen.getByText(/Not a valid SeedQR/)).toBeTruthy();
@@ -344,7 +344,7 @@ describe('MnemonicScreen', () => {
     it('shows error when decodeSeedQr fails on valid-length hex', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       const bip39 = require('@scure/bip39');
       jest.spyOn(bip39, 'entropyToMnemonic').mockImplementationOnce(() => {
@@ -359,7 +359,7 @@ describe('MnemonicScreen', () => {
     it('clears error when Tap to retry is pressed', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       triggerScan('notahex!!!');
       expect(screen.getByText(/Not a valid SeedQR/)).toBeTruthy();
@@ -379,7 +379,7 @@ describe('MnemonicScreen', () => {
       );
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       expect(screen.getByTestId('camera')).toBeTruthy();
       await act(async () => {
@@ -391,7 +391,7 @@ describe('MnemonicScreen', () => {
     it('does not navigate anywhere on scan', async () => {
       renderScreen();
       await act(async () => {
-        fireEvent.press(screen.getByText('Scan SeedQR'));
+        fireEvent.press(screen.getByTestId('scan-seedqr-button'));
       });
       triggerScan(VALID_12_HEX);
       expect(navigation.navigate).not.toHaveBeenCalled();

--- a/src/components/MnemonicWordEntry.tsx
+++ b/src/components/MnemonicWordEntry.tsx
@@ -12,6 +12,8 @@ import { Text } from 'react-native-paper';
 
 import theme from '../theme';
 
+import { Icons } from '@/assets/icons';
+
 type Props = {
   value: string;
   onChangeText: (text: string) => void;
@@ -24,6 +26,8 @@ type Props = {
   onWordErrorChange?: (error: string | null) => void;
   wordCountOptions?: readonly number[];
   onWordCountChange?: (wordCount: number) => void;
+  onScanPress?: () => void;
+  scanTestID?: string;
   inputStyle?: StyleProp<TextStyle>;
   wrapperStyle?: StyleProp<ViewStyle>;
 };
@@ -40,6 +44,8 @@ export default function MnemonicWordEntry({
   onWordErrorChange,
   wordCountOptions,
   onWordCountChange,
+  onScanPress,
+  scanTestID,
   inputStyle,
   wrapperStyle,
 }: Props) {
@@ -99,17 +105,35 @@ export default function MnemonicWordEntry({
       )}
 
       <View style={styles.inputWrapper}>
-        <TextInput
-          style={[styles.wordInput, inputStyle]}
-          value={value}
-          onChangeText={onChangeText}
-          multiline
-          autoCapitalize="none"
-          autoCorrect={false}
-          spellCheck={false}
-          placeholder={placeholder}
-          placeholderTextColor={theme.colors.onSurfacePlaceholder}
-        />
+        <View>
+          <TextInput
+            style={[
+              styles.wordInput,
+              onScanPress && styles.wordInputWithScan,
+              inputStyle,
+            ]}
+            value={value}
+            onChangeText={onChangeText}
+            multiline
+            autoCapitalize="none"
+            autoCorrect={false}
+            spellCheck={false}
+            placeholder={placeholder}
+            placeholderTextColor={theme.colors.onSurfacePlaceholder}
+          />
+          {onScanPress && (
+            <Pressable
+              style={styles.scanIcon}
+              onPress={onScanPress}
+              hitSlop={12}
+              testID={scanTestID}
+              accessibilityRole="button"
+              accessibilityLabel="Scan SeedQR"
+            >
+              <Icons.qr width={24} height={24} color={theme.colors.onSurface} />
+            </Pressable>
+          )}
+        </View>
         {wordError && <Text style={styles.errorText}>{wordError}</Text>}
         {errors
           .filter((error): error is string => Boolean(error))
@@ -178,6 +202,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 4,
     textAlignVertical: 'top',
+  },
+  wordInputWithScan: {
+    paddingRight: 48,
+  },
+  scanIcon: {
+    position: 'absolute',
+    right: 12,
+    top: 8,
   },
   errorText: {
     color: theme.colors.error,

--- a/src/screens/keypair/MnemonicScreen.tsx
+++ b/src/screens/keypair/MnemonicScreen.tsx
@@ -89,6 +89,11 @@ export default function MnemonicScreen({
     cancel();
   }, [cancel]);
 
+  const handleScanPress = useCallback(() => {
+    setScanError(null);
+    setScanning(true);
+  }, []);
+
   useEffect(() => {
     if (phase !== 'done') {
       return;
@@ -178,6 +183,8 @@ export default function MnemonicScreen({
           placeholder="Enter your recovery phrase"
           errors={[phraseError]}
           onWordsChange={setWords}
+          onScanPress={handleScanPress}
+          scanTestID="scan-seedqr-button"
         />
 
         <TextInput
@@ -188,16 +195,6 @@ export default function MnemonicScreen({
           placeholderTextColor={theme.colors.onSurfacePlaceholder}
           autoCapitalize="none"
           autoCorrect={false}
-        />
-
-        <PrimaryButton
-          label="Scan SeedQR"
-          icon={Icons.qr}
-          onPress={() => {
-            setScanError(null);
-            setScanning(true);
-          }}
-          testID="scan-seedqr-button"
         />
       </ScrollView>
 


### PR DESCRIPTION
Replace the "Scan SeedQR" button with a QR icon rendered inside the seed-phrase input. Decode/validation path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SeedQR scanning can now be started by tapping the QR icon inside the seed-phrase input.

* **Bug Fixes**
  * Preserved existing scanner behavior, including error handling, retry, dismissal, and invalid QR code handling.

* **Documentation**
  * Updated the unreleased changelog to reflect the revised SeedQR scanning experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->