### PR TITLE
feat: show full derivation path on View Addresses rows (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Title bar with a back affordance on the PIN-entry screen, matching every other screen and giving iOS a way to dismiss
 - Explainer on the Connect-software-wallet screen and above the exported-key QR code
+- View Addresses now shows the full BIP32 derivation path (e.g. `m/44'/60'/0'/0/0`) under each address in the list and on the address detail screen, replacing the bare index column
 
 ### Changed
 

--- a/__tests__/AboutScreen.test.tsx
+++ b/__tests__/AboutScreen.test.tsx
@@ -116,14 +116,12 @@ describe('AboutScreen', () => {
     fireEvent.press(screen.getByLabelText('Show Bitcoin QR code'));
     expect(navigation.navigate).toHaveBeenCalledWith('AddressDetail', {
       address: bitcoinAddress,
-      index: 0,
       title: 'Bitcoin address',
     });
 
     fireEvent.press(screen.getByLabelText('Show Ethereum QR code'));
     expect(navigation.navigate).toHaveBeenCalledWith('AddressDetail', {
       address: ethereumAddress,
-      index: 0,
       title: 'Ethereum address',
     });
   });

--- a/__tests__/AddressDetailScreen.test.tsx
+++ b/__tests__/AddressDetailScreen.test.tsx
@@ -65,23 +65,23 @@ function setupEnsResolved(name: string) {
 // ---------------------------------------------------------------------------
 
 const ETH_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
-const INDEX = 7;
+const DERIVATION_PATH = "m/44'/60'/0'/0/7";
 
 const navigation = { setOptions: jest.fn() } as any;
 
-function makeRoute(address = ETH_ADDRESS, index = INDEX) {
+function makeRoute(address = ETH_ADDRESS, derivationPath = DERIVATION_PATH) {
   return {
     key: 'AddressDetail',
     name: 'AddressDetail',
-    params: { address, index },
+    params: { address, derivationPath },
   } as any;
 }
 
-function renderScreen(address = ETH_ADDRESS, index = INDEX) {
+function renderScreen(address = ETH_ADDRESS, derivationPath = DERIVATION_PATH) {
   return render(
     <AddressDetailScreen
       navigation={navigation}
-      route={makeRoute(address, index)}
+      route={makeRoute(address, derivationPath)}
     />,
   );
 }
@@ -121,9 +121,9 @@ describe('AddressDetailScreen', () => {
   });
 
   describe('title', () => {
-    it('sets the navigation title to the address index', () => {
-      renderScreen(ETH_ADDRESS, 5);
-      expect(navigation.setOptions).toHaveBeenCalledWith({ title: '5' });
+    it('defaults the navigation title to Address', () => {
+      renderScreen();
+      expect(navigation.setOptions).toHaveBeenCalledWith({ title: 'Address' });
     });
 
     it('uses a custom title when provided', () => {
@@ -136,7 +136,6 @@ describe('AddressDetailScreen', () => {
               name: 'AddressDetail',
               params: {
                 address: ETH_ADDRESS,
-                index: 0,
                 title: 'Ethereum address',
               },
             } as any
@@ -146,6 +145,29 @@ describe('AddressDetailScreen', () => {
       expect(navigation.setOptions).toHaveBeenCalledWith({
         title: 'Ethereum address',
       });
+    });
+  });
+
+  describe('derivation path', () => {
+    it('renders the derivation path under the address', () => {
+      renderScreen();
+      expect(screen.getByText(DERIVATION_PATH)).toBeTruthy();
+    });
+
+    it('renders no path row when derivationPath is absent', () => {
+      render(
+        <AddressDetailScreen
+          navigation={navigation}
+          route={
+            {
+              key: 'AddressDetail',
+              name: 'AddressDetail',
+              params: { address: ETH_ADDRESS, title: 'Ethereum address' },
+            } as any
+          }
+        />,
+      );
+      expect(screen.queryByText(DERIVATION_PATH)).toBeNull();
     });
   });
 

--- a/__tests__/AddressListScreen.test.tsx
+++ b/__tests__/AddressListScreen.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@scure/bip32', () => ({ HDKey: jest.fn() }));
 // Mock deriveAddresses — returns predictable test addresses
 const mockDeriveAddresses = jest.fn();
 jest.mock('../src/utils/hdAddress', () => ({
+  ...jest.requireActual('../src/utils/hdAddress'),
   parseExtendedKeyFromTLV: jest.fn(),
   deriveAddresses: (...args: any[]) => mockDeriveAddresses(...args),
 }));
@@ -201,6 +202,13 @@ describe('AddressListScreen', () => {
       expect(screen.getByText('0xAddr9')).toBeTruthy();
     });
 
+    it('renders the full derivation path under each address', async () => {
+      mockDeriveAddresses.mockReturnValue(makeBatch('0xAddr'));
+      await renderScreen('done', mockAccountKey);
+      expect(screen.getByText("m/44'/60'/0'/0/0")).toBeTruthy();
+      expect(screen.getByText("m/44'/60'/0'/0/9")).toBeTruthy();
+    });
+
     it('loads more addresses starting at the next index on subsequent calls', async () => {
       mockDeriveAddresses.mockReturnValue(makeBatch('0xAddr'));
       await renderScreen('done', mockAccountKey);
@@ -225,7 +233,7 @@ describe('AddressListScreen', () => {
   });
 
   describe('row press', () => {
-    it('navigates to AddressDetail with address and index when a row is pressed', async () => {
+    it('navigates to AddressDetail with address and derivation path when a row is pressed', async () => {
       mockDeriveAddresses.mockReturnValue(makeBatch('0xAddr'));
       await renderScreen('done', mockAccountKey);
 
@@ -235,7 +243,7 @@ describe('AddressListScreen', () => {
 
       expect(navigation.navigate).toHaveBeenCalledWith('AddressDetail', {
         address: '0xAddr0',
-        index: 0,
+        derivationPath: "m/44'/60'/0'/0/0",
       });
     });
   });
@@ -246,6 +254,12 @@ describe('AddressListScreen', () => {
       await renderScreen('done', mockAccountKey, 'btc');
       expect(mockDeriveAddresses).toHaveBeenCalled();
       expect(screen.getByText('bc1q0')).toBeTruthy();
+    });
+
+    it('renders BTC derivation paths', async () => {
+      mockDeriveAddresses.mockReturnValue(makeBatch('bc1q'));
+      await renderScreen('done', mockAccountKey, 'btc');
+      expect(screen.getByText("m/84'/0'/0'/0/0")).toBeTruthy();
     });
   });
 });

--- a/__tests__/hdAddress.test.ts
+++ b/__tests__/hdAddress.test.ts
@@ -1,4 +1,4 @@
-import { deriveAddresses } from '../src/utils/hdAddress';
+import { addressDerivationPath, deriveAddresses } from '../src/utils/hdAddress';
 
 // ---------------------------------------------------------------------------
 // Tests: deriveAddresses
@@ -28,5 +28,21 @@ describe('deriveAddresses', () => {
     const addrFn = jest.fn((pub: Uint8Array) => `addr-${pub[0]}`);
     const result = deriveAddresses(key as any, 2, addrFn, 10);
     expect(result).toEqual(['addr-10', 'addr-11']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: addressDerivationPath
+// ---------------------------------------------------------------------------
+
+describe('addressDerivationPath', () => {
+  it('builds the full ETH path from the account path and index', () => {
+    expect(addressDerivationPath('eth', 0)).toBe("m/44'/60'/0'/0/0");
+    expect(addressDerivationPath('eth', 7)).toBe("m/44'/60'/0'/0/7");
+  });
+
+  it('builds the full BTC path from the account path and index', () => {
+    expect(addressDerivationPath('btc', 0)).toBe("m/84'/0'/0'/0/0");
+    expect(addressDerivationPath('btc', 21)).toBe("m/84'/0'/0'/0/21");
   });
 });

--- a/__tests__/useAddresses.test.ts
+++ b/__tests__/useAddresses.test.ts
@@ -43,6 +43,7 @@ jest.mock('keycard-sdk', () => ({
 }));
 
 jest.mock('../src/utils/hdAddress', () => ({
+  ...jest.requireActual('../src/utils/hdAddress'),
   deriveAddresses: jest.fn(),
 }));
 

--- a/src/hooks/keycard/useAddresses.ts
+++ b/src/hooks/keycard/useAddresses.ts
@@ -2,15 +2,12 @@ import { HDKey } from '@scure/bip32';
 import Keycard from 'keycard-sdk';
 import { useCallback } from 'react';
 
+import { ACCOUNT_PATHS } from '@/utils/hdAddress';
+
 import { useKeycardOp } from './useKeycardOperation';
 
-const COIN_CONFIG = {
-  eth: { path: "m/44'/60'/0'" },
-  btc: { path: "m/84'/0'/0'" },
-};
-
 export function useAddresses(coin: 'eth' | 'btc') {
-  const { path } = COIN_CONFIG[coin];
+  const path = ACCOUNT_PATHS[coin];
 
   return useKeycardOp<HDKey>(
     useCallback(

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -60,7 +60,7 @@ export type RootStackParamList = {
   PairingSlots: undefined;
   AddressMenu: undefined;
   AddressList: { coin: 'btc' | 'eth' };
-  AddressDetail: { address: string; index: number; title?: string };
+  AddressDetail: { address: string; derivationPath?: string; title?: string };
   QRResult: {
     urString: string; // fully encoded UR string, ready for QR display
     title: string;

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -96,7 +96,6 @@ export default function AboutScreen({ navigation }: AboutScreenProps) {
         onShowQR={(label, address) =>
           navigation.navigate('AddressDetail', {
             address,
-            index: 0,
             title: `${label} address`,
           })
         }

--- a/src/screens/address/AddressDetailScreen.tsx
+++ b/src/screens/address/AddressDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import QRCode from 'react-native-qrcode-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -15,12 +15,12 @@ export default function AddressDetailScreen({
   route,
   navigation,
 }: AddressDetailScreenProps) {
-  const { address, index, title } = route.params;
+  const { address, derivationPath, title } = route.params;
   const insets = useSafeAreaInsets();
 
   useLayoutEffect(() => {
-    navigation.setOptions({ title: title ?? String(index) });
-  }, [navigation, index, title]);
+    navigation.setOptions({ title: title ?? 'Address' });
+  }, [navigation, title]);
 
   const handleCopy = useCallback(() => {
     Clipboard.setString(address);
@@ -38,6 +38,9 @@ export default function AddressDetailScreen({
           />
         </View>
         <EnsAddressLabel address={address} />
+        {derivationPath ? (
+          <Text style={styles.path}>{derivationPath}</Text>
+        ) : null}
       </View>
       <PrimaryButton
         label="Copy Address"
@@ -66,5 +69,10 @@ const styles = StyleSheet.create({
     padding: 16,
     backgroundColor: '#ffffff',
     borderRadius: 8,
+  },
+  path: {
+    color: theme.colors.onSurfaceVariant,
+    fontFamily: 'monospace',
+    fontSize: 12,
   },
 });

--- a/src/screens/address/AddressListScreen.tsx
+++ b/src/screens/address/AddressListScreen.tsx
@@ -28,23 +28,23 @@ import { useAddresses } from '../../hooks/keycard/useAddresses';
 
 import { pubKeyToBtcAddress } from '../../utils/bitcoinAddress';
 import { pubKeyToEthAddress } from '../../utils/ethereumAddress';
-import { deriveAddresses } from '../../utils/hdAddress';
+import { addressDerivationPath, deriveAddresses } from '../../utils/hdAddress';
 
 const BATCH = 20;
 const ADDR_FN = { eth: pubKeyToEthAddress, btc: pubKeyToBtcAddress };
 
 type RowProps = {
   address: string;
-  index: number;
-  onNavigate: (address: string, index: number) => void;
+  path: string;
+  onNavigate: (address: string, path: string) => void;
 };
 
-const AddressRow = memo(({ address, index, onNavigate }: RowProps) => (
-  <Pressable style={styles.row} onPress={() => onNavigate(address, index)}>
-    <Text style={styles.index}>{index}</Text>
+const AddressRow = memo(({ address, path, onNavigate }: RowProps) => (
+  <Pressable style={styles.row} onPress={() => onNavigate(address, path)}>
     <AddressText address={address} style={styles.address} />
-    <View style={styles.qrIcon}>
-      <Icons.qr width={20} height={20} color={theme.colors.onSurfaceVariant} />
+    <View style={styles.metaRow}>
+      <Text style={styles.path}>{path}</Text>
+      <Icons.qr width={16} height={16} color={theme.colors.onSurfaceVariant} />
     </View>
   </Pressable>
 ));
@@ -87,16 +87,20 @@ export default function AddressListScreen({
   const keyExtractor = useCallback((_: string, i: number) => String(i), []);
 
   const handleRowPress = useCallback(
-    (address: string, index: number) =>
-      navigation.navigate('AddressDetail', { address, index }),
+    (address: string, derivationPath: string) =>
+      navigation.navigate('AddressDetail', { address, derivationPath }),
     [navigation],
   );
 
   const renderItem = useCallback(
     ({ item, index }: { item: string; index: number }) => (
-      <AddressRow address={item} index={index} onNavigate={handleRowPress} />
+      <AddressRow
+        address={item}
+        path={addressDerivationPath(coin, index)}
+        onNavigate={handleRowPress}
+      />
     ),
-    [handleRowPress],
+    [coin, handleRowPress],
   );
 
   const handleCancel = useCallback(() => {
@@ -143,13 +147,25 @@ export default function AddressListScreen({
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   row: {
-    flexDirection: 'row',
     padding: 12,
+    gap: 4,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: theme.colors.surfaceVariant,
   },
-  index: { width: 40, color: theme.colors.onSurfaceVariant },
-  address: { flex: 1, color: theme.colors.onSurface, fontFamily: 'monospace' },
+  address: {
+    color: theme.colors.onSurface,
+    fontFamily: 'monospace',
+    textAlign: 'center',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  path: {
+    color: theme.colors.onSurfaceVariant,
+    fontFamily: 'monospace',
+    fontSize: 12,
+  },
   footer: { paddingVertical: 16 },
-  qrIcon: { width: 40, alignItems: 'center', justifyContent: 'center' },
 });

--- a/src/utils/hdAddress.ts
+++ b/src/utils/hdAddress.ts
@@ -1,5 +1,19 @@
 import { HDKey } from '@scure/bip32';
 
+// Account-level derivation paths exported from the Keycard per coin.
+export const ACCOUNT_PATHS = {
+  eth: "m/44'/60'/0'",
+  btc: "m/84'/0'/0'",
+} as const;
+
+// Full derivation path for the address at `index` on the external chain.
+export function addressDerivationPath(
+  coin: 'eth' | 'btc',
+  index: number,
+): string {
+  return `${ACCOUNT_PATHS[coin]}/0/${index}`;
+}
+
 // Derive `count` child public keys at path .../0/0, .../0/1, ...
 // addrFn converts a compressed pubkey to a coin-specific address string.
 export function deriveAddresses(


### PR DESCRIPTION
List rows: address centered full-width, path below left, small QR icon right. Detail screen shows path under the address. Index removed — contained in path. AddressDetail param index → derivationPath; ACCOUNT_PATHS + addressDerivationPath added to hdAddress.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Address lists now display complete Bitcoin and Ethereum derivation paths instead of numeric indexes.
  - Address detail screens show the derivation path when available.
  - Donation address navigation no longer includes an unnecessary address index.
- **Bug Fixes**
  - Improved address navigation and display consistency across Bitcoin and Ethereum address flows.
  - Added support for cases where a derivation path is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->