### PR TITLE
feat: explain xpub on connect-software-wallet and export QR screens (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Title bar with a back affordance on the PIN-entry screen, matching every other screen and giving iOS a way to dismiss
+- Explainer on the Connect-software-wallet screen and above the exported-key QR code
 
 ### Changed
 

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
 
 import ExportKeyScreen, {
   dashboardEntry,
@@ -24,10 +29,20 @@ jest.mock('../src/assets/icons', () => {
   return {
     Icons: {
       chevronRight: Icon,
+      close: Icon,
       nfcActivate: Icon,
     },
   };
 });
+
+const mockLoadXpubNoticeDismissed = jest.fn();
+const mockSaveXpubNoticeDismissed = jest.fn();
+jest.mock('../src/storage/preferencesStorage', () => ({
+  loadXpubNoticeDismissed: (...args: unknown[]) =>
+    mockLoadXpubNoticeDismissed(...args),
+  saveXpubNoticeDismissed: (...args: unknown[]) =>
+    mockSaveXpubNoticeDismissed(...args),
+}));
 
 // ExportKeyScreen imports dashboardActions for border-style calculation.
 jest.mock('../src/navigation/dashboardActions', () => ({
@@ -40,13 +55,20 @@ jest.mock('../src/navigation/dashboardActions', () => ({
 
 const navigation = { navigate: jest.fn() } as any;
 
-function renderScreen() {
+function renderScreenRaw() {
   return render(
     <ExportKeyScreen
       navigation={navigation}
       route={{ key: 'ExportKey', name: 'ExportKey' } as any}
     />,
   );
+}
+
+// Renders and waits for the async xpub-notice preference load to settle.
+async function renderScreen() {
+  const result = renderScreenRaw();
+  await screen.findByText(/extended public key \(xpub\)/);
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -56,20 +78,46 @@ function renderScreen() {
 describe('ExportKeyScreen', () => {
   beforeEach(() => {
     navigation.navigate.mockClear();
+    mockLoadXpubNoticeDismissed.mockReset().mockResolvedValue(false);
+    mockSaveXpubNoticeDismissed.mockReset().mockResolvedValue(undefined);
   });
 
   describe('layout', () => {
-    it('renders without crashing', () => {
-      expect(renderScreen()).toBeDefined();
+    it('renders without crashing', async () => {
+      expect(await renderScreen()).toBeDefined();
     });
 
-    it('renders the Ethereum option', () => {
-      renderScreen();
+    it('renders the Ethereum option', async () => {
+      await renderScreen();
       expect(screen.getByText('Ethereum')).toBeTruthy();
     });
 
-    it('shows the NFC indicator for every export option', () => {
-      renderScreen();
+    it('explains the extended public key and its privacy caveat', async () => {
+      await renderScreen();
+      expect(screen.getByText(/extended public key \(xpub\)/)).toBeTruthy();
+      expect(screen.getByText(/cannot spend/)).toBeTruthy();
+    });
+
+    it('does not show the xpub notice when it was previously dismissed', async () => {
+      mockLoadXpubNoticeDismissed.mockResolvedValue(true);
+      renderScreenRaw();
+      await waitFor(() =>
+        expect(mockLoadXpubNoticeDismissed).toHaveBeenCalled(),
+      );
+      expect(screen.queryByText(/extended public key \(xpub\)/)).toBeNull();
+    });
+
+    it('hides the xpub notice and persists dismissal when the close button is pressed', async () => {
+      await renderScreen();
+
+      fireEvent.press(screen.getByTestId('xpub-notice-close'));
+
+      expect(screen.queryByText(/extended public key \(xpub\)/)).toBeNull();
+      expect(mockSaveXpubNoticeDismissed).toHaveBeenCalledWith(true);
+    });
+
+    it('shows the NFC indicator for every export option', async () => {
+      await renderScreen();
 
       for (const index of [0, 1, 2, 3, 4, 5, 6]) {
         expect(screen.getByTestId(`menu-nfc-indicator-${index}`)).toBeTruthy();
@@ -78,8 +126,8 @@ describe('ExportKeyScreen', () => {
   });
 
   describe('navigation', () => {
-    it('navigates to Keycard with export_key operation when Ethereum is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with export_key operation when Ethereum is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Ethereum'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -88,8 +136,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with Bitcoin export path when Bitcoin is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with Bitcoin export path when Bitcoin is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -97,8 +145,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with multisig export path when Bitcoin Multisig is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with multisig export path when Bitcoin Multisig is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin Multisig'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -106,8 +154,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with testnet export path when Bitcoin Testnet is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with testnet export path when Bitcoin Testnet is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin Testnet'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -115,8 +163,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with source "account.ledger_live" when Ledger Live is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with source "account.ledger_live" when Ledger Live is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Ledger Live'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -125,8 +173,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with source "account.ledger_legacy" when Ledger Legacy is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with source "account.ledger_legacy" when Ledger Legacy is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Ledger Legacy'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
@@ -135,8 +183,8 @@ describe('ExportKeyScreen', () => {
       });
     });
 
-    it('navigates to Keycard with derivationPath "bitget" when Bitget is pressed', () => {
-      renderScreen();
+    it('navigates to Keycard with derivationPath "bitget" when Bitget is pressed', async () => {
+      await renderScreen();
       fireEvent.press(screen.getByText('Bitget'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',

--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -99,11 +100,21 @@ describe('ExportKeyScreen', () => {
     });
 
     it('does not show the xpub notice when it was previously dismissed', async () => {
-      mockLoadXpubNoticeDismissed.mockResolvedValue(true);
+      let resolveLoad!: (dismissed: boolean) => void;
+      mockLoadXpubNoticeDismissed.mockReturnValue(
+        new Promise<boolean>(resolve => {
+          resolveLoad = resolve;
+        }),
+      );
       renderScreenRaw();
       await waitFor(() =>
         expect(mockLoadXpubNoticeDismissed).toHaveBeenCalled(),
       );
+
+      await act(async () => {
+        resolveLoad(true);
+      });
+
       expect(screen.queryByText(/extended public key \(xpub\)/)).toBeNull();
     });
 

--- a/__tests__/PairingPasswordEntry.test.tsx
+++ b/__tests__/PairingPasswordEntry.test.tsx
@@ -66,21 +66,30 @@ describe('PairingPasswordEntry', () => {
 
   it('calls onSubmit with trimmed password when Continue is pressed', () => {
     renderEntry();
-    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), 'myPassword');
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Pairing password'),
+      'myPassword',
+    );
     fireEvent.press(screen.getByText('Continue'));
     expect(onSubmit).toHaveBeenCalledWith('myPassword');
   });
 
   it('trims whitespace before submitting', () => {
     renderEntry();
-    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), '  secret  ');
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Pairing password'),
+      '  secret  ',
+    );
     fireEvent.press(screen.getByText('Continue'));
     expect(onSubmit).toHaveBeenCalledWith('secret');
   });
 
   it('does not call onSubmit when input is only whitespace', () => {
     renderEntry();
-    fireEvent.changeText(screen.getByPlaceholderText('Pairing password'), '   ');
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Pairing password'),
+      '   ',
+    );
     fireEvent.press(screen.getByText('Continue'));
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/__tests__/QRResultScreen.test.tsx
+++ b/__tests__/QRResultScreen.test.tsx
@@ -32,12 +32,13 @@ function renderScreen(
   urString: string,
   title = 'Show signature to the wallet',
   navigation?: object,
+  description?: string,
 ) {
   return render(
     <QRResultScreen
       route={
         {
-          params: { urString, title },
+          params: { urString, title, description },
           key: 'QRResult',
           name: 'QRResult',
         } as any
@@ -75,6 +76,23 @@ describe('QRResultScreen', () => {
     expect(setOptions).toHaveBeenCalledWith({
       title: 'Show key to the wallet',
     });
+  });
+
+  it('renders the description above the QR code when provided', () => {
+    renderScreen(
+      SAMPLE_UR,
+      'Show key to the wallet',
+      undefined,
+      'An xpub lets the wallet watch your balance.',
+    );
+    expect(
+      screen.getByText('An xpub lets the wallet watch your balance.'),
+    ).toBeTruthy();
+  });
+
+  it('renders no description when none is provided', () => {
+    renderScreen(SAMPLE_UR);
+    expect(screen.queryByText(/xpub/)).toBeNull();
   });
 
   it('"Done" resets navigation to Dashboard', () => {

--- a/__tests__/preferencesStorage.test.ts
+++ b/__tests__/preferencesStorage.test.ts
@@ -2,9 +2,11 @@ import {
   loadDashboardKeycardNoticeDismissed,
   loadPinPadScramble,
   loadTokenImagesEnabled,
+  loadXpubNoticeDismissed,
   saveDashboardKeycardNoticeDismissed,
   savePinPadScramble,
   saveTokenImagesEnabled,
+  saveXpubNoticeDismissed,
 } from '../src/storage/preferencesStorage';
 
 const mockGetItem = jest.fn();
@@ -157,6 +159,51 @@ describe('preferencesStorage', () => {
       await saveTokenImagesEnabled(false);
       expect(mockSetItem).toHaveBeenCalledWith(
         'preference_token_images_enabled',
+        '0',
+      );
+    });
+  });
+
+  describe('loadXpubNoticeDismissed', () => {
+    it('reads the correct storage key', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await loadXpubNoticeDismissed();
+      expect(mockGetItem).toHaveBeenCalledWith(
+        'preference_xpub_notice_dismissed',
+      );
+    });
+
+    it('returns true when stored value is "1"', async () => {
+      mockGetItem.mockResolvedValue('1');
+      expect(await loadXpubNoticeDismissed()).toBe(true);
+    });
+
+    it('returns false when nothing stored', async () => {
+      mockGetItem.mockResolvedValue(null);
+      expect(await loadXpubNoticeDismissed()).toBe(false);
+    });
+
+    it('returns false when storage throws', async () => {
+      mockGetItem.mockRejectedValue(new Error('storage failure'));
+      expect(await loadXpubNoticeDismissed()).toBe(false);
+    });
+  });
+
+  describe('saveXpubNoticeDismissed', () => {
+    it('stores true as "1"', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveXpubNoticeDismissed(true);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'preference_xpub_notice_dismissed',
+        '1',
+      );
+    });
+
+    it('stores false as "0"', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveXpubNoticeDismissed(false);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        'preference_xpub_notice_dismissed',
         '0',
       );
     });

--- a/__tests__/useKeycardOperation.test.ts
+++ b/__tests__/useKeycardOperation.test.ts
@@ -599,12 +599,10 @@ describe('useKeycardOperation', () => {
         sw: 0x9000,
         data: new Uint8Array([0x20 | 0]), // length-0 name = unnamed card
       }),
-      exportKey: jest
-        .fn()
-        .mockResolvedValue({
-          data: new Uint8Array([0x02]),
-          checkOK: jest.fn(),
-        }),
+      exportKey: jest.fn().mockResolvedValue({
+        data: new Uint8Array([0x02]),
+        checkOK: jest.fn(),
+      }),
       ...overrides,
     });
 

--- a/src/constants/exportKey.ts
+++ b/src/constants/exportKey.ts
@@ -1,0 +1,5 @@
+export const XPUB_EXPLAINER =
+  'Connecting shares an extended public key (xpub) from your Keycard. An ' +
+  'xpub lets the software wallet derive all of your addresses, so it can ' +
+  'watch your full balance and transaction history — but it cannot spend ' +
+  'your funds. Spending always requires your Keycard.';

--- a/src/hooks/keycard/useGenuineCheck.ts
+++ b/src/hooks/keycard/useGenuineCheck.ts
@@ -49,5 +49,10 @@ export function useGenuineCheck() {
     pendingUidRef.current = null;
   }, []);
 
-  return { showGenuineWarning, checkOrSkipGenuine, proceedWithNonGenuine, resetGenuineState };
+  return {
+    showGenuineWarning,
+    checkOrSkipGenuine,
+    proceedWithNonGenuine,
+    resetGenuineState,
+  };
 }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -64,6 +64,7 @@ export type RootStackParamList = {
   QRResult: {
     urString: string; // fully encoded UR string, ready for QR display
     title: string;
+    description?: string; // explanatory copy rendered above the QR code
   };
   About: undefined;
   LicenseDetail: {

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -123,6 +123,8 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
             onPress={handleDismissNotice}
             hitSlop={8}
             testID="xpub-notice-close"
+            accessibilityRole="button"
+            accessibilityLabel="Close the extended public key notice"
           >
             <Icons.close
               width={18}

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -1,10 +1,18 @@
-import { StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DashboardAction, ExportKeyScreenProps } from '../navigation/types';
 import theme from '../theme';
 
 import Menu from '../components/Menu';
+
+import { Icons } from '../assets/icons';
+import { XPUB_EXPLAINER } from '../constants/exportKey';
+import {
+  loadXpubNoticeDismissed,
+  saveXpubNoticeDismissed,
+} from '../storage/preferencesStorage';
 
 export const dashboardEntry: DashboardAction = {
   label: 'Connect software wallet',
@@ -13,6 +21,28 @@ export const dashboardEntry: DashboardAction = {
 
 export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
   const insets = useSafeAreaInsets();
+  const [noticeVisible, setNoticeVisible] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    loadXpubNoticeDismissed()
+      .then(dismissed => {
+        if (isMounted) setNoticeVisible(!dismissed);
+      })
+      .catch(() => {
+        if (isMounted) setNoticeVisible(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleDismissNotice = useCallback(() => {
+    setNoticeVisible(false);
+    saveXpubNoticeDismissed(true).catch(() => {});
+  }, []);
 
   const entries = [
     {
@@ -85,6 +115,23 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+      {noticeVisible ? (
+        <View style={styles.notice}>
+          <Text style={styles.description}>{XPUB_EXPLAINER}</Text>
+          <Pressable
+            style={styles.noticeClose}
+            onPress={handleDismissNotice}
+            hitSlop={8}
+            testID="xpub-notice-close"
+          >
+            <Icons.close
+              width={18}
+              height={18}
+              color={theme.colors.onSurfaceMuted}
+            />
+          </Pressable>
+        </View>
+      ) : null}
       <Menu entries={entries} />
     </View>
   );
@@ -94,5 +141,22 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  notice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    paddingLeft: 24,
+    paddingRight: 16,
+    paddingTop: 16,
+  },
+  description: {
+    flex: 1,
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 13,
+    lineHeight: 13 * 1.45,
+  },
+  noticeClose: {
+    paddingTop: 2,
   },
 });

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { XPUB_EXPLAINER } from '../constants/exportKey';
 import type { KeycardScreenProps } from '../navigation/types';
 import theme from '../theme';
 
@@ -148,7 +149,11 @@ export default function KeycardScreen({
           { name: 'ExportKey' },
           {
             name: 'QRResult',
-            params: { urString, title: 'Show key to the wallet' },
+            params: {
+              urString,
+              title: 'Show key to the wallet',
+              description: XPUB_EXPLAINER,
+            },
           },
         ],
       });

--- a/src/screens/QRResultScreen.tsx
+++ b/src/screens/QRResultScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import AnimatedURQRCode from 'react-native-animated-ur-qr';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -15,7 +15,7 @@ export default function QRResultScreen({
 }: QRResultScreenProps) {
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
-  const { urString, title } = route.params;
+  const { urString, title, description } = route.params;
 
   useEffect(() => {
     navigation.setOptions({ title });
@@ -29,6 +29,9 @@ export default function QRResultScreen({
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
+      {description ? (
+        <Text style={styles.description}>{description}</Text>
+      ) : null}
       <View style={styles.qrArea}>
         <AnimatedURQRCode urString={urString} size={qrSize} />
       </View>
@@ -44,6 +47,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  description: {
+    color: theme.colors.onSurfaceMuted,
+    fontSize: 13,
+    lineHeight: 13 * 1.45,
+    paddingHorizontal: 24,
+    paddingTop: 16,
   },
   qrArea: {
     flex: 1,

--- a/src/storage/preferencesStorage.ts
+++ b/src/storage/preferencesStorage.ts
@@ -4,6 +4,7 @@ const DASHBOARD_KEYCARD_NOTICE_DISMISSED =
   'preference_dashboard_keycard_notice_dismissed';
 const PIN_PAD_SCRAMBLE = 'preference_pinpad_scramble';
 const TOKEN_IMAGES_ENABLED = 'preference_token_images_enabled';
+const XPUB_NOTICE_DISMISSED = 'preference_xpub_notice_dismissed';
 
 async function loadBoolean(key: string): Promise<boolean> {
   try {
@@ -41,4 +42,12 @@ export async function loadTokenImagesEnabled(): Promise<boolean> {
 
 export async function saveTokenImagesEnabled(value: boolean): Promise<void> {
   return saveBoolean(TOKEN_IMAGES_ENABLED, value);
+}
+
+export async function loadXpubNoticeDismissed(): Promise<boolean> {
+  return loadBoolean(XPUB_NOTICE_DISMISSED);
+}
+
+export async function saveXpubNoticeDismissed(value: boolean): Promise<void> {
+  return saveBoolean(XPUB_NOTICE_DISMISSED, value);
 }


### PR DESCRIPTION
Add XPUB_EXPLAINER copy: what an extended public key is, that it lets the wallet watch all addresses and history but never spend.

- ExportKeyScreen: muted dismissible notice with X; dismissal persisted via preference_xpub_notice_dismissed, never shown again
- QRResultScreen: optional description param rendered above QR code; KeycardScreen passes explainer for export-key results only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an XPUB explainer describing how connecting a software wallet enables address and transaction monitoring while keeping spending secured by the Keycard.
  - Displayed the explainer above exported-key QR codes.
  - Added a dismissible notice; once closed, it stays hidden using a saved preference.
  - QR result screens can now optionally show descriptive text above the QR code.
- **Tests**
  - Expanded coverage for QR descriptions and XPUB notice preference loading/dismissal behavior.
- **Chores**
  - Updated the unreleased changelog entry for the new explainer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->