### PR TITLE
refactor: single EthPayload classification — displayed digest equals signed bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Full and pre-hashed EIP-712 sign requests (`dataType=2`) are now signable: the card signs the computed EIP-712 digest — the same digest shown in the review — instead of failing on raw bytes after PIN entry. Unclassifiable payloads now show a "cannot be signed" explanation in the review instead of a Sign button
 - Title bar with a back affordance on the PIN-entry screen, matching every other screen and giving iOS a way to dismiss
 - Explainer on the Connect-software-wallet screen and above the exported-key QR code
 - View Addresses now shows the full BIP32 derivation path (e.g. `m/44'/60'/0'/0/0`) under each address in the list and on the address detail screen, replacing the bare index column
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Ethereum signature `v` is now derived from the classified payload kind instead of sniffing the first byte of the payload: a personal-sign message or EIP-712 digest that happened to start with `0x01`/`0x02` no longer produces an invalid signature (`v = recId` instead of `27 + recId`)
 - Generated recovery-phrase list: two-digit word numbers (`10.`, `11.`, `12.`) no longer wrap onto a second line on iOS; the number column is now auto-width
 
 ## [1.8.0] - 2026-06-30

--- a/__tests__/EthSignRequestDetail.test.tsx
+++ b/__tests__/EthSignRequestDetail.test.tsx
@@ -652,3 +652,28 @@ describe('EthSignRequestDetail — pre-hashed EIP-712', () => {
     expect(screen.getByText(/Message hash/)).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Invalid payload banner (classifyEthPayload → kind 'invalid')
+// ---------------------------------------------------------------------------
+
+describe('EthSignRequestDetail — invalid payload banner', () => {
+  it('shows the cannot-sign banner with the classification reason', () => {
+    renderDetail({
+      signData: 'ab'.repeat(31), // 31 bytes — not a valid 32-byte digest
+      dataType: 0,
+      derivationPath: "m/44'/60'/0'/0",
+    });
+    expect(screen.getByText(/This request cannot be signed/)).toBeTruthy();
+    expect(screen.getByText(/31 bytes/)).toBeTruthy();
+  });
+
+  it('does not show the banner for a signable payload', () => {
+    renderDetail({
+      signData: 'ab'.repeat(32),
+      dataType: 0,
+      derivationPath: "m/44'/60'/0'/0",
+    });
+    expect(screen.queryByText(/This request cannot be signed/)).toBeNull();
+  });
+});

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -65,7 +65,6 @@ jest.mock('../src/utils/keycardExport', () => {
   return {
     ...actual,
     exportKeyForWallet: jest.fn(),
-    prepareSignHash: jest.fn(() => new Uint8Array(32)),
   };
 });
 
@@ -98,7 +97,8 @@ const signRoute = {
   params: {
     operation: 'sign',
     signMode: 'eth',
-    signData: 'deadbeef',
+    // 32-byte digest → classifies as raw-digest (dataType=2)
+    signData: 'ab'.repeat(32),
     derivationPath: "m/44'/60'/0'/0",
     dataType: 2,
     chainId: 1,
@@ -526,13 +526,7 @@ describe('KeycardScreen', () => {
   });
 
   describe('eth sign execute callback', () => {
-    it('calls signWithPath with the prepared hash and derivation path', async () => {
-      const { prepareSignHash } = require('../src/utils/keycardExport') as {
-        prepareSignHash: jest.Mock;
-      };
-      const hash = new Uint8Array(32).fill(0xcc);
-      (prepareSignHash as jest.Mock).mockReturnValue(hash);
-
+    it('calls signWithPath with the signing digest and derivation path', async () => {
       const checkOK = jest.fn();
       const signWithPath = jest.fn().mockResolvedValue({
         checkOK,
@@ -544,8 +538,10 @@ describe('KeycardScreen', () => {
       const signOp = mockExecute.mock.calls[0][0];
       const result = await signOp({ signWithPath });
 
+      // signRoute carries a raw 32-byte digest, so the signing digest is the
+      // payload bytes themselves (raw-digest passthrough).
       expect(signWithPath).toHaveBeenCalledWith(
-        hash,
+        new Uint8Array(Buffer.from(signRoute.params.signData, 'hex')),
         signRoute.params.derivationPath,
         false,
       );

--- a/__tests__/TransactionDetailScreen.test.tsx
+++ b/__tests__/TransactionDetailScreen.test.tsx
@@ -218,7 +218,8 @@ function renderScreenWithWc(result: any) {
 }
 
 const fullRequest: EthSignRequest = {
-  signData: 'aabbccdd',
+  // First byte >= 0xc0 → classifies as tx-legacy (signable)
+  signData: 'e8aabbccdd',
   dataType: 1,
   derivationPath: "m/44'/60'/0'/0",
   chainId: 1,
@@ -288,7 +289,7 @@ describe('TransactionDetailScreen – eth-sign-request result', () => {
       kind: 'eth-sign-request',
       request: fullRequest,
     });
-    expect(screen.getByText('aabbccdd')).toBeTruthy();
+    expect(screen.getByText('e8aabbccdd')).toBeTruthy();
   });
 
   it('displays the derivation path', async () => {

--- a/__tests__/ethPayload.test.ts
+++ b/__tests__/ethPayload.test.ts
@@ -1,0 +1,310 @@
+import { keccak_256 } from '@noble/hashes/sha3.js';
+import { hashTypedData } from 'viem';
+
+import {
+  classifyEthPayload,
+  signingDigest,
+  type EthPayload,
+} from '../src/utils/ethPayload';
+import { computeEthV } from '../src/utils/ethSignature';
+import {
+  computeEip712DigestFromJson,
+  computeEip712DigestFromPrehashed,
+} from '../src/utils/erc8213';
+
+function hex(bytes: Uint8Array): string {
+  return '0x' + Buffer.from(bytes).toString('hex');
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// Minimal legacy tx: RLP list first byte (>= 0xc0). Classification only
+// inspects the first byte; scan-time validation (parseTx) guards structure.
+const LEGACY_TX_HEX =
+  'e980843b9aca0082520894aabbccddeeff00112233445566778899aabbccdd8080018080';
+const EIP2930_TX_HEX =
+  '01f85901018082520894aabbccddeeff00112233445566778899aabbccdd8080c0';
+const EIP1559_TX_HEX =
+  '02f8590101010182520894aabbccddeeff00112233445566778899aabbccdd8080c0';
+
+const TYPED_DATA = {
+  domain: {
+    name: 'Test',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+  },
+  primaryType: 'Mail',
+  types: {
+    Mail: [{ name: 'contents', type: 'string' }],
+  },
+  message: { contents: 'hi' },
+} as const;
+const TYPED_DATA_JSON_HEX =
+  '0x' + Buffer.from(JSON.stringify(TYPED_DATA), 'utf8').toString('hex');
+
+const DOMAIN_SEPARATOR = '0x' + 'aa'.repeat(32);
+const MESSAGE_HASH = '0x' + 'bb'.repeat(32);
+const PREHASHED_HEX = '0x1901' + 'aa'.repeat(32) + 'bb'.repeat(32);
+
+const DIGEST_32_HEX = '0x' + 'cd'.repeat(32);
+
+// ── Classification ───────────────────────────────────────────────────────────
+
+describe('classifyEthPayload', () => {
+  it('dataType=1 with RLP list first byte → tx-legacy', () => {
+    expect(classifyEthPayload(LEGACY_TX_HEX, 1).kind).toBe('tx-legacy');
+  });
+
+  it('dataType=1 with 0x01 first byte → tx-eip2930', () => {
+    expect(classifyEthPayload(EIP2930_TX_HEX, 1).kind).toBe('tx-eip2930');
+  });
+
+  it('dataType=4 with 0x01 first byte → tx-eip2930', () => {
+    expect(classifyEthPayload(EIP2930_TX_HEX, 4).kind).toBe('tx-eip2930');
+  });
+
+  it('dataType=4 with 0x02 first byte → tx-eip1559', () => {
+    expect(classifyEthPayload(EIP1559_TX_HEX, 4).kind).toBe('tx-eip1559');
+  });
+
+  it('dataType=1 with 0x02 first byte → invalid (mirrors parseTx accept set)', () => {
+    expect(classifyEthPayload(EIP1559_TX_HEX, 1).kind).toBe('invalid');
+  });
+
+  it('dataType=4 with RLP list first byte → invalid (mirrors parseTx accept set)', () => {
+    expect(classifyEthPayload(LEGACY_TX_HEX, 4).kind).toBe('invalid');
+  });
+
+  it('dataType=1 with unrecognized first byte → invalid', () => {
+    expect(classifyEthPayload('79aabb', 1).kind).toBe('invalid');
+  });
+
+  it('dataType=1 with empty payload → invalid', () => {
+    expect(classifyEthPayload('', 1).kind).toBe('invalid');
+  });
+
+  it('dataType=3 → personal-message', () => {
+    const messageHex = Buffer.from('hello world', 'utf8').toString('hex');
+    expect(classifyEthPayload(messageHex, 3).kind).toBe('personal-message');
+  });
+
+  it('dataType=3 message starting 0x01 stays personal-message (adversarial first byte)', () => {
+    expect(classifyEthPayload('01aabbcc', 3).kind).toBe('personal-message');
+  });
+
+  it('dataType=2 with full typed-data JSON → eip712-json with the ERC-8213 digest', () => {
+    const payload = classifyEthPayload(TYPED_DATA_JSON_HEX, 2);
+    expect(payload.kind).toBe('eip712-json');
+    if (payload.kind !== 'eip712-json') throw new Error('unreachable');
+    expect(payload.digest).toBe(
+      computeEip712DigestFromJson(
+        TYPED_DATA.domain as Record<string, unknown>,
+        TYPED_DATA.message as unknown as Record<string, unknown>,
+        TYPED_DATA.primaryType,
+        TYPED_DATA.types as unknown as Record<string, unknown>,
+      ),
+    );
+    expect(payload.digest).toBe(hashTypedData(TYPED_DATA));
+  });
+
+  it('dataType=2 with 66-byte 0x1901 payload → eip712-prehashed with the final digest', () => {
+    const payload = classifyEthPayload(PREHASHED_HEX, 2);
+    expect(payload.kind).toBe('eip712-prehashed');
+    if (payload.kind !== 'eip712-prehashed') throw new Error('unreachable');
+    expect(payload.prehashed.domainSeparatorHash).toBe(DOMAIN_SEPARATOR);
+    expect(payload.prehashed.messageHash).toBe(MESSAGE_HASH);
+    expect(payload.digest).toBe(
+      computeEip712DigestFromPrehashed(DOMAIN_SEPARATOR, MESSAGE_HASH),
+    );
+  });
+
+  it('dataType=2 with a bare 32-byte digest → raw-digest', () => {
+    const payload = classifyEthPayload(DIGEST_32_HEX, 2);
+    expect(payload).toEqual({ kind: 'raw-digest', digest: DIGEST_32_HEX });
+  });
+
+  it('dataType=2 with unhashable JSON → invalid', () => {
+    // primaryType names a type that does not exist → hashTypedData throws
+    const junkJson =
+      '0x' +
+      Buffer.from(
+        JSON.stringify({
+          domain: {},
+          message: {},
+          primaryType: 'Mail',
+          types: {},
+        }),
+        'utf8',
+      ).toString('hex');
+    expect(classifyEthPayload(junkJson, 2).kind).toBe('invalid');
+  });
+
+  it('dataType=2 with 47 junk bytes → invalid', () => {
+    expect(classifyEthPayload('ee'.repeat(47), 2).kind).toBe('invalid');
+  });
+
+  it('dataType=0 with a 32-byte digest → raw-digest (WC typed-data convention)', () => {
+    expect(classifyEthPayload(DIGEST_32_HEX, 0)).toEqual({
+      kind: 'raw-digest',
+      digest: DIGEST_32_HEX,
+    });
+  });
+
+  it('undefined dataType with a 32-byte digest → raw-digest', () => {
+    expect(classifyEthPayload(DIGEST_32_HEX, undefined).kind).toBe(
+      'raw-digest',
+    );
+  });
+
+  it('dataType=0 with a non-32-byte payload → invalid with byte count in the reason', () => {
+    const payload = classifyEthPayload('ab'.repeat(31), 0);
+    expect(payload.kind).toBe('invalid');
+    if (payload.kind !== 'invalid') throw new Error('unreachable');
+    expect(payload.reason).toContain('31 bytes');
+  });
+
+  it('dataType=0 with a single byte → invalid with singular byte count', () => {
+    const payload = classifyEthPayload('ab', 0);
+    expect(payload.kind).toBe('invalid');
+    if (payload.kind !== 'invalid') throw new Error('unreachable');
+    expect(payload.reason).toContain('1 byte');
+  });
+
+  it('digest hex is normalized to lowercase with 0x prefix', () => {
+    const payload = classifyEthPayload('AB'.repeat(32), 0);
+    expect(payload).toEqual({
+      kind: 'raw-digest',
+      digest: '0x' + 'ab'.repeat(32),
+    });
+  });
+
+  it('non-hex signData → invalid', () => {
+    expect(classifyEthPayload('zz not hex', 0).kind).toBe('invalid');
+  });
+
+  it('odd-length hex → invalid', () => {
+    expect(classifyEthPayload('abc', 0).kind).toBe('invalid');
+  });
+});
+
+// ── Signing digest ───────────────────────────────────────────────────────────
+
+describe('signingDigest', () => {
+  it('tx kinds: keccak256 of the raw payload', () => {
+    for (const [fixture, dataType] of [
+      [LEGACY_TX_HEX, 1],
+      [EIP2930_TX_HEX, 4],
+      [EIP1559_TX_HEX, 4],
+    ] as const) {
+      const payload = classifyEthPayload(fixture, dataType);
+      const expected = keccak_256(new Uint8Array(Buffer.from(fixture, 'hex')));
+      expect(hex(signingDigest(payload))).toBe(hex(expected));
+    }
+  });
+
+  it('personal-message: EIP-191 prefixed keccak256', () => {
+    const message = Buffer.from('hello world', 'utf8');
+    const payload = classifyEthPayload(message.toString('hex'), 3);
+    const prefix = Buffer.from(
+      `\x19Ethereum Signed Message:\n${message.length}`,
+      'utf8',
+    );
+    const expected = keccak_256(
+      new Uint8Array(Buffer.concat([prefix, message])),
+    );
+    expect(hex(signingDigest(payload))).toBe(hex(expected));
+  });
+
+  it('eip712-json: signs the ERC-8213 digest (not the raw JSON bytes)', () => {
+    const payload = classifyEthPayload(TYPED_DATA_JSON_HEX, 2);
+    expect(hex(signingDigest(payload))).toBe(hashTypedData(TYPED_DATA));
+  });
+
+  it('eip712-prehashed: signs keccak256(0x1901 || domainSeparator || messageHash)', () => {
+    const payload = classifyEthPayload(PREHASHED_HEX, 2);
+    expect(hex(signingDigest(payload))).toBe(
+      computeEip712DigestFromPrehashed(DOMAIN_SEPARATOR, MESSAGE_HASH),
+    );
+  });
+
+  it('raw-digest: passes the 32 bytes through unchanged', () => {
+    const payload = classifyEthPayload(DIGEST_32_HEX, 0);
+    expect(hex(signingDigest(payload))).toBe(DIGEST_32_HEX);
+  });
+
+  it('always returns exactly 32 bytes for every signable kind', () => {
+    const signable: Array<[string, number]> = [
+      [LEGACY_TX_HEX, 1],
+      [EIP2930_TX_HEX, 4],
+      [EIP1559_TX_HEX, 4],
+      [Buffer.from('x'.repeat(200), 'utf8').toString('hex'), 3],
+      [TYPED_DATA_JSON_HEX, 2],
+      [PREHASHED_HEX, 2],
+      [DIGEST_32_HEX, 0],
+    ];
+    for (const [signData, dataType] of signable) {
+      expect(
+        signingDigest(classifyEthPayload(signData, dataType)),
+      ).toHaveLength(32);
+    }
+  });
+
+  it('throws on invalid payloads', () => {
+    const payload: EthPayload = { kind: 'invalid', reason: 'nope' };
+    expect(() => signingDigest(payload)).toThrow('nope');
+  });
+});
+
+// ── The invariant #234 exists for ────────────────────────────────────────────
+// The digest displayed in review and the bytes sent to the card come from the
+// same classification, so they cannot diverge. The review renders
+// payload.digest; the card receives signingDigest(payload).
+
+describe('displayed digest === signed bytes', () => {
+  it('eip712-json: displayed digest is byte-identical to the signed hash', () => {
+    const payload = classifyEthPayload(TYPED_DATA_JSON_HEX, 2);
+    if (payload.kind !== 'eip712-json') throw new Error('unreachable');
+    expect(hex(signingDigest(payload))).toBe(payload.digest);
+  });
+
+  it('eip712-prehashed: displayed digest is byte-identical to the signed hash', () => {
+    const payload = classifyEthPayload(PREHASHED_HEX, 2);
+    if (payload.kind !== 'eip712-prehashed') throw new Error('unreachable');
+    expect(hex(signingDigest(payload))).toBe(payload.digest);
+  });
+
+  it('raw-digest: displayed digest is byte-identical to the signed hash', () => {
+    const payload = classifyEthPayload(DIGEST_32_HEX, 0);
+    if (payload.kind !== 'raw-digest') throw new Error('unreachable');
+    expect(hex(signingDigest(payload))).toBe(payload.digest);
+  });
+});
+
+// ── Adversarial v regressions ────────────────────────────────────────────────
+// Before #234, detectTxType sniffed the first byte of ANY signData, so a
+// personal message or WC digest that happened to start 0x01/0x02 flipped v
+// from 27+recId to recId. Classification is now gated on dataType.
+
+describe('adversarial first-byte payloads keep v = 27 + recId', () => {
+  it('personal message starting 0x01', () => {
+    const payload = classifyEthPayload('01aabbcc', 3);
+    expect(payload.kind).toBe('personal-message');
+    expect(computeEthV(0, payload.kind, 1)).toBe(27);
+    expect(computeEthV(1, payload.kind, 1)).toBe(28);
+  });
+
+  it('WC typed-data digest starting 0x02', () => {
+    const digest = '02' + 'ab'.repeat(31);
+    const payload = classifyEthPayload(digest, 0);
+    expect(payload.kind).toBe('raw-digest');
+    expect(computeEthV(0, payload.kind, 1)).toBe(27);
+  });
+
+  it('EIP-712 raw digest starting 0x01 (dataType=2)', () => {
+    const digest = '01' + 'cd'.repeat(31);
+    const payload = classifyEthPayload(digest, 2);
+    expect(payload.kind).toBe('raw-digest');
+    expect(computeEthV(1, payload.kind, undefined)).toBe(28);
+  });
+});

--- a/__tests__/ethSignature.test.ts
+++ b/__tests__/ethSignature.test.ts
@@ -106,60 +106,72 @@ describe('buildEthSignatureUR', () => {
   });
 
   it('returns a ur:eth-signature string', () => {
-    const ur = buildEthSignatureUR(tlvHex, HASH, 4, undefined, undefined);
+    const ur = buildEthSignatureUR(
+      tlvHex,
+      HASH,
+      'tx-eip1559',
+      undefined,
+      undefined,
+    );
     expect(ur.toLowerCase()).toMatch(/^ur:eth-signature\//);
   });
 
-  describe('v calculation by dataType', () => {
-    it('EIP-1559 (dataType=4): v equals recId (0 or 1)', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 4, undefined, undefined);
+  describe('v calculation by payload kind', () => {
+    it('tx-eip1559: v equals recId (0 or 1)', () => {
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-eip1559',
+        undefined,
+        undefined,
+      );
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig[sig.length - 1]).toBe(recId);
     });
 
-    it('legacy transaction (dataType=1, chainId=1): v = 37 + recId', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 1, undefined);
+    it('tx-legacy (chainId=1): v = 37 + recId', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 'tx-legacy', 1, undefined);
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig[sig.length - 1]).toBe(37 + recId);
     });
 
     it('encodes multi-byte legacy v values', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 111, undefined);
+      const ur = buildEthSignatureUR(tlvHex, HASH, 'tx-legacy', 111, undefined);
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig.subarray(64)).toEqual(Buffer.from([0x01, 0x01 + recId]));
     });
 
     it('encodes three-byte legacy v values', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 40_000, undefined);
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-legacy',
+        40_000,
+        undefined,
+      );
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig.subarray(64)).toHaveLength(3);
       expect(sig.readUIntBE(64, 3)).toBe(80_035 + recId);
     });
 
     it('encodes four-byte legacy v values', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 9_000_000, undefined);
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-legacy',
+        9_000_000,
+        undefined,
+      );
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig.subarray(64)).toHaveLength(4);
       expect(sig.readUInt32BE(64)).toBe(18_000_035 + recId);
     });
 
-    it('EIP-712 (dataType=2): v = 27 + recId', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 2, undefined, undefined);
-      const sig: Buffer = decodeUR(ur)[2];
-      expect(sig[sig.length - 1]).toBe(27 + recId);
-    });
-
-    it('personal_sign (dataType=3): v = 27 + recId', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 3, undefined, undefined);
-      const sig: Buffer = decodeUR(ur)[2];
-      expect(sig[sig.length - 1]).toBe(27 + recId);
-    });
-
-    it('undefined dataType falls back to v = 27 + recId', () => {
+    it('eip712-json: v = 27 + recId', () => {
       const ur = buildEthSignatureUR(
         tlvHex,
         HASH,
-        undefined,
+        'eip712-json',
         undefined,
         undefined,
       );
@@ -167,31 +179,72 @@ describe('buildEthSignatureUR', () => {
       expect(sig[sig.length - 1]).toBe(27 + recId);
     });
 
-    it('EIP-2930 (txType=0x01, dataType=1): v equals recId, not EIP-155', () => {
-      // Without txType, dataType=1 chainId=1 would give v = 37 + recId
-      const ur = buildEthSignatureUR(tlvHex, HASH, 1, 1, undefined, 0x01);
+    it('personal-message: v = 27 + recId', () => {
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'personal-message',
+        undefined,
+        undefined,
+      );
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig[sig.length - 1]).toBe(27 + recId);
+    });
+
+    it('raw-digest: v = 27 + recId', () => {
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'raw-digest',
+        undefined,
+        undefined,
+      );
+      const sig: Buffer = decodeUR(ur)[2];
+      expect(sig[sig.length - 1]).toBe(27 + recId);
+    });
+
+    it('tx-eip2930 (chainId=1): v equals recId, not EIP-155', () => {
+      const ur = buildEthSignatureUR(tlvHex, HASH, 'tx-eip2930', 1, undefined);
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig[sig.length - 1]).toBe(recId);
       expect(sig[sig.length - 1]).not.toBe(37 + recId);
     });
 
-    it('EIP-1559 (txType=0x02, dataType=4): v equals recId', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 4, 1, undefined, 0x02);
+    it('eip712-prehashed: v = 27 + recId', () => {
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'eip712-prehashed',
+        1,
+        undefined,
+      );
       const sig: Buffer = decodeUR(ur)[2];
-      expect(sig[sig.length - 1]).toBe(recId);
+      expect(sig[sig.length - 1]).toBe(27 + recId);
     });
   });
 
   describe('CBOR map structure', () => {
     it('always includes signature (key 2) and origin "Keycard Pal" (key 3)', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 4, undefined, undefined);
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-eip1559',
+        undefined,
+        undefined,
+      );
       const decoded = decodeUR(ur);
       expect(Buffer.isBuffer(decoded[2])).toBe(true);
       expect(decoded[3]).toBe('Keycard Pal');
     });
 
     it('signature is 65 bytes (r || s || v) for single-byte v values', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 4, undefined, undefined);
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-eip1559',
+        undefined,
+        undefined,
+      );
       const sig: Buffer = decodeUR(ur)[2];
       expect(sig.length).toBe(65);
     });
@@ -200,7 +253,7 @@ describe('buildEthSignatureUR', () => {
       const ur = buildEthSignatureUR(
         tlvHex,
         HASH,
-        4,
+        'tx-eip1559',
         undefined,
         '0102030405060708090a0b0c0d0e0f10',
       );
@@ -209,7 +262,13 @@ describe('buildEthSignatureUR', () => {
     });
 
     it('omits requestId (key 1) when not provided', () => {
-      const ur = buildEthSignatureUR(tlvHex, HASH, 4, undefined, undefined);
+      const ur = buildEthSignatureUR(
+        tlvHex,
+        HASH,
+        'tx-eip1559',
+        undefined,
+        undefined,
+      );
       const decoded = decodeUR(ur);
       expect(decoded[1]).toBeUndefined();
     });
@@ -217,51 +276,50 @@ describe('buildEthSignatureUR', () => {
 
   it('throws on malformed TLV', () => {
     expect(() =>
-      buildEthSignatureUR('deadbeef', HASH, 4, undefined, undefined),
+      buildEthSignatureUR('deadbeef', HASH, 'tx-eip1559', undefined, undefined),
     ).toThrow();
   });
 });
 
 describe('computeEthV', () => {
-  it('EIP-2930 (txType=0x01): returns recId regardless of dataType/chainId', () => {
-    expect(computeEthV(0, 1, 1, 0x01)).toBe(0);
-    expect(computeEthV(1, 1, 1, 0x01)).toBe(1);
+  it('tx-eip2930: returns recId regardless of chainId', () => {
+    expect(computeEthV(0, 'tx-eip2930', 1)).toBe(0);
+    expect(computeEthV(1, 'tx-eip2930', 1)).toBe(1);
   });
 
-  it('EIP-1559 (txType=0x02): returns recId', () => {
-    expect(computeEthV(0, 4, 1, 0x02)).toBe(0);
-    expect(computeEthV(1, 4, 1, 0x02)).toBe(1);
+  it('tx-eip1559: returns recId', () => {
+    expect(computeEthV(0, 'tx-eip1559', 1)).toBe(0);
+    expect(computeEthV(1, 'tx-eip1559', 1)).toBe(1);
   });
 
-  it('legacy EIP-155 tx (dataType=1): v = 35 + 2*chainId + recId', () => {
-    expect(computeEthV(0, 1, 1, undefined)).toBe(37);
-    expect(computeEthV(1, 1, 1, undefined)).toBe(38);
-    expect(computeEthV(0, 1, 137, undefined)).toBe(35 + 274);
+  it('tx-legacy: v = 35 + 2*chainId + recId', () => {
+    expect(computeEthV(0, 'tx-legacy', 1)).toBe(37);
+    expect(computeEthV(1, 'tx-legacy', 1)).toBe(38);
+    expect(computeEthV(0, 'tx-legacy', 137)).toBe(35 + 274);
   });
 
-  it('legacy EIP-155 tx (dataType=1) with no chainId: v = 35 + recId', () => {
-    expect(computeEthV(0, 1, undefined, undefined)).toBe(35);
-    expect(computeEthV(1, 1, undefined, undefined)).toBe(36);
+  it('tx-legacy with no chainId: v = 35 + recId', () => {
+    expect(computeEthV(0, 'tx-legacy', undefined)).toBe(35);
+    expect(computeEthV(1, 'tx-legacy', undefined)).toBe(36);
   });
 
-  it('typed tx without explicit txType (dataType=4): v = recId', () => {
-    expect(computeEthV(0, 4, undefined, undefined)).toBe(0);
-    expect(computeEthV(1, 4, undefined, undefined)).toBe(1);
+  it('personal-message: v = 27 + recId', () => {
+    expect(computeEthV(0, 'personal-message', undefined)).toBe(27);
+    expect(computeEthV(1, 'personal-message', undefined)).toBe(28);
   });
 
-  it('personal_sign (dataType=3): v = 27 + recId', () => {
-    expect(computeEthV(0, 3, undefined, undefined)).toBe(27);
-    expect(computeEthV(1, 3, undefined, undefined)).toBe(28);
+  it('eip712-json and eip712-prehashed: v = 27 + recId', () => {
+    expect(computeEthV(0, 'eip712-json', undefined)).toBe(27);
+    expect(computeEthV(1, 'eip712-prehashed', undefined)).toBe(28);
   });
 
-  it('EIP-712 (dataType=2): v = 27 + recId', () => {
-    expect(computeEthV(0, 2, undefined, undefined)).toBe(27);
-    expect(computeEthV(1, 2, undefined, undefined)).toBe(28);
+  it('raw-digest: v = 27 + recId', () => {
+    expect(computeEthV(0, 'raw-digest', undefined)).toBe(27);
+    expect(computeEthV(1, 'raw-digest', undefined)).toBe(28);
   });
 
-  it('undefined dataType: v = 27 + recId', () => {
-    expect(computeEthV(0, undefined, undefined, undefined)).toBe(27);
-    expect(computeEthV(1, undefined, undefined, undefined)).toBe(28);
+  it('invalid: throws', () => {
+    expect(() => computeEthV(0, 'invalid', undefined)).toThrow();
   });
 });
 
@@ -284,57 +342,52 @@ describe('buildRawEthHexSignature', () => {
   });
 
   it('returns 0x-prefixed hex of length 132 (single-byte v)', () => {
-    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, undefined);
+    const result = buildRawEthHexSignature(
+      tlvBytes,
+      HASH,
+      'tx-eip1559',
+      undefined,
+    );
     expect(result).toMatch(/^0x[0-9a-f]{130}$/);
   });
 
-  it('v = recId for dataType=4', () => {
-    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, undefined);
-    const vHex = result.slice(2 + 128);
-    expect(parseInt(vHex, 16)).toBe(recId);
-  });
-
-  it('v = 27 + recId for dataType=3 (personal_sign)', () => {
-    const result = buildRawEthHexSignature(tlvBytes, HASH, 3, undefined);
-    const vHex = result.slice(2 + 128);
-    expect(parseInt(vHex, 16)).toBe(27 + recId);
-  });
-
-  it('detects EIP-2930 from 0x-prefixed signData first byte 0x01 → v = recId', () => {
-    const result = buildRawEthHexSignature(tlvBytes, HASH, 1, 1, '0x01aabbcc');
-    const vHex = result.slice(2 + 128);
-    expect(parseInt(vHex, 16)).toBe(recId);
-  });
-
-  it('detects EIP-1559 from signData first byte 0x02 → v = recId', () => {
-    const result = buildRawEthHexSignature(tlvBytes, HASH, 4, 1, '02aabbcc');
-    const vHex = result.slice(2 + 128);
-    expect(parseInt(vHex, 16)).toBe(recId);
-  });
-
-  it('falls back to default v when signData is undefined', () => {
+  it('v = recId for tx-eip1559', () => {
     const result = buildRawEthHexSignature(
       tlvBytes,
       HASH,
-      3,
+      'tx-eip1559',
       undefined,
+    );
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+
+  it('v = recId for tx-eip2930 even with a chainId', () => {
+    const result = buildRawEthHexSignature(tlvBytes, HASH, 'tx-eip2930', 1);
+    const vHex = result.slice(2 + 128);
+    expect(parseInt(vHex, 16)).toBe(recId);
+  });
+
+  it('v = 27 + recId for personal-message', () => {
+    const result = buildRawEthHexSignature(
+      tlvBytes,
+      HASH,
+      'personal-message',
       undefined,
     );
     const vHex = result.slice(2 + 128);
     expect(parseInt(vHex, 16)).toBe(27 + recId);
   });
 
-  it('non-typed signData (first byte not 0x01/0x02) does not override dataType v', () => {
-    // 0xde is not a typed tx prefix → detectTxType returns undefined → uses dataType=4 → v = recId
+  it('v = 27 + recId for raw-digest (WC typed-data digest)', () => {
     const result = buildRawEthHexSignature(
       tlvBytes,
       HASH,
-      4,
+      'raw-digest',
       undefined,
-      '0xdeadbeef',
     );
     const vHex = result.slice(2 + 128);
-    expect(parseInt(vHex, 16)).toBe(recId);
+    expect(parseInt(vHex, 16)).toBe(27 + recId);
   });
 });
 
@@ -358,7 +411,7 @@ describe('buildEthSignatureURFromResult', () => {
     const ur = buildEthSignatureURFromResult(
       tlvBytes,
       HASH,
-      4,
+      'tx-eip1559',
       undefined,
       undefined,
     );
@@ -369,7 +422,7 @@ describe('buildEthSignatureURFromResult', () => {
     const ur = buildEthSignatureURFromResult(
       tlvBytes,
       HASH,
-      4,
+      'tx-eip1559',
       undefined,
       '0102030405060708090a0b0c0d0e0f10',
     );
@@ -377,14 +430,13 @@ describe('buildEthSignatureURFromResult', () => {
     expect(decoded[1]).toBeDefined();
   });
 
-  it('detects tx type from signData for correct v encoding', () => {
+  it('tx-eip2930 kind yields v = recId in the UR signature', () => {
     const ur = buildEthSignatureURFromResult(
       tlvBytes,
       HASH,
-      1,
+      'tx-eip2930',
       1,
       undefined,
-      '0x01deadbeef',
     );
     const sig: Buffer = decodeUR(ur)[2];
     // EIP-2930 → v = recId (0 or 1), not 37+

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -1,10 +1,4 @@
-import { keccak_256 } from '@noble/hashes/sha3.js';
-
-import {
-  buildExportUr,
-  exportKeyForWallet,
-  prepareSignHash,
-} from '../src/utils/keycardExport';
+import { buildExportUr, exportKeyForWallet } from '../src/utils/keycardExport';
 
 jest.mock('keycard-sdk', () => ({
   __esModule: true,
@@ -26,57 +20,6 @@ jest.mock('../src/utils/cryptoMultiAccounts', () => ({
   buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
   exportKeysForBitget: jest.fn(),
 }));
-
-function hex(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString('hex');
-}
-
-describe('prepareSignHash', () => {
-  const message = 'hello world';
-  const messageHex = Buffer.from(message, 'utf8').toString('hex');
-
-  it('dataType=1 returns keccak256 of raw bytes', () => {
-    const raw = Buffer.from(messageHex, 'hex');
-    const expected = hex(keccak_256(raw));
-    expect(hex(prepareSignHash(messageHex, 1))).toBe(expected);
-  });
-
-  it('dataType=4 returns keccak256 of raw bytes', () => {
-    const raw = Buffer.from(messageHex, 'hex');
-    const expected = hex(keccak_256(raw));
-    expect(hex(prepareSignHash(messageHex, 4))).toBe(expected);
-  });
-
-  it('dataType=3 returns EIP-191 personal_sign hash', () => {
-    const raw = Buffer.from(message, 'utf8');
-    const prefix = `\x19Ethereum Signed Message:\n${raw.length}`;
-    const prefixBytes = new TextEncoder().encode(prefix);
-    const combined = new Uint8Array(prefixBytes.length + raw.length);
-    combined.set(prefixBytes);
-    combined.set(raw, prefixBytes.length);
-    const expected = hex(keccak_256(combined));
-    expect(hex(prepareSignHash(messageHex, 3))).toBe(expected);
-  });
-
-  it('dataType=3 produces a 32-byte hash regardless of message length', () => {
-    const long = 'x'.repeat(200);
-    const longHex = Buffer.from(long, 'utf8').toString('hex');
-    const result = prepareSignHash(longHex, 3);
-    expect(result).toHaveLength(32);
-  });
-
-  it('dataType=2 returns raw bytes unchanged', () => {
-    const hash32Hex = 'ab'.repeat(32);
-    const result = prepareSignHash(hash32Hex, 2);
-    expect(hex(result)).toBe(hash32Hex);
-  });
-
-  it('undefined dataType returns raw bytes unchanged', () => {
-    const hash32Hex = 'cd'.repeat(32);
-    const result = prepareSignHash(hash32Hex, undefined);
-    expect(hex(result)).toBe(hash32Hex);
-  });
-});
 
 describe('buildExportUr', () => {
   const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey');

--- a/__tests__/signNavigation.test.ts
+++ b/__tests__/signNavigation.test.ts
@@ -3,10 +3,11 @@ import type { ScanResult } from '../src/types';
 
 describe('buildSignKeycardParams', () => {
   it('returns eth params for eth-sign-request', () => {
+    // First byte >= 0xc0 → classifies as tx-legacy (signable)
     const result: ScanResult = {
       kind: 'eth-sign-request',
       request: {
-        signData: 'aabbccdd',
+        signData: 'e8aabbccdd',
         dataType: 1,
         derivationPath: "m/44'/60'/0'/0",
         chainId: 1,
@@ -16,12 +17,49 @@ describe('buildSignKeycardParams', () => {
     expect(buildSignKeycardParams(result)).toEqual({
       operation: 'sign',
       signMode: 'eth',
-      signData: 'aabbccdd',
+      signData: 'e8aabbccdd',
       derivationPath: "m/44'/60'/0'/0",
       chainId: 1,
       requestId: 'req-1',
       dataType: 1,
     });
+  });
+
+  it('returns null for an eth-sign-request whose payload classifies as invalid', () => {
+    // dataType=1 with a first byte that is neither 0x01 nor an RLP list
+    const result: ScanResult = {
+      kind: 'eth-sign-request',
+      request: {
+        signData: 'aabbccdd',
+        dataType: 1,
+        derivationPath: "m/44'/60'/0'/0",
+      },
+    };
+    expect(buildSignKeycardParams(result)).toBeNull();
+  });
+
+  it('returns null for a WC digest request that is not 32 bytes', () => {
+    const result: ScanResult = {
+      kind: 'eth-sign-request',
+      request: {
+        signData: 'ab'.repeat(31),
+        dataType: 0,
+        derivationPath: "m/44'/60'/0'/0",
+      },
+    };
+    expect(buildSignKeycardParams(result)).toBeNull();
+  });
+
+  it('returns eth params for a 32-byte WC digest request', () => {
+    const result: ScanResult = {
+      kind: 'eth-sign-request',
+      request: {
+        signData: 'ab'.repeat(32),
+        dataType: 0,
+        derivationPath: "m/44'/60'/0'/0",
+      },
+    };
+    expect(buildSignKeycardParams(result)).not.toBeNull();
   });
 
   it('returns btc params for crypto-psbt', () => {

--- a/src/components/SignRequestDetail/eth/DataTabPanel/Eip712JsonPanel.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/Eip712JsonPanel.tsx
@@ -7,8 +7,8 @@ import type { EthSignRequest } from '@/types';
 import AddressInfoRow from '@/components/ens/AddressInfoRow.online';
 import InfoRow from '@/components/InfoRow';
 
-import { computeEip712DigestFromJson } from '@/utils/erc8213';
-import { parseEip712RawTypedData, type Eip712Summary } from '@/utils/eip712';
+import { type Eip712Summary } from '@/utils/eip712';
+import { classifyEthPayload } from '@/utils/ethPayload';
 
 import { DigestRow, SectionHeader } from './shared';
 import SpecialEip712Section from './SpecialEip712Section';
@@ -28,21 +28,13 @@ export default function Eip712JsonPanel({
   const specialEip712 = eip712.special;
 
   const eip712Digest = useMemo(() => {
-    const raw = parseEip712RawTypedData(request.signData);
-    if (raw) {
-      return computeEip712DigestFromJson(
-        raw.domain,
-        raw.message,
-        raw.primaryType,
-        raw.types,
-      );
-    }
-    // dataType=0 (WC pre-hashed): signData is already the 32-byte digest
-    if (/^0x[0-9a-fA-F]{64}$/.test(request.signData)) {
-      return request.signData;
-    }
-    return null;
-  }, [request.signData]);
+    // Same classification that produces the bytes sent to the card
+    // (signingDigest) — the digest shown here is the digest signed.
+    const payload = classifyEthPayload(request.signData, request.dataType);
+    return payload.kind === 'eip712-json' || payload.kind === 'raw-digest'
+      ? payload.digest
+      : null;
+  }, [request.signData, request.dataType]);
 
   return (
     <View style={styles.panel}>

--- a/src/components/SignRequestDetail/eth/DataTabPanel/Eip712PrehashedPanel.tsx
+++ b/src/components/SignRequestDetail/eth/DataTabPanel/Eip712PrehashedPanel.tsx
@@ -6,8 +6,9 @@ import type { EthSignRequest } from '@/types';
 
 import InfoRow from '@/components/InfoRow';
 
-import { computeEip712DigestFromPrehashed } from '@/utils/erc8213';
 import { type Eip712Prehashed } from '@/utils/eip712';
+import { computeEip712DigestFromPrehashed } from '@/utils/erc8213';
+import { classifyEthPayload } from '@/utils/ethPayload';
 
 import { DigestRow, SectionHeader } from './shared';
 
@@ -22,14 +23,18 @@ export default function Eip712PrehashedPanel({
 }) {
   const [tab, setTab] = useState<Tab>('details');
 
-  const eip712Digest = useMemo(
-    () =>
-      computeEip712DigestFromPrehashed(
-        eip712Prehashed.domainSeparatorHash,
-        eip712Prehashed.messageHash,
-      ),
-    [eip712Prehashed],
-  );
+  const eip712Digest = useMemo(() => {
+    // Prefer the classification's digest — the same value signingDigest sends
+    // to the card. Fall back to the prop-derived compute for WC requests whose
+    // pre-hash came from reviewData rather than signData.
+    const payload = classifyEthPayload(request.signData, request.dataType);
+    return payload.kind === 'eip712-prehashed'
+      ? payload.digest
+      : computeEip712DigestFromPrehashed(
+          eip712Prehashed.domainSeparatorHash,
+          eip712Prehashed.messageHash,
+        );
+  }, [request.signData, request.dataType, eip712Prehashed]);
 
   return (
     <View style={styles.panel}>

--- a/src/components/SignRequestDetail/eth/SignRequestDetail.tsx
+++ b/src/components/SignRequestDetail/eth/SignRequestDetail.tsx
@@ -10,6 +10,7 @@ import InfoRow from '@/components/InfoRow';
 
 import { getChainName, getNativeCurrencySymbol } from '@/utils/chainMetadata';
 import { parseEip712Prehashed, parseEip712Summary } from '@/utils/eip712';
+import { classifyEthPayload } from '@/utils/ethPayload';
 import { checksumEthAddress } from '@/utils/ethereumAddress';
 import { getTxLabel, parseTx } from '@/utils/txParser';
 
@@ -34,6 +35,7 @@ export default function SignRequestDetail({
   const signer = request.address
     ? checksumEthAddress(request.address)
     : request.derivationPath;
+  const payload = classifyEthPayload(request.signData, request.dataType);
 
   return (
     <>
@@ -43,6 +45,14 @@ export default function SignRequestDetail({
           {typeLabel}
         </Text>
       </View>
+
+      {payload.kind === 'invalid' && (
+        <View style={styles.invalidBanner}>
+          <Text variant="bodyMedium" style={styles.invalidText}>
+            This request cannot be signed. {payload.reason}
+          </Text>
+        </View>
+      )}
 
       <View style={styles.row}>
         <AddressInfoRow label="Signer" value={signer} />
@@ -124,6 +134,15 @@ const styles = StyleSheet.create({
   },
   typeChipText: {
     color: theme.colors.primary,
+  },
+  invalidBanner: {
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: theme.colors.surfaceVariant,
+  },
+  invalidText: {
+    color: theme.colors.error,
   },
   row: {
     paddingVertical: 8,

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -17,6 +17,7 @@ import {
   parseKeycardBtcMessageSignature,
 } from '../utils/btcMessage';
 import { BtcSigningSession, buildCryptoPsbtUR } from '../utils/btcPsbt';
+import { classifyEthPayload, signingDigest } from '../utils/ethPayload';
 import {
   buildEthSignatureURFromResult,
   buildRawEthHexSignature,
@@ -24,7 +25,6 @@ import {
 import {
   buildExportUr,
   exportKeyForWallet,
-  prepareSignHash,
   type ExportKeyResult,
 } from '../utils/keycardExport';
 
@@ -60,7 +60,12 @@ export default function KeycardScreen({
     }
 
     if (params.signMode === 'eth') {
-      const hash = prepareSignHash(params.signData, params.dataType);
+      const payload = classifyEthPayload(params.signData, params.dataType);
+      if (payload.kind === 'invalid') {
+        // buildSignKeycardParams never routes invalid payloads here.
+        return;
+      }
+      const hash = signingDigest(payload);
       hashRef.current = hash;
 
       execute(async cmdSet => {
@@ -172,15 +177,18 @@ export default function KeycardScreen({
       requestId?: string;
       signData?: string;
     };
+    const payload = classifyEthPayload(p.signData ?? '', p.dataType);
+    if (payload.kind === 'invalid') {
+      return;
+    }
 
     if (wcContext && !respondedRef.current) {
       respondedRef.current = true;
       const rawSig = buildRawEthHexSignature(
         result,
         hashRef.current,
-        p.dataType,
+        payload.kind,
         p.chainId,
-        p.signData,
       );
       respondSuccess(wcContext, rawSig).finally(() => resetToDashboard());
       return;
@@ -190,10 +198,9 @@ export default function KeycardScreen({
       buildEthSignatureURFromResult(
         result,
         hashRef.current,
-        p.dataType,
+        payload.kind,
         p.chainId,
         p.requestId,
-        p.signData,
       ),
     );
   }, [

--- a/src/utils/ethPayload.ts
+++ b/src/utils/ethPayload.ts
@@ -1,0 +1,160 @@
+import { keccak_256 } from '@noble/hashes/sha3.js';
+
+import {
+  parseEip712Prehashed,
+  parseEip712RawTypedData,
+  type Eip712Prehashed,
+  type Eip712RawTypedData,
+} from './eip712';
+import {
+  computeEip712DigestFromJson,
+  computeEip712DigestFromPrehashed,
+} from './erc8213';
+
+/**
+ * The single classification of an Ethereum sign request payload.
+ *
+ * Every consumer of (signData, dataType) — the review Digests tab, the hash
+ * sent to the card, and the signature v computation — must go through this
+ * union so they can never disagree about what the bytes mean. The digest a
+ * variant carries is the digest the card signs; the review displays the same
+ * value ("the digest shown is the digest signed").
+ *
+ * Transaction classification mirrors txParser.parseTx's accept set exactly:
+ * a payload parseTx rejects at scan time must classify as 'invalid' here.
+ */
+export type EthPayload =
+  | { kind: 'tx-legacy'; raw: Uint8Array }
+  | { kind: 'tx-eip2930'; raw: Uint8Array }
+  | { kind: 'tx-eip1559'; raw: Uint8Array }
+  | { kind: 'personal-message'; raw: Uint8Array }
+  | { kind: 'eip712-json'; typedData: Eip712RawTypedData; digest: string }
+  | { kind: 'eip712-prehashed'; prehashed: Eip712Prehashed; digest: string }
+  | { kind: 'raw-digest'; digest: string }
+  | { kind: 'invalid'; reason: string };
+
+export type EthPayloadKind = EthPayload['kind'];
+
+const RLP_LIST_MIN = 0xc0;
+const DIGEST_BYTES = 32;
+
+function invalid(reason: string): EthPayload {
+  return { kind: 'invalid', reason };
+}
+
+function stripHexPrefix(value: string): string {
+  return value.replace(/^0x/i, '');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+export function classifyEthPayload(
+  signData: string,
+  dataType: number | undefined,
+): EthPayload {
+  const hex = stripHexPrefix(signData);
+  if (!/^([0-9a-fA-F]{2})*$/.test(hex)) {
+    return invalid('Payload is not valid hex data.');
+  }
+  const raw = hexToBytes(hex);
+
+  if (dataType === 1 || dataType === 4) {
+    if (raw.length === 0) {
+      return invalid('Transaction payload is empty.');
+    }
+    if (raw[0] === 0x01) {
+      return { kind: 'tx-eip2930', raw };
+    }
+    if (dataType === 4 && raw[0] === 0x02) {
+      return { kind: 'tx-eip1559', raw };
+    }
+    if (dataType === 1 && raw[0] >= RLP_LIST_MIN) {
+      return { kind: 'tx-legacy', raw };
+    }
+    return invalid(
+      `Unrecognized transaction payload (first byte 0x${raw[0]
+        .toString(16)
+        .padStart(2, '0')}).`,
+    );
+  }
+
+  if (dataType === 3) {
+    return { kind: 'personal-message', raw };
+  }
+
+  if (dataType === 2) {
+    const typedData = parseEip712RawTypedData(signData);
+    if (typedData) {
+      const digest = computeEip712DigestFromJson(
+        typedData.domain,
+        typedData.message,
+        typedData.primaryType,
+        typedData.types,
+      );
+      if (!digest) {
+        return invalid('EIP-712 typed data could not be hashed.');
+      }
+      return { kind: 'eip712-json', typedData, digest };
+    }
+    const prehashed = parseEip712Prehashed(signData);
+    if (prehashed) {
+      return {
+        kind: 'eip712-prehashed',
+        prehashed,
+        digest: computeEip712DigestFromPrehashed(
+          prehashed.domainSeparatorHash,
+          prehashed.messageHash,
+        ),
+      };
+    }
+    if (raw.length === DIGEST_BYTES) {
+      return { kind: 'raw-digest', digest: `0x${hex.toLowerCase()}` };
+    }
+    return invalid(
+      'EIP-712 payload is neither typed-data JSON, a pre-hashed \\x19\\x01 payload, nor a 32-byte digest.',
+    );
+  }
+
+  // dataType 0 / undefined: the payload must already be the 32-byte digest
+  // (WalletConnect typed-data convention — see requestAdapter.handleTypedData).
+  if (raw.length === DIGEST_BYTES) {
+    return { kind: 'raw-digest', digest: `0x${hex.toLowerCase()}` };
+  }
+  return invalid(
+    `Expected a 32-byte digest, got ${raw.length} byte${
+      raw.length === 1 ? '' : 's'
+    }.`,
+  );
+}
+
+/**
+ * The 32-byte digest the Keycard signs for this payload. The review Digests
+ * tab renders the same value, so display and signature cannot diverge.
+ * Throws on 'invalid' — buildSignKeycardParams never routes such a payload
+ * to the Keycard screen.
+ */
+export function signingDigest(payload: EthPayload): Uint8Array {
+  switch (payload.kind) {
+    case 'tx-legacy':
+    case 'tx-eip2930':
+    case 'tx-eip1559':
+      return keccak_256(payload.raw);
+    case 'personal-message': {
+      // EIP-191: keccak256("\x19Ethereum Signed Message:\n{len}{message}")
+      const prefix = `\x19Ethereum Signed Message:\n${payload.raw.length}`;
+      const prefixBytes = new TextEncoder().encode(prefix);
+      const combined = new Uint8Array(prefixBytes.length + payload.raw.length);
+      combined.set(prefixBytes);
+      combined.set(payload.raw, prefixBytes.length);
+      return keccak_256(combined);
+    }
+    case 'eip712-json':
+    case 'eip712-prehashed':
+    case 'raw-digest':
+      return hexToBytes(stripHexPrefix(payload.digest));
+    case 'invalid':
+      throw new Error(`Cannot sign: ${payload.reason}`);
+  }
+}

--- a/src/utils/ethSignature.ts
+++ b/src/utils/ethSignature.ts
@@ -4,6 +4,7 @@ import Keycard from 'keycard-sdk';
 import { hexToBytes } from 'viem';
 
 import { APP_NAME } from '@/constants/app';
+import type { EthPayloadKind } from './ethPayload';
 import { ensureHexPrefix } from './hex';
 
 // ── secp256k1 / Ethereum ─────────────────────────────────────────────────────
@@ -46,31 +47,21 @@ function bytesToHex(bytes: Uint8Array): string {
     .join('');
 }
 
-// Detects EIP-2718 tx type from first byte of signData (0x01=EIP-2930, 0x02=EIP-1559).
-function detectTxType(signData?: string): number | undefined {
-  if (!signData) return undefined;
-  const hex = signData.startsWith('0x') ? signData.slice(2) : signData;
-  const firstByte = parseInt(hex.slice(0, 2), 16);
-  return firstByte === 0x01 || firstByte === 0x02 ? firstByte : undefined;
-}
-
 export function computeEthV(
   recId: number,
-  dataType: number | undefined,
+  kind: EthPayloadKind,
   chainId: number | undefined,
-  txType?: number,
 ): number {
-  if (txType === 0x01 || txType === 0x02) {
+  if (kind === 'invalid') {
+    throw new Error('Cannot compute v for an invalid payload');
+  }
+  if (kind === 'tx-eip2930' || kind === 'tx-eip1559') {
     return recId;
   }
-  switch (dataType) {
-    case 1:
-      return V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
-    case 4:
-      return recId;
-    default:
-      return V_BASE_LEGACY + recId;
+  if (kind === 'tx-legacy') {
+    return V_BASE_EIP155 + 2 * (chainId ?? 0) + recId;
   }
+  return V_BASE_LEGACY + recId;
 }
 
 export function buildRawHexSignature(
@@ -93,43 +84,39 @@ export function buildRawHexSignature(
 export function buildRawEthHexSignature(
   result: Uint8Array,
   hash: Uint8Array,
-  dataType: number | undefined,
+  kind: EthPayloadKind,
   chainId: number | undefined,
-  signData?: string,
 ): string {
   const sig = new Keycard.RecoverableSignature({
     hash,
     tlvData: hexToBytes(ensureHexPrefix(bytesToHex(result))),
   });
-  const v = computeEthV(sig.recId!, dataType, chainId, detectTxType(signData));
+  const v = computeEthV(sig.recId!, kind, chainId);
   return buildRawHexSignature(sig.r!, sig.s!, v);
 }
 
 export function buildEthSignatureURFromResult(
   result: Uint8Array,
   hash: Uint8Array,
-  dataType: number | undefined,
+  kind: EthPayloadKind,
   chainId: number | undefined,
   requestId: string | undefined,
-  signData?: string,
 ): string {
   return buildEthSignatureUR(
     bytesToHex(result),
     hash,
-    dataType,
+    kind,
     chainId,
     requestId,
-    detectTxType(signData),
   );
 }
 
 export function buildEthSignatureUR(
   signRespDataHex: string,
   hash: Uint8Array,
-  dataType: number | undefined,
+  kind: EthPayloadKind,
   chainId: number | undefined,
   requestId: string | undefined,
-  txType?: number,
 ): string {
   const sig = new Keycard.RecoverableSignature({
     hash,
@@ -139,7 +126,7 @@ export function buildEthSignatureUR(
   const recId = sig.recId!;
   const r = pad32(sig.r!);
   const s = pad32(sig.s!);
-  const v = computeEthV(recId, dataType, chainId, txType);
+  const v = computeEthV(recId, kind, chainId);
 
   const sigBytes = new Uint8Array(r.length + s.length + encodeV(v).length);
   sigBytes.set(r, 0);

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-bitwise */
-import { keccak_256 } from '@noble/hashes/sha3.js';
 import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
@@ -29,26 +28,6 @@ type BitcoinDescriptorPlan = {
   parentPath: string;
   scriptType: BitcoinCryptoAccount['descriptors'][number]['scriptType'];
 };
-
-export function prepareSignHash(
-  signData: string,
-  dataType: number | undefined,
-): Uint8Array {
-  const raw = new Uint8Array(Buffer.from(signData.replace(/^0x/i, ''), 'hex'));
-  if (dataType === 1 || dataType === 4) {
-    return keccak_256(raw);
-  }
-  if (dataType === 3) {
-    // EIP-191 personal_sign: keccak256("\x19Ethereum Signed Message:\n{len}{message}")
-    const prefix = `\x19Ethereum Signed Message:\n${raw.length}`;
-    const prefixBytes = new TextEncoder().encode(prefix);
-    const combined = new Uint8Array(prefixBytes.length + raw.length);
-    combined.set(prefixBytes);
-    combined.set(raw, prefixBytes.length);
-    return keccak_256(combined);
-  }
-  return raw;
-}
 
 export function buildExportUr(
   result: ExportKeyResult,

--- a/src/utils/signNavigation.ts
+++ b/src/utils/signNavigation.ts
@@ -1,5 +1,6 @@
 import type { KeycardParams } from '@/navigation/types';
 import type { ScanResult } from '@/types';
+import { classifyEthPayload } from '@/utils/ethPayload';
 
 export function buildSignKeycardParams(
   result: ScanResult,
@@ -7,6 +8,11 @@ export function buildSignKeycardParams(
   if (result.kind === 'eth-sign-request') {
     const { signData, derivationPath, chainId, requestId, dataType } =
       result.request;
+    // An unclassifiable payload must never reach the Keycard screen — the
+    // review shows the reason and the Sign button is withheld.
+    if (classifyEthPayload(signData, dataType).kind === 'invalid') {
+      return null;
+    }
     return {
       operation: 'sign',
       signMode: 'eth',


### PR DESCRIPTION
Closes #234

## Summary

Review and signing previously interpreted `(signData, dataType)` with five different rules and no shared seam — `parseTx` gated the first-byte check on dataType, `detectTxType` sniffed it unconditionally, `prepareSignHash`'s default branch assumed raw bytes were already a hash, and the erc8213 digests were display-only. The digest shown in review was never guaranteed to be the digest signed.

This PR introduces `src/utils/ethPayload.ts` as the single classification:

- `classifyEthPayload(signData, dataType)` → `tx-legacy | tx-eip2930 | tx-eip1559 | personal-message | eip712-json | eip712-prehashed | raw-digest | invalid` (transaction rules mirror `parseTx`'s accept set)
- `signingDigest(payload)` → the 32 bytes the card signs; the review Digests tabs render the same value, so display and signature cannot diverge
- `computeEthV(recId, payload.kind, chainId)` replaces dataType+first-byte sniffing; `detectTxType` and `prepareSignHash` are deleted

Consumers rewired: KeycardScreen, ethSignature builders, signNavigation (invalid → no Sign button), both Eip712 panels, EthSignRequestDetail (cannot-sign banner).

## Behavior changes

- **Full-JSON and pre-hashed EIP-712 requests (`dataType=2`) are now signable** — the card signs the computed EIP-712 digest instead of receiving raw bytes and failing after PIN entry
- **v fix**: a personal message or digest whose first byte happens to be `0x01`/`0x02` no longer flips v from `27 + recId` to `recId` (previously produced an invalid signature)
- **Invalid payloads blocked at review**: unclassifiable requests (e.g. a WalletConnect digest that isn't 32 bytes) show a "cannot be signed" reason and never present a Sign button, instead of failing on hardware after approval

## Test plan

- New `__tests__/ethPayload.test.ts` (37 tests): classification table for every dataType × shape, signing-digest table, `displayed digest === signed bytes` invariant per fixture, adversarial first-byte v regressions — 100% branch coverage
- `ethSignature`, `signNavigation`, `KeycardScreen`, `TransactionDetailScreen`, `EthSignRequestDetail` suites updated; full suite: 1433 passed
- ESLint + Prettier clean