### PR TITLE
refactor: one phase vocabulary, typed NFCBottomSheet phase, no pairing-slots rename cycle

### DIFF
--- a/__tests__/NFCBottomSheet.test.tsx
+++ b/__tests__/NFCBottomSheet.test.tsx
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import NFCBottomSheet from '../src/components/NFCBottomSheet';
 import type { NFCOperation } from '../src/components/NFCBottomSheet';
+import type { KeycardPhase } from '../src/hooks/keycard/useKeycardOperation';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,7 +34,7 @@ jest.mock('../src/components/PinPad', () => {
 const onCancel = jest.fn();
 
 function makeNfc(
-  phase: string,
+  phase: KeycardPhase,
   extra: Partial<NFCOperation> = {},
 ): NFCOperation {
   return { phase, status: 'Ready', ...extra };

--- a/__tests__/PairingSlotsScreen.test.tsx
+++ b/__tests__/PairingSlotsScreen.test.tsx
@@ -142,7 +142,7 @@ function makeCheckHook(
 ) {
   return {
     phase,
-    status: phase === 'checking' ? 'Selecting applet...' : '',
+    status: phase === 'nfc' ? 'Selecting applet...' : '',
     slotInfo,
     checkSlots: mockCheckSlots,
     cancel: mockCancel,
@@ -210,7 +210,7 @@ describe('PairingSlotsScreen', () => {
         ourSlotIndex: 3,
         cardUid: 'abcd',
       };
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       expect(mockCheckSlots).not.toHaveBeenCalled();
     });
   });
@@ -222,7 +222,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('passes check hook to NFCBottomSheet', () => {
-      renderScreen('checking');
+      renderScreen('nfc');
       const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
       expect(lastCall?.[0].nfc.phase).toBe('nfc');
       expect(lastCall?.[0].showOnDone).toBe(false);
@@ -252,20 +252,20 @@ describe('PairingSlotsScreen', () => {
     };
 
     it('renders slot summary', () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       expect(screen.getByText('Slots free')).toBeTruthy();
       expect(screen.getByText('7 / 10')).toBeTruthy();
     });
 
     it('renders all 10 slots with 1-based numbering', () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       for (let i = 0; i < 10; i++) {
         expect(screen.getByText(`Slot ${i + 1}`)).toBeTruthy();
       }
     });
 
     it('marks our slot as This device', () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       expect(screen.getByText('This device')).toBeTruthy();
     });
   });
@@ -279,14 +279,14 @@ describe('PairingSlotsScreen', () => {
     };
 
     it('shows ConfirmPrompt with correct slot number when a row is pressed', () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 1'));
       expect(screen.getByText('Unpair slot 1?')).toBeTruthy();
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
     it('executes unpair after user confirms', async () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 3'));
       await act(async () => {
         fireEvent.press(screen.getByText('Unpair'));
@@ -295,7 +295,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('returns to slot list when user cancels confirmation', () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 3'));
       fireEvent.press(screen.getByText('Cancel'));
       expect(mockExecute).not.toHaveBeenCalled();
@@ -303,7 +303,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('deletes local pairing when unpairing our own slot', async () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       // ourSlotIndex is 3, so Slot 4 (1-based) is our slot
       fireEvent.press(screen.getByText('Slot 4'));
       await act(async () => {
@@ -317,7 +317,7 @@ describe('PairingSlotsScreen', () => {
 
     it('keeps unpair success path when local pairing cleanup fails', async () => {
       mockDeletePairing.mockRejectedValueOnce(new Error('storage failed'));
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
 
       fireEvent.press(screen.getByText('Slot 4'));
       await act(async () => {
@@ -330,7 +330,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('does not delete local pairing when unpairing another slot', async () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 1'));
       await act(async () => {
         fireEvent.press(screen.getByText('Unpair'));
@@ -342,7 +342,7 @@ describe('PairingSlotsScreen', () => {
 
   describe('unpairing state', () => {
     it('passes unpair hook to NFCBottomSheet with showOnDone', () => {
-      renderScreen('ready', null, 'nfc');
+      renderScreen('done', null, 'nfc');
       const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
       expect(lastCall?.[0].nfc.phase).toBe('nfc');
       expect(lastCall?.[0].showOnDone).toBe(true);
@@ -351,7 +351,7 @@ describe('PairingSlotsScreen', () => {
 
   describe('cancel NFC', () => {
     it('calls cancelCheck when cancelling during slot check', () => {
-      renderScreen('checking');
+      renderScreen('nfc');
       const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
       lastCall?.[0].onCancel();
       expect(mockCancel).toHaveBeenCalled();
@@ -359,7 +359,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('calls cancelUnpair when cancelling during unpair', () => {
-      renderScreen('ready', null, 'nfc');
+      renderScreen('done', null, 'nfc');
       const lastCall = MockNFCBottomSheet.mock.calls.at(-1);
       lastCall?.[0].onCancel();
       expect(mockUnpairCancel).toHaveBeenCalled();
@@ -379,7 +379,7 @@ describe('PairingSlotsScreen', () => {
       const mockResetNFCOnly = jest.fn();
       const mockResetUnpair = jest.fn();
       mockUsePairingSlots.mockReturnValue({
-        ...makeCheckHook('ready', slotInfo),
+        ...makeCheckHook('done', slotInfo),
         resetNFCOnly: mockResetNFCOnly,
       });
       mockUseKeycardOperation.mockReturnValue({
@@ -391,7 +391,7 @@ describe('PairingSlotsScreen', () => {
       );
 
       mockUsePairingSlots.mockReturnValue({
-        ...makeCheckHook('ready', slotInfo),
+        ...makeCheckHook('done', slotInfo),
         resetNFCOnly: mockResetNFCOnly,
       });
       mockUseKeycardOperation.mockReturnValue({
@@ -416,7 +416,7 @@ describe('PairingSlotsScreen', () => {
     };
 
     it('shows snackbar with slot number after unpair operation runs', async () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 2'));
       await act(async () => {
         fireEvent.press(screen.getByText('Unpair'));
@@ -425,7 +425,7 @@ describe('PairingSlotsScreen', () => {
     });
 
     it('hides snackbar when dismissed', async () => {
-      renderScreen('ready', slotInfo);
+      renderScreen('done', slotInfo);
       fireEvent.press(screen.getByText('Slot 2'));
       await act(async () => {
         fireEvent.press(screen.getByText('Unpair'));

--- a/__tests__/usePairingSlots.test.ts
+++ b/__tests__/usePairingSlots.test.ts
@@ -89,12 +89,12 @@ describe('usePairingSlots', () => {
   });
 
   describe('checkSlots', () => {
-    it('transitions to checking and calls startNFC', async () => {
+    it('transitions to nfc and calls startNFC', async () => {
       const { result } = renderHook(() => usePairingSlots());
       await act(async () => {
         result.current.checkSlots();
       });
-      expect(result.current.phase).toBe('checking');
+      expect(result.current.phase).toBe('nfc');
       expect(mockStartNFC).toHaveBeenCalledWith('Tap your Keycard');
     });
 
@@ -109,7 +109,7 @@ describe('usePairingSlots', () => {
         await capturedOnConnected?.();
       });
 
-      expect(result.current.phase).toBe('ready');
+      expect(result.current.phase).toBe('done');
       expect(result.current.slotInfo).toEqual({
         totalSlots: 10,
         freeSlots: 7,

--- a/src/components/NFCBottomSheet/index.tsx
+++ b/src/components/NFCBottomSheet/index.tsx
@@ -21,6 +21,8 @@ import { Icons } from '@/assets/icons';
 
 import PinPad from '@/components/PinPad';
 
+import type { KeycardPhase } from '@/hooks/keycard/useKeycardOperation';
+
 import GenuineWarning from './GenuineWarning';
 import NFCError from './NFCError';
 import NFCSheet from './NFCSheet';
@@ -32,7 +34,7 @@ const PIN_MODAL_EDGES: readonly Edge[] = ['top', 'bottom', 'left', 'right'];
 export type NFCVariant = 'scanning' | 'success' | 'error' | 'genuine_warning';
 
 export type NFCOperation = {
-  phase: string;
+  phase: KeycardPhase;
   status: string;
   cardName?: string | null;
   cardFingerprint?: number | null;

--- a/src/hooks/keycard/useKeycardOperation.ts
+++ b/src/hooks/keycard/useKeycardOperation.ts
@@ -9,17 +9,19 @@ import { pubKeyFingerprint } from '@/utils/cryptoAccount';
 import { toHex } from '@/utils/hex';
 import { displayKeycardName, parseKeycardName } from '@/utils/keycardName';
 import { useGenuineCheck } from './useGenuineCheck';
-import { useNFCOperation } from './useNFCOperation';
+import { useNFCOperation, type NFCSessionPhase } from './useNFCOperation';
 import { usePairing } from './usePairing';
 
-export type Phase =
-  | 'idle'
+/**
+ * The full phase vocabulary of a coordinated Keycard operation: the 4-state
+ * session machine plus the coordinator's interactive interrupts. There is one
+ * vocabulary — never re-declare or rename these states downstream.
+ */
+export type KeycardPhase =
+  | NFCSessionPhase
   | 'pin_entry'
   | 'pairing_password'
-  | 'nfc'
-  | 'genuine_warning'
-  | 'done'
-  | 'error';
+  | 'genuine_warning';
 
 export type KeycardOperationFn<T> = (
   cmdSet: InstanceType<typeof Keycard.Commandset>,
@@ -32,7 +34,7 @@ export interface ExecuteOptions {
 }
 
 export interface UseKeycardOperation<T> {
-  phase: Phase;
+  phase: KeycardPhase;
   status: string;
   cardName: string | null;
   cardFingerprint: number | null;
@@ -247,7 +249,7 @@ export function useKeycardOperation<T>(): UseKeycardOperation<T> {
   };
 
   // 'genuine_warning' takes priority over all other phase overrides.
-  const phase: Phase = showGenuineWarning
+  const phase: KeycardPhase = showGenuineWarning
     ? 'genuine_warning'
     : waitingForPairingPassword ||
       (pairingPasswordError !== null && nfcPhase === 'error')

--- a/src/hooks/keycard/useNFCOperation.ts
+++ b/src/hooks/keycard/useNFCOperation.ts
@@ -1,11 +1,11 @@
 import { useCallback, useRef, useState } from 'react';
 import { Commandset } from 'keycard-sdk/dist/commandset';
-import useNFCSession, { Phase } from './useNFCSession';
+import useNFCSession, { NFCSessionPhase } from './useNFCSession';
 
-export type { Phase };
+export type { NFCSessionPhase };
 
 export interface UseNFCOperation<T> {
-  phase: Phase;
+  phase: NFCSessionPhase;
   status: string;
   result: T | null;
   start: () => void;

--- a/src/hooks/keycard/useNFCSession.ts
+++ b/src/hooks/keycard/useNFCSession.ts
@@ -4,10 +4,10 @@ import RNKeycard from 'react-native-keycard';
 import Keycard from 'keycard-sdk';
 import { Commandset } from 'keycard-sdk/dist/commandset';
 
-export type Phase = 'idle' | 'nfc' | 'done' | 'error';
+export type NFCSessionPhase = 'idle' | 'nfc' | 'done' | 'error';
 
 export interface UseNFCSessionOperation {
-  phase: Phase;
+  phase: NFCSessionPhase;
   status: string;
   startNFC: () => void;
   reset: () => void;
@@ -24,7 +24,7 @@ export default function useNFCSession(
   ) => Promise<void>,
   onCardDisconnected: () => Promise<void>,
 ): UseNFCSessionOperation {
-  const [phase, setPhase] = useState<Phase>('idle');
+  const [phase, setPhase] = useState<NFCSessionPhase>('idle');
   const [status, setStatus] = useState('');
   const [nfcDisabled, setNfcDisabled] = useState(false);
   const onNFCAvailableRef = useRef<(() => void) | null>(null);

--- a/src/hooks/keycard/usePairingSlots.ts
+++ b/src/hooks/keycard/usePairingSlots.ts
@@ -3,7 +3,7 @@ import { Commandset } from 'keycard-sdk/dist/commandset';
 
 import { loadPairing } from '../../storage/pairingStorage';
 import { toHex } from '../../utils/hex';
-import { useNFCOperation } from './useNFCOperation';
+import { useNFCOperation, type NFCSessionPhase } from './useNFCOperation';
 
 const TOTAL_SLOTS = 10;
 
@@ -14,10 +14,8 @@ export interface SlotInfo {
   cardUid: string;
 }
 
-export type PairingSlotsPhase = 'idle' | 'checking' | 'ready' | 'error';
-
 export interface UsePairingSlots {
-  phase: PairingSlotsPhase;
+  phase: NFCSessionPhase;
   slotInfo: SlotInfo | null;
   status: string;
   checkSlots: () => void;
@@ -56,7 +54,7 @@ export function usePairingSlots(): UsePairingSlots {
     start,
     cancel: nfcCancel,
     reset: nfcReset,
-    phase: nfcPhase,
+    phase,
     status,
   } = useNFCOperation(handleConnected);
 
@@ -93,15 +91,6 @@ export function usePairingSlots(): UsePairingSlots {
     },
     [readSlotInfo],
   );
-
-  let phase: PairingSlotsPhase = 'idle';
-  if (nfcPhase === 'nfc') {
-    phase = 'checking';
-  } else if (nfcPhase === 'done' && slotInfo) {
-    phase = 'ready';
-  } else if (nfcPhase === 'error') {
-    phase = 'error';
-  }
 
   return {
     phase,

--- a/src/screens/PairingSlotsScreen.tsx
+++ b/src/screens/PairingSlotsScreen.tsx
@@ -110,19 +110,9 @@ export default function PairingSlotsScreen({
     }
   }, [isUnpairing, cancelUnpair, cancelCheck, navigation]);
 
-  // Build the NFCOperation object passed to NFCBottomSheet.
-  // The check flow maps 'checking' → 'nfc' so the bottom sheet shows.
   const activeNfc: NFCOperation = isUnpairing
     ? unpairHook
-    : {
-        phase:
-          checkPhase === 'checking'
-            ? 'nfc'
-            : checkPhase === 'ready'
-            ? 'done'
-            : checkPhase,
-        status: checkStatus,
-      };
+    : { phase: checkPhase, status: checkStatus };
 
   if (pendingSlotIndex !== null) {
     return (
@@ -141,7 +131,7 @@ export default function PairingSlotsScreen({
 
   const showContent =
     !isUnpairing &&
-    (checkPhase === 'idle' || checkPhase === 'ready' || checkPhase === 'error');
+    (checkPhase === 'idle' || checkPhase === 'done' || checkPhase === 'error');
 
   const menuEntries = slotInfo?.totalSlots
     ? Array.from({ length: slotInfo.totalSlots }, (_, i) => {


### PR DESCRIPTION
Closes #236

## Summary

The phase state machine is the de-facto interface of the NFC stack (~14 modules, 31 comparisons dispatch on it), but its vocabulary was published four ways: `useNFCSession` exported a 4-state `Phase`, `useKeycardOperation` exported a second, different union also named `Phase`, `NFCBottomSheet` erased both to `phase: string` at the one component where every phase converges (10 comparisons, none compiler-checked), and `usePairingSlots` renamed the session states to `'checking'/'ready'` only for `PairingSlotsScreen` to rename them straight back.

Now there is one vocabulary, published once:

- `NFCSessionPhase` (`'idle' | 'nfc' | 'done' | 'error'`) exported from `useNFCSession`, re-exported by `useNFCOperation`
- `KeycardPhase = NFCSessionPhase | 'pin_entry' | 'pairing_password' | 'genuine_warning'` exported from `useKeycardOperation`, defined as an extension instead of a parallel list
- `NFCBottomSheet`'s `NFCOperation.phase` is typed `KeycardPhase`; a misspelled or unhandled phase is now a compile error (the typecheck immediately flagged the test helper that passed arbitrary strings)
- `usePairingSlots` returns the raw `NFCSessionPhase`; the `'checking'/'ready'` vocabulary and the screen's remapping object are deleted

Named `NFCSessionPhase` rather than `SessionPhase` because the WalletConnect context already exports a `SessionPhase` with different states; reusing the name would reintroduce the same-name-different-union problem this PR removes.

## Behavior

None. Pure type-level refactor; PairingSlotsScreen renders identical states (guards use `'done'` where they used `'ready'`). No changelog entry for that reason.

## Test plan

- `usePairingSlots`, `PairingSlotsScreen`, and `NFCBottomSheet` suites updated to the real phase names; the sheet's test helper is now typed `KeycardPhase`
- Full suite 1442 passed; ESLint and Prettier clean; tsc reports no new errors

## Notes

- Leverage lands with PLAN_NFC_RECONNECT: it extends exactly this machine, and every consumer is now compiler-checked instead of grep-checked
- Unblocks #237 (shared phase-to-navigation adapter), which keys its guards on these unions
