### PR TITLE
refactor: flow registry for KeycardScreen, tagged operations instead of result duck-typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Ethereum signature `v` is now derived from the classified payload kind instead of sniffing the first byte of the payload: a personal-sign message or EIP-712 digest that happened to start with `0x01`/`0x02` no longer produces an invalid signature (`v = recId` instead of `27 + recId`)
+- Signing a malformed PSBT or failing to encode the result QR now shows an error screen instead of crashing or doing nothing
 - Generated recovery-phrase list: two-digit word numbers (`10.`, `11.`, `12.`) no longer wrap onto a second line on iOS; the number column is now auto-width
 
 ## [1.8.0] - 2026-06-30

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -403,18 +403,6 @@ describe('KeycardScreen', () => {
       expect(resetCall.routes[1].name).toBe('QRResult');
       expect(resetCall.routes[1].params.urString).toMatch(/^ur:crypto-psbt\//i);
     });
-
-    it('does not navigate if result is missing psbtHex', async () => {
-      mockUseKeycardOperation.mockReturnValue({
-        ...hookMock('done'),
-        result: { psbtHex: undefined },
-      });
-      await renderWithMockedHook(btcSignRoute);
-      await act(async () => {
-        jest.advanceTimersByTime(800);
-      });
-      expect(navigation.reset).not.toHaveBeenCalled();
-    });
   });
 
   describe('BTC message sign navigation', () => {
@@ -434,7 +422,10 @@ describe('KeycardScreen', () => {
 
       expect(mockExecute).toHaveBeenCalledTimes(1);
       const signOperation = mockExecute.mock.calls[0][0];
-      const result = await signOperation({ signWithPath });
+      const result = await signOperation(
+        { signWithPath },
+        { setStatus: jest.fn() },
+      );
 
       expect(hashBitcoinMessage).toHaveBeenCalledWith(
         btcMessageSignRoute.params.signDataHex,
@@ -461,18 +452,6 @@ describe('KeycardScreen', () => {
       const resetCall = navigation.reset.mock.calls[0][0];
       expect(resetCall.routes[1].name).toBe('QRResult');
       expect(resetCall.routes[1].params.urString).toBe('ur:btc-signature/mock');
-    });
-
-    it('does not navigate when result is not a Uint8Array (handleBtcMessageSignDone guard)', async () => {
-      mockUseKeycardOperation.mockReturnValue({
-        ...hookMock('done'),
-        result: { psbtHex: 'unexpected' },
-      });
-      await renderWithMockedHook(btcMessageSignRoute);
-      await act(async () => {
-        jest.advanceTimersByTime(800);
-      });
-      expect(navigation.reset).not.toHaveBeenCalled();
     });
   });
 
@@ -536,7 +515,7 @@ describe('KeycardScreen', () => {
       await renderScreen('pin_entry', signRoute);
 
       const signOp = mockExecute.mock.calls[0][0];
-      const result = await signOp({ signWithPath });
+      const result = await signOp({ signWithPath }, { setStatus: jest.fn() });
 
       // signRoute carries a raw 32-byte digest, so the signing digest is the
       // payload bytes themselves (raw-digest passthrough).
@@ -596,18 +575,6 @@ describe('KeycardScreen', () => {
         setStatus,
       );
     });
-
-    it('does not navigate when export result is a Uint8Array (ArrayBuffer guard)', async () => {
-      mockUseKeycardOperation.mockReturnValue({
-        ...hookMock('done'),
-        result: new Uint8Array([1, 2, 3]),
-      });
-      await renderWithMockedHook(ethExportRoute);
-      await act(async () => {
-        jest.advanceTimersByTime(800);
-      });
-      expect(navigation.reset).not.toHaveBeenCalled();
-    });
   });
 
   describe('WalletConnect eth sign done', () => {
@@ -653,22 +620,8 @@ describe('KeycardScreen', () => {
     });
   });
 
-  describe('handleEthSignDone guard', () => {
-    it('does not navigate when result is not a Uint8Array', async () => {
-      mockUseKeycardOperation.mockReturnValue({
-        ...hookMock('done'),
-        result: { unexpected: true },
-      });
-      await renderWithMockedHook(signRoute);
-      await act(async () => {
-        jest.advanceTimersByTime(800);
-      });
-      expect(navigation.reset).not.toHaveBeenCalled();
-    });
-  });
-
   describe('UR build error handling', () => {
-    it('logs console.error when UR building throws inside the 800ms timer', async () => {
+    it('shows a visible error state when UR building throws inside the 800ms timer', async () => {
       const { buildEthSignatureURFromResult } =
         require('../src/utils/ethSignature') as {
           buildEthSignatureURFromResult: jest.Mock;
@@ -677,24 +630,76 @@ describe('KeycardScreen', () => {
         throw new Error('encode failed');
       });
 
-      const consoleSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-
       mockUseKeycardOperation.mockReturnValue({
         ...hookMock('done'),
         result: new Uint8Array(65).fill(0x01),
       });
-      await renderWithMockedHook(signRoute);
+      const view = await renderWithMockedHook(signRoute);
       await act(async () => {
         jest.advanceTimersByTime(800);
       });
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[KeycardScreen] Failed to build UR:',
-        'encode failed',
+      expect(navigation.reset).not.toHaveBeenCalled();
+      expect(
+        view.getByText(/Failed to build the result: encode failed/),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('prepare failure', () => {
+    it('shows the error state and never starts NFC when the PSBT cannot be prepared', async () => {
+      const { BtcSigningSession } = require('../src/utils/btcPsbt') as {
+        BtcSigningSession: jest.Mock;
+      };
+      BtcSigningSession.mockImplementationOnce(() => {
+        throw new Error('Invalid PSBT payload');
+      });
+
+      mockUseKeycardOperation.mockReturnValue(hookMock('idle'));
+      const view = render(
+        <KeycardScreen route={btcSignRoute} navigation={navigation} />,
       );
-      consoleSpy.mockRestore();
+      await act(async () => {});
+
+      expect(mockExecute).not.toHaveBeenCalled();
+      expect(view.getByText('Unable to prepare')).toBeTruthy();
+      expect(view.getByText('Invalid PSBT payload')).toBeTruthy();
+    });
+
+    it('falls back to a generic message when the prepare error has none', async () => {
+      const { BtcSigningSession } = require('../src/utils/btcPsbt') as {
+        BtcSigningSession: jest.Mock;
+      };
+      BtcSigningSession.mockImplementationOnce(() => {
+        throw Object.assign(new Error(), { message: undefined });
+      });
+
+      mockUseKeycardOperation.mockReturnValue(hookMock('idle'));
+      const view = render(
+        <KeycardScreen route={btcSignRoute} navigation={navigation} />,
+      );
+      await act(async () => {});
+
+      expect(view.getByText('Failed to prepare the operation.')).toBeTruthy();
+    });
+
+    it('Go back returns to the previous screen', async () => {
+      const { BtcSigningSession } = require('../src/utils/btcPsbt') as {
+        BtcSigningSession: jest.Mock;
+      };
+      BtcSigningSession.mockImplementationOnce(() => {
+        throw new Error('Invalid PSBT payload');
+      });
+
+      mockUseKeycardOperation.mockReturnValue(hookMock('idle'));
+      const view = render(
+        <KeycardScreen route={btcSignRoute} navigation={navigation} />,
+      );
+      await act(async () => {});
+
+      const { fireEvent } = require('@testing-library/react-native');
+      fireEvent.press(view.getByText('Go back'));
+      expect(navigation.goBack).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/keycardFlows.test.ts
+++ b/__tests__/keycardFlows.test.ts
@@ -1,0 +1,280 @@
+import { XPUB_EXPLAINER } from '../src/constants/exportKey';
+import { signingDigest, classifyEthPayload } from '../src/utils/ethPayload';
+import { prepareKeycardFlow } from '../src/utils/keycardFlows';
+
+jest.mock('../src/utils/ethSignature', () => ({
+  buildEthSignatureURFromResult: jest.fn(() => 'ur:eth-signature/mock'),
+  buildRawEthHexSignature: jest.fn(() => '0xrawsig'),
+}));
+
+jest.mock('../src/utils/btcPsbt', () => ({
+  BtcSigningSession: jest.fn(),
+  buildCryptoPsbtUR: jest.fn(() => 'ur:crypto-psbt/mock'),
+}));
+
+jest.mock('../src/utils/btcMessage', () => ({
+  hashBitcoinMessage: jest.fn(() => new Uint8Array(32).fill(0x77)),
+  parseKeycardBtcMessageSignature: jest.fn(() => ({
+    signature: Buffer.alloc(65, 0x11),
+    publicKey: Buffer.alloc(33, 0x02),
+  })),
+  buildBtcSignatureUR: jest.fn(() => 'ur:btc-signature/mock'),
+}));
+
+jest.mock('../src/utils/keycardExport', () => ({
+  buildExportUr: jest.fn(() => 'ur:crypto-hdkey/mock'),
+  exportKeyForWallet: jest.fn(),
+}));
+
+const {
+  buildEthSignatureURFromResult,
+  buildRawEthHexSignature,
+} = require('../src/utils/ethSignature');
+const {
+  BtcSigningSession,
+  buildCryptoPsbtUR,
+} = require('../src/utils/btcPsbt');
+const {
+  hashBitcoinMessage,
+  parseKeycardBtcMessageSignature,
+  buildBtcSignatureUR,
+} = require('../src/utils/btcMessage');
+const {
+  buildExportUr,
+  exportKeyForWallet,
+} = require('../src/utils/keycardExport');
+
+const DIGEST_HEX = 'ab'.repeat(32);
+
+const ethParams = {
+  operation: 'sign',
+  signMode: 'eth',
+  signData: DIGEST_HEX,
+  dataType: 2,
+  derivationPath: "m/44'/60'/0'/0",
+  chainId: 1,
+  requestId: 'req-1',
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  buildEthSignatureURFromResult.mockReturnValue('ur:eth-signature/mock');
+  buildRawEthHexSignature.mockReturnValue('0xrawsig');
+  buildCryptoPsbtUR.mockReturnValue('ur:crypto-psbt/mock');
+  hashBitcoinMessage.mockReturnValue(new Uint8Array(32).fill(0x77));
+  buildBtcSignatureUR.mockReturnValue('ur:btc-signature/mock');
+  buildExportUr.mockReturnValue('ur:crypto-hdkey/mock');
+});
+
+describe('eth sign flow', () => {
+  it('cardOp signs the classified payload digest with the derivation path', async () => {
+    const flowRun = prepareKeycardFlow(ethParams);
+    const checkOK = jest.fn();
+    const signWithPath = jest.fn().mockResolvedValue({
+      checkOK,
+      data: new Uint8Array([0xde, 0xad]),
+    });
+
+    const result = await flowRun.cardOp({ signWithPath } as any, jest.fn());
+
+    const expectedHash = signingDigest(
+      classifyEthPayload(ethParams.signData, ethParams.dataType),
+    );
+    expect(signWithPath).toHaveBeenCalledWith(
+      expectedHash,
+      ethParams.derivationPath,
+      false,
+    );
+    expect(checkOK).toHaveBeenCalled();
+    expect(result).toEqual(new Uint8Array([0xde, 0xad]));
+  });
+
+  it('buildOutput returns a UR outcome wired to the same classification', () => {
+    const flowRun = prepareKeycardFlow(ethParams);
+    const cardResult = new Uint8Array(65).fill(0x01);
+
+    const outcome = flowRun.buildOutput(cardResult);
+
+    const expectedHash = signingDigest(
+      classifyEthPayload(ethParams.signData, ethParams.dataType),
+    );
+    expect(buildEthSignatureURFromResult).toHaveBeenCalledWith(
+      cardResult,
+      expectedHash,
+      'raw-digest',
+      ethParams.chainId,
+      ethParams.requestId,
+    );
+    expect(outcome).toEqual({
+      kind: 'ur',
+      urString: 'ur:eth-signature/mock',
+      title: 'Show signature to the wallet',
+      doneNavigation: 'sign',
+    });
+  });
+
+  it('buildOutput returns a wc-signature outcome when wcContext is present', () => {
+    const flowRun = prepareKeycardFlow({
+      ...ethParams,
+      wcContext: { id: 1, topic: 't' },
+    });
+    const cardResult = new Uint8Array(65).fill(0x02);
+
+    const outcome = flowRun.buildOutput(cardResult);
+
+    expect(buildRawEthHexSignature).toHaveBeenCalledWith(
+      cardResult,
+      expect.any(Uint8Array),
+      'raw-digest',
+      ethParams.chainId,
+    );
+    expect(outcome).toEqual({ kind: 'wc-signature', rawSig: '0xrawsig' });
+    expect(buildEthSignatureURFromResult).not.toHaveBeenCalled();
+  });
+
+  it('prepare throws for a payload that classifies as invalid', () => {
+    expect(() =>
+      prepareKeycardFlow({ ...ethParams, signData: 'ab'.repeat(31) }),
+    ).toThrow(/Cannot sign/);
+  });
+});
+
+describe('btc PSBT flow', () => {
+  it('prepare constructs the signing session before NFC and throws on a malformed PSBT', () => {
+    BtcSigningSession.mockImplementationOnce(() => {
+      throw new Error('Invalid PSBT payload');
+    });
+    expect(() =>
+      prepareKeycardFlow({
+        operation: 'sign',
+        signMode: 'btc',
+        psbtHex: 'not-a-psbt',
+      } as any),
+    ).toThrow('Invalid PSBT payload');
+    expect(BtcSigningSession).toHaveBeenCalledWith('not-a-psbt');
+  });
+
+  it('cardOp signs with the prepared session; buildOutput encodes the signed PSBT', async () => {
+    const signWithKeycard = jest
+      .fn()
+      .mockResolvedValue({ psbtHex: 'signed-hex' });
+    BtcSigningSession.mockImplementationOnce(() => ({ signWithKeycard }));
+
+    const flowRun = prepareKeycardFlow({
+      operation: 'sign',
+      signMode: 'btc',
+      psbtHex: 'deadbeef',
+    } as any);
+
+    const setStatus = jest.fn();
+    const cmdSet = {} as any;
+    const result = await flowRun.cardOp(cmdSet, setStatus);
+    expect(signWithKeycard).toHaveBeenCalledWith(cmdSet, setStatus);
+    expect(result).toEqual({ psbtHex: 'signed-hex' });
+
+    const outcome = flowRun.buildOutput(result);
+    expect(buildCryptoPsbtUR).toHaveBeenCalledWith('signed-hex');
+    expect(outcome).toEqual({
+      kind: 'ur',
+      urString: 'ur:crypto-psbt/mock',
+      title: 'Show signature to the wallet',
+      doneNavigation: 'sign',
+    });
+  });
+});
+
+describe('btc message flow', () => {
+  const params = {
+    operation: 'sign',
+    signMode: 'btc-message',
+    requestId: 'req-2',
+    signDataHex: 'cafebabe',
+    derivationPath: "m/84'/0'/0'/0/3",
+  } as any;
+
+  it('hashes at prepare time and signs the hash with the requested path', async () => {
+    const flowRun = prepareKeycardFlow(params);
+    expect(hashBitcoinMessage).toHaveBeenCalledWith('cafebabe');
+
+    const checkOK = jest.fn();
+    const signWithPath = jest.fn().mockResolvedValue({
+      checkOK,
+      data: new Uint8Array([0x99]),
+    });
+    await flowRun.cardOp({ signWithPath } as any, jest.fn());
+
+    expect(signWithPath).toHaveBeenCalledWith(
+      new Uint8Array(32).fill(0x77),
+      params.derivationPath,
+      false,
+    );
+    expect(checkOK).toHaveBeenCalled();
+  });
+
+  it('buildOutput parses the keycard signature against the prepared hash', () => {
+    const flowRun = prepareKeycardFlow(params);
+    const cardResult = new Uint8Array([0x99]);
+
+    const outcome = flowRun.buildOutput(cardResult);
+
+    expect(parseKeycardBtcMessageSignature).toHaveBeenCalledWith(
+      new Uint8Array(32).fill(0x77),
+      cardResult,
+    );
+    expect(buildBtcSignatureUR).toHaveBeenCalledWith({
+      requestId: 'req-2',
+      signature: Buffer.alloc(65, 0x11),
+      publicKey: Buffer.alloc(33, 0x02),
+    });
+    expect(outcome).toEqual({
+      kind: 'ur',
+      urString: 'ur:btc-signature/mock',
+      title: 'Show signature to the wallet',
+      doneNavigation: 'sign',
+    });
+  });
+});
+
+describe('export key flow', () => {
+  const params = {
+    operation: 'export_key',
+    derivationPath: "m/44'/60'/0'",
+    source: 'MetaMask',
+  } as any;
+
+  it('cardOp delegates to exportKeyForWallet with the derivation path', async () => {
+    const exportResult = { exportRespData: new Uint8Array([1]) };
+    exportKeyForWallet.mockResolvedValue(exportResult);
+
+    const flowRun = prepareKeycardFlow(params);
+    const setStatus = jest.fn();
+    const cmdSet = {} as any;
+
+    await expect(flowRun.cardOp(cmdSet, setStatus)).resolves.toBe(exportResult);
+    expect(exportKeyForWallet).toHaveBeenCalledWith(
+      cmdSet,
+      params.derivationPath,
+      setStatus,
+    );
+  });
+
+  it('buildOutput builds the export UR with the xpub explainer and export navigation', () => {
+    const flowRun = prepareKeycardFlow(params);
+    const exportResult = { exportRespData: new Uint8Array([1]) };
+
+    const outcome = flowRun.buildOutput(exportResult);
+
+    expect(buildExportUr).toHaveBeenCalledWith(
+      exportResult,
+      params.derivationPath,
+      params.source,
+    );
+    expect(outcome).toEqual({
+      kind: 'ur',
+      urString: 'ur:crypto-hdkey/mock',
+      title: 'Show key to the wallet',
+      description: XPUB_EXPLAINER,
+      doneNavigation: 'export',
+    });
+  });
+});

--- a/src/screens/KeycardScreen.tsx
+++ b/src/screens/KeycardScreen.tsx
@@ -1,32 +1,24 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { XPUB_EXPLAINER } from '../constants/exportKey';
 import type { KeycardScreenProps } from '../navigation/types';
 import theme from '../theme';
 
 import NFCBottomSheet from '../components/NFCBottomSheet';
+import PrimaryButton from '../components/PrimaryButton';
 
 import { useKeycardOperation } from '../hooks/keycard/useKeycardOperation';
 import { useWalletConnectSession } from '../hooks/useWalletConnectSession.online';
 
-import {
-  buildBtcSignatureUR,
-  hashBitcoinMessage,
-  parseKeycardBtcMessageSignature,
-} from '../utils/btcMessage';
-import { BtcSigningSession, buildCryptoPsbtUR } from '../utils/btcPsbt';
-import { classifyEthPayload, signingDigest } from '../utils/ethPayload';
-import {
-  buildEthSignatureURFromResult,
-  buildRawEthHexSignature,
-} from '../utils/ethSignature';
-import {
-  buildExportUr,
-  exportKeyForWallet,
-  type ExportKeyResult,
-} from '../utils/keycardExport';
+import { prepareKeycardFlow, type KeycardFlowRun } from '../utils/keycardFlows';
 
 export default function KeycardScreen({
   route,
@@ -34,10 +26,11 @@ export default function KeycardScreen({
 }: KeycardScreenProps) {
   const params = route.params;
   const insets = useSafeAreaInsets();
-  const hashRef = useRef<Uint8Array | null>(null);
-  const btcSessionRef = useRef<BtcSigningSession | null>(null);
-  const respondedRef = useRef(false);
+  const flowRef = useRef<KeycardFlowRun | null>(null);
+  const [flowError, setFlowError] = useState<string | null>(null);
 
+  // respondSuccess/respondError are idempotent behind the provider's
+  // interface — a second call for the same request is a no-op.
   const { respondSuccess, respondError } = useWalletConnectSession();
 
   const wcContext =
@@ -45,260 +38,83 @@ export default function KeycardScreen({
       ? params.wcContext
       : undefined;
 
-  const keycard = useKeycardOperation<
-    ExportKeyResult | { psbtHex: string } | Uint8Array
-  >();
+  const keycard = useKeycardOperation<unknown>();
   const { phase, result, execute, cancel } = keycard;
 
   const resetToDashboard = useCallback(() => {
     navigation.reset({ index: 0, routes: [{ name: 'Dashboard' }] });
   }, [navigation]);
 
-  const handleSign = useCallback(() => {
-    if (params.operation !== 'sign') {
-      return;
+  // Prepare the flow (all heavy local work, before NFC) and start the card
+  // operation. A prepare failure — e.g. an unparseable PSBT — becomes a
+  // visible error state instead of opening the PIN pad.
+  useEffect(() => {
+    try {
+      const flowRun = prepareKeycardFlow(params);
+      flowRef.current = flowRun;
+      execute((cmdSet, { setStatus }) => flowRun.cardOp(cmdSet, setStatus));
+    } catch (e: any) {
+      setFlowError(e?.message ?? 'Failed to prepare the operation.');
     }
-
-    if (params.signMode === 'eth') {
-      const payload = classifyEthPayload(params.signData, params.dataType);
-      if (payload.kind === 'invalid') {
-        // buildSignKeycardParams never routes invalid payloads here.
-        return;
-      }
-      const hash = signingDigest(payload);
-      hashRef.current = hash;
-
-      execute(async cmdSet => {
-        const signResp = await cmdSet.signWithPath(
-          hash,
-          params.derivationPath,
-          false,
-        );
-        signResp.checkOK();
-        return signResp.data;
-      });
-      return;
-    }
-
-    if (params.signMode === 'btc-message') {
-      const hash = hashBitcoinMessage(params.signDataHex);
-      hashRef.current = hash;
-
-      execute(async cmdSet => {
-        const signResp = await cmdSet.signWithPath(
-          hash,
-          params.derivationPath,
-          false,
-        );
-        signResp.checkOK();
-        return signResp.data;
-      });
-      return;
-    }
-
-    if (!btcSessionRef.current) {
-      btcSessionRef.current = new BtcSigningSession(params.psbtHex);
-    }
-
-    execute(async (cmdSet, { setStatus }) => {
-      const signed = await btcSessionRef.current!.signWithKeycard(
-        cmdSet,
-        setStatus,
-      );
-      return { psbtHex: signed.psbtHex };
-    });
-  }, [execute, params]);
-
-  const handleExportKey = useCallback(() => {
-    if (params.operation !== 'export_key') {
-      return;
-    }
-
-    execute(
-      (cmdSet, { setStatus }) =>
-        exportKeyForWallet(cmdSet, params.derivationPath, setStatus),
-      { requiresPin: true },
-    );
   }, [execute, params]);
 
   useEffect(() => {
-    if (params.operation === 'sign') {
-      handleSign();
-    } else if (params.operation === 'export_key') {
-      handleExportKey();
+    if (phase !== 'done' || result == null || !flowRef.current) {
+      return;
     }
-  }, [handleExportKey, handleSign, params.operation]);
+    const flowRun = flowRef.current;
 
-  const navigateToSignResult = useCallback(
-    (urString: string) => {
+    const timer = setTimeout(() => {
+      let outcome;
+      try {
+        outcome = flowRun.buildOutput(result);
+      } catch (e: any) {
+        setFlowError(
+          `Failed to build the result: ${e?.message ?? 'unknown error'}`,
+        );
+        return;
+      }
+
+      if (outcome.kind === 'wc-signature') {
+        respondSuccess(wcContext!, outcome.rawSig).finally(() =>
+          resetToDashboard(),
+        );
+        return;
+      }
+
+      if (outcome.doneNavigation === 'export') {
+        navigation.reset({
+          index: 2,
+          routes: [
+            { name: 'Dashboard' },
+            { name: 'ExportKey' },
+            {
+              name: 'QRResult',
+              params: {
+                urString: outcome.urString,
+                title: outcome.title,
+                description: outcome.description,
+              },
+            },
+          ],
+        });
+        return;
+      }
+
       navigation.reset({
         index: 1,
         routes: [
           { name: 'QRScanner' },
           {
             name: 'QRResult',
-            params: { urString, title: 'Show signature to the wallet' },
+            params: { urString: outcome.urString, title: outcome.title },
           },
         ],
       });
-    },
-    [navigation],
-  );
-
-  const navigateToExportResult = useCallback(
-    (urString: string) => {
-      navigation.reset({
-        index: 2,
-        routes: [
-          { name: 'Dashboard' },
-          { name: 'ExportKey' },
-          {
-            name: 'QRResult',
-            params: {
-              urString,
-              title: 'Show key to the wallet',
-              description: XPUB_EXPLAINER,
-            },
-          },
-        ],
-      });
-    },
-    [navigation],
-  );
-
-  const handleEthSignDone = useCallback(() => {
-    if (!hashRef.current || !(result instanceof Uint8Array)) {
-      return;
-    }
-
-    const p = params as {
-      dataType?: number;
-      chainId?: number;
-      requestId?: string;
-      signData?: string;
-    };
-    const payload = classifyEthPayload(p.signData ?? '', p.dataType);
-    if (payload.kind === 'invalid') {
-      return;
-    }
-
-    if (wcContext && !respondedRef.current) {
-      respondedRef.current = true;
-      const rawSig = buildRawEthHexSignature(
-        result,
-        hashRef.current,
-        payload.kind,
-        p.chainId,
-      );
-      respondSuccess(wcContext, rawSig).finally(() => resetToDashboard());
-      return;
-    }
-
-    navigateToSignResult(
-      buildEthSignatureURFromResult(
-        result,
-        hashRef.current,
-        payload.kind,
-        p.chainId,
-        p.requestId,
-      ),
-    );
-  }, [
-    result,
-    params,
-    wcContext,
-    respondSuccess,
-    resetToDashboard,
-    navigateToSignResult,
-  ]);
-
-  const handleBtcSignDone = useCallback(() => {
-    if (
-      !result ||
-      !('psbtHex' in result) ||
-      typeof result.psbtHex !== 'string' ||
-      result.psbtHex.length === 0
-    ) {
-      return;
-    }
-    navigateToSignResult(buildCryptoPsbtUR(result.psbtHex));
-  }, [result, navigateToSignResult]);
-
-  const handleBtcMessageSignDone = useCallback(() => {
-    if (
-      params.operation !== 'sign' ||
-      params.signMode !== 'btc-message' ||
-      !hashRef.current ||
-      !(result instanceof Uint8Array)
-    ) {
-      return;
-    }
-
-    const parsed = parseKeycardBtcMessageSignature(hashRef.current, result);
-    navigateToSignResult(
-      buildBtcSignatureUR({
-        requestId: params.requestId,
-        signature: parsed.signature,
-        publicKey: parsed.publicKey,
-      }),
-    );
-  }, [result, params, navigateToSignResult]);
-
-  const handleExportKeyDone = useCallback(() => {
-    if (
-      !result ||
-      ArrayBuffer.isView(result) ||
-      !(
-        'exportRespData' in result ||
-        'descriptors' in result ||
-        'keys' in result
-      )
-    ) {
-      return;
-    }
-    navigateToExportResult(
-      buildExportUr(
-        result,
-        (params as { derivationPath: string; source?: string }).derivationPath,
-        (params as { derivationPath: string; source?: string }).source,
-      ),
-    );
-  }, [result, params, navigateToExportResult]);
-
-  useEffect(() => {
-    if (phase !== 'done' || !result) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      try {
-        if (params.operation === 'sign' && params.signMode === 'eth') {
-          handleEthSignDone();
-        } else if (params.operation === 'sign' && params.signMode === 'btc') {
-          handleBtcSignDone();
-        } else if (
-          params.operation === 'sign' &&
-          params.signMode === 'btc-message'
-        ) {
-          handleBtcMessageSignDone();
-        } else if (params.operation === 'export_key') {
-          handleExportKeyDone();
-        }
-      } catch (e: any) {
-        console.error('[KeycardScreen] Failed to build UR:', e.message);
-      }
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [
-    phase,
-    result,
-    params,
-    handleEthSignDone,
-    handleBtcSignDone,
-    handleBtcMessageSignDone,
-    handleExportKeyDone,
-  ]);
+  }, [phase, result, navigation, wcContext, respondSuccess, resetToDashboard]);
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'Enter Keycard PIN' });
@@ -306,8 +122,7 @@ export default function KeycardScreen({
 
   const handleCancel = useCallback(async () => {
     cancel();
-    if (wcContext && !respondedRef.current) {
-      respondedRef.current = true;
+    if (wcContext) {
       try {
         await respondError(wcContext, 4001, 'User rejected');
       } catch {
@@ -319,7 +134,24 @@ export default function KeycardScreen({
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      {flowError !== null ? (
+        <View style={styles.errorContainer}>
+          <Text variant="titleMedium" style={styles.errorTitle}>
+            Unable to prepare
+          </Text>
+          <Text variant="bodyMedium" style={styles.errorMessage}>
+            {flowError}
+          </Text>
+          <View style={styles.errorAction}>
+            <PrimaryButton
+              label="Go back"
+              onPress={() => navigation.goBack()}
+            />
+          </View>
+        </View>
+      ) : (
+        <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      )}
     </View>
   );
 }
@@ -328,5 +160,22 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  errorTitle: {
+    color: theme.colors.error,
+    textAlign: 'center',
+  },
+  errorMessage: {
+    color: theme.colors.onSurfaceVariant,
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  errorAction: {
+    marginTop: 24,
   },
 });

--- a/src/utils/keycardFlows.ts
+++ b/src/utils/keycardFlows.ts
@@ -1,0 +1,197 @@
+import type { Commandset } from 'keycard-sdk/dist/commandset';
+
+import { XPUB_EXPLAINER } from '@/constants/exportKey';
+import type { KeycardParams } from '@/navigation/types';
+
+import {
+  buildBtcSignatureUR,
+  hashBitcoinMessage,
+  parseKeycardBtcMessageSignature,
+} from './btcMessage';
+import { BtcSigningSession, buildCryptoPsbtUR } from './btcPsbt';
+import { classifyEthPayload, signingDigest } from './ethPayload';
+import {
+  buildEthSignatureURFromResult,
+  buildRawEthHexSignature,
+} from './ethSignature';
+import { buildExportUr, exportKeyForWallet } from './keycardExport';
+
+/**
+ * What happens after the card operation succeeds. 'ur' outcomes navigate to
+ * QRResult (via the sign or export reset stack); 'wc-signature' outcomes are
+ * responded to the WalletConnect relay instead of showing a QR.
+ */
+export type FlowOutcome =
+  | {
+      kind: 'ur';
+      urString: string;
+      title: string;
+      description?: string;
+      doneNavigation: 'sign' | 'export';
+    }
+  | { kind: 'wc-signature'; rawSig: string };
+
+/**
+ * One Keycard operation, prepared and ready to run: the card op and the
+ * completion that consumes its result are created together as a closure pair
+ * over the same narrowed params, so they can never disagree about what the
+ * result means — no shape-sniffing, no casts at the consumer.
+ */
+export type KeycardFlowRun = {
+  cardOp: (
+    cmdSet: Commandset,
+    setStatus: (status: string) => void,
+  ) => Promise<unknown>;
+  buildOutput: (result: unknown) => FlowOutcome;
+};
+
+// Internal helper: ties cardOp's result type to buildOutput's input type,
+// then erases it for the generic executor.
+function flow<R>(run: {
+  cardOp: (
+    cmdSet: Commandset,
+    setStatus: (status: string) => void,
+  ) => Promise<R>;
+  buildOutput: (result: R) => FlowOutcome;
+}): KeycardFlowRun {
+  return run as KeycardFlowRun;
+}
+
+const SIGN_RESULT_TITLE = 'Show signature to the wallet';
+
+type EthSignParams = Extract<
+  KeycardParams,
+  { operation: 'sign'; signMode: 'eth' }
+>;
+type BtcPsbtParams = Extract<
+  KeycardParams,
+  { operation: 'sign'; signMode: 'btc' }
+>;
+type BtcMessageParams = Extract<
+  KeycardParams,
+  { operation: 'sign'; signMode: 'btc-message' }
+>;
+type ExportKeyParams = Extract<KeycardParams, { operation: 'export_key' }>;
+
+function prepareEthSign(params: EthSignParams): KeycardFlowRun {
+  const payload = classifyEthPayload(params.signData, params.dataType);
+  // signingDigest throws on 'invalid' with the classification reason —
+  // buildSignKeycardParams withholds the Sign button for these, so this is
+  // a belt-and-braces guard, surfaced as a prepare error.
+  const hash = signingDigest(payload);
+  return flow<Uint8Array>({
+    cardOp: async cmdSet => {
+      const signResp = await cmdSet.signWithPath(
+        hash,
+        params.derivationPath,
+        false,
+      );
+      signResp.checkOK();
+      return signResp.data;
+    },
+    buildOutput: result => {
+      if (params.wcContext) {
+        return {
+          kind: 'wc-signature',
+          rawSig: buildRawEthHexSignature(
+            result,
+            hash,
+            payload.kind,
+            params.chainId,
+          ),
+        };
+      }
+      return {
+        kind: 'ur',
+        urString: buildEthSignatureURFromResult(
+          result,
+          hash,
+          payload.kind,
+          params.chainId,
+          params.requestId,
+        ),
+        title: SIGN_RESULT_TITLE,
+        doneNavigation: 'sign',
+      };
+    },
+  });
+}
+
+function prepareBtcPsbtSign(params: BtcPsbtParams): KeycardFlowRun {
+  // Throws on a malformed PSBT — the review keeps its Sign button on
+  // unparseable PSBTs by design, so this is the path that catches them.
+  const session = new BtcSigningSession(params.psbtHex);
+  return flow<{ psbtHex: string }>({
+    cardOp: async (cmdSet, setStatus) => {
+      const signed = await session.signWithKeycard(cmdSet, setStatus);
+      return { psbtHex: signed.psbtHex };
+    },
+    buildOutput: result => ({
+      kind: 'ur',
+      urString: buildCryptoPsbtUR(result.psbtHex),
+      title: SIGN_RESULT_TITLE,
+      doneNavigation: 'sign',
+    }),
+  });
+}
+
+function prepareBtcMessageSign(params: BtcMessageParams): KeycardFlowRun {
+  const hash = hashBitcoinMessage(params.signDataHex);
+  return flow<Uint8Array>({
+    cardOp: async cmdSet => {
+      const signResp = await cmdSet.signWithPath(
+        hash,
+        params.derivationPath,
+        false,
+      );
+      signResp.checkOK();
+      return signResp.data;
+    },
+    buildOutput: result => {
+      const parsed = parseKeycardBtcMessageSignature(hash, result);
+      return {
+        kind: 'ur',
+        urString: buildBtcSignatureUR({
+          requestId: params.requestId,
+          signature: parsed.signature,
+          publicKey: parsed.publicKey,
+        }),
+        title: SIGN_RESULT_TITLE,
+        doneNavigation: 'sign',
+      };
+    },
+  });
+}
+
+function prepareExportKey(params: ExportKeyParams): KeycardFlowRun {
+  return flow<Awaited<ReturnType<typeof exportKeyForWallet>>>({
+    cardOp: (cmdSet, setStatus) =>
+      exportKeyForWallet(cmdSet, params.derivationPath, setStatus),
+    buildOutput: result => ({
+      kind: 'ur',
+      urString: buildExportUr(result, params.derivationPath, params.source),
+      title: 'Show key to the wallet',
+      description: XPUB_EXPLAINER,
+      doneNavigation: 'export',
+    }),
+  });
+}
+
+/**
+ * Prepare the flow for a Keycard route: all heavy local work (payload
+ * classification, hashing, PSBT parsing) happens here, BEFORE the NFC prompt
+ * opens. Throws when the payload cannot be prepared — callers surface the
+ * error instead of opening the PIN pad.
+ */
+export function prepareKeycardFlow(params: KeycardParams): KeycardFlowRun {
+  if (params.operation === 'export_key') {
+    return prepareExportKey(params);
+  }
+  if (params.signMode === 'eth') {
+    return prepareEthSign(params);
+  }
+  if (params.signMode === 'btc-message') {
+    return prepareBtcMessageSign(params);
+  }
+  return prepareBtcPsbtSign(params);
+}


### PR DESCRIPTION
Closes #235

## Summary

KeycardScreen knew the operation kind at `execute()` time and threw that knowledge away — on `phase === 'done'` it reconstructed it by shape-sniffing an untagged result union (`instanceof Uint8Array`, `'psbtHex' in result`, `'exportRespData' in result`), across three separate dispatch sites. A params/result disagreement was a silent dead end, and adding a signable kind touched ~7 files.

New `src/utils/keycardFlows.ts`: `prepareKeycardFlow(params)` narrows the `KeycardParams` union once and returns a `{ cardOp, buildOutput }` closure pair — the operation and the completion that consumes its result are created together over the same narrowed params, so they cannot disagree. All heavy local work (payload classification, hashing, `BtcSigningSession` construction) happens in prepare, **before the NFC prompt opens**, per the tap-window rule.

KeycardScreen shrinks to a generic executor: prepare (catch -> error state) -> execute -> buildOutput -> navigate or respond to WalletConnect. Gone: both dispatch towers, all four duck-typed guards, the `params as` casts, `hashRef`/`btcSessionRef`, and the screen's duplicate `respondedRef` (the WC provider's respond functions are already idempotent behind their interface).

## Fixed along the way

- **Malformed PSBT no longer crashes**: the review keeps its Sign button on unparseable PSBTs by design; tapping it previously threw uncaught inside an effect (`new BtcSigningSession`). Now prepare fails visibly — "Unable to prepare" + Go back — before the PIN pad.
- **UR-encoding failures are visible**: a throw while building the result QR after a successful card signature was swallowed by `console.error`, leaving the user stuck on a success sheet. Now it renders the same error state.

## Test plan

- New `__tests__/keycardFlows.test.ts` (10 tests): each flow tested as a plain object without rendering — prepare-throw on malformed PSBT and invalid eth payloads, cardOp wiring against a fake cmdSet, buildOutput pairing (UR and WC outcomes)
- Screen suite: four obsolete shape-mismatch guard tests removed (those states are now unrepresentable), error-state and prepare-failure tests added
- Coverage: `keycardFlows.ts` 100% branch, `KeycardScreen.tsx` 95% branch; full suite 1442 passed, ESLint + Prettier clean

## Notes

- #238 (ExportTarget table) now only needs to swap the export flow entry's internals
- Depends on #234's `EthPayload` classification (already on main)
