### PR TITLE
fix: bump Gemfile concurrent-ruby pin to >= 1.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,10 @@ ruby ">= 3.1.0"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 7.2.3.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+# 1.3.7+ fixes GHSA-h8w8-99g7-qmvj, GHSA-wv3x-4vxv-whpp, GHSA-6wx8-w4f5-wwcr.
+# The old '< 1.3.4' pin (logger/activesupport build failures) is obsolete:
+# activesupport >= 7.2.3.1 and the explicit 'logger' gem below cover it.
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'


### PR DESCRIPTION
Completes 557de61 (the Dependabot fix PR), which claimed the concurrent-ruby pin change in its commit message but did not include the Gemfile.

Changes `gem 'concurrent-ruby', '< 1.3.4'` to `'>= 1.3.7'`, resolving the three remaining Ruby Dependabot alerts (#29, #30, #31: GHSA-h8w8-99g7-qmvj, GHSA-wv3x-4vxv-whpp, GHSA-6wx8-w4f5-wwcr).

The old `< 1.3.4` pin was the React Native template workaround for activesupport/logger build failures. It is obsolete here: the Gemfile already requires `activesupport >= 7.2.3.1` and declares the `logger` gem explicitly.

Note: no Gemfile.lock in this repo and no macOS in this environment, so `pod install` was not verified; the first iOS build will confirm.
