### PR TITLE
fix: prevent two-digit seed-word index from wrapping on iOS (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - SeedQR scanning now opens from a QR icon inside the seed-phrase input instead of a separate "Scan SeedQR" button
 
+### Fixed
+
+- Generated recovery-phrase list: two-digit word numbers (`10.`, `11.`, `12.`) no longer wrap onto a second line on iOS; the number column is now auto-width
+
 ## [1.8.0] - 2026-06-30
 
 ### Added

--- a/src/screens/keypair/GenerateKeyScreen.tsx
+++ b/src/screens/keypair/GenerateKeyScreen.tsx
@@ -78,7 +78,9 @@ export default function GenerateKeyScreen({
                 <View style={styles.column}>
                   {words.slice(0, half).map((word, i) => (
                     <View key={i} style={styles.wordCell}>
-                      <Text style={styles.wordIndex}>{i + 1}.</Text>
+                      <Text style={styles.wordIndex} numberOfLines={1}>
+                        {i + 1}.
+                      </Text>
                       <Text style={styles.wordText}>{word}</Text>
                     </View>
                   ))}
@@ -86,7 +88,9 @@ export default function GenerateKeyScreen({
                 <View style={styles.column}>
                   {words.slice(half).map((word, i) => (
                     <View key={i} style={styles.wordCell}>
-                      <Text style={styles.wordIndex}>{half + i + 1}.</Text>
+                      <Text style={styles.wordIndex} numberOfLines={1}>
+                        {half + i + 1}.
+                      </Text>
                       <Text style={styles.wordText}>{word}</Text>
                     </View>
                   ))}
@@ -184,13 +188,15 @@ const styles = StyleSheet.create({
   wordIndex: {
     color: theme.colors.onSurfaceDisabled,
     fontSize: 13,
-    width: 22,
+    minWidth: 22,
+    flexShrink: 0,
     textAlign: 'right',
   },
   wordText: {
     color: theme.colors.onSurface,
     fontSize: 15,
     fontWeight: '500',
+    flex: 1,
   },
   buttonArea: {
     paddingHorizontal: 24,


### PR DESCRIPTION
The generated-mnemonic list gave the number column a fixed width of 22, which was too narrow for two-digit numbers plus the dot on iOS, causing `10.`/`11.`/`12.` to wrap onto a second line. Make the number column auto-width (minWidth + no wrap/shrink) and let the word take the remaining space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recovery-phrase numbering on iOS so two-digit word numbers remain on a single line.
  * Improved the number column layout to adjust automatically and prevent wrapping or overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->