### PR TITLE
refactor: shared phase-to-navigation adapter hook for Keycard operation screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Importing a key pair (recovery phrase or backup check) now returns to a fresh Dashboard like every other completed Keycard operation, clearing the seed-entry screens from the navigation stack
 - SeedQR scanning now opens from a QR icon inside the seed-phrase input instead of a separate "Scan SeedQR" button
 - iOS back button now shows only the arrow instead of the previous screen's title text
 - Renamed "Keypair" to "Key pair" across the menu and screen titles
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Ethereum signature `v` is now derived from the classified payload kind instead of sniffing the first byte of the payload: a personal-sign message or EIP-712 digest that happened to start with `0x01`/`0x02` no longer produces an invalid signature (`v = recId` instead of `27 + recId`)
 - Signing a malformed PSBT or failing to encode the result QR now shows an error screen instead of crashing or doing nothing
+- Navigating back during an active Keycard tap now cancels the NFC session on every Keycard screen; previously only Initialize Card and Change PIN/PUK did this, leaving the session running elsewhere
 - Generated recovery-phrase list: two-digit word numbers (`10.`, `11.`, `12.`) no longer wrap onto a second line on iOS; the number column is now auto-width
 
 ## [1.8.0] - 2026-06-30

--- a/__tests__/AddressListScreen.test.tsx
+++ b/__tests__/AddressListScreen.test.tsx
@@ -9,6 +9,10 @@ import NFCBottomSheet from '../src/components/NFCBottomSheet';
 // Mocks
 // ---------------------------------------------------------------------------
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -51,6 +55,7 @@ jest.mock('../src/hooks/keycard/useAddresses', () => ({
 // ---------------------------------------------------------------------------
 
 const navigation = {
+  addListener: jest.fn(() => jest.fn()),
   goBack: jest.fn(),
   navigate: jest.fn(),
   setOptions: jest.fn(),

--- a/__tests__/ConfirmKeyScreen.test.tsx
+++ b/__tests__/ConfirmKeyScreen.test.tsx
@@ -85,8 +85,9 @@ const CORRECT_WORDS = CHALLENGE_POSITIONS.map(i => WORDS[i]);
 const WRONG_WORD_FOR_SLOT_0 = 'charlie';
 
 const navigation = {
+  addListener: jest.fn(() => jest.fn()),
   goBack: jest.fn(),
-  navigate: jest.fn(),
+  reset: jest.fn(),
   setOptions: jest.fn(),
 } as any;
 
@@ -138,7 +139,7 @@ describe('ConfirmKeyScreen', () => {
     MockNFCBottomSheet.mockClear();
     MockPinPad.mockClear();
     navigation.goBack.mockClear();
-    navigation.navigate.mockClear();
+    navigation.reset.mockClear();
     navigation.setOptions.mockClear();
   });
 
@@ -292,16 +293,22 @@ describe('ConfirmKeyScreen', () => {
   // -------------------------------------------------------------------------
 
   describe('navigation', () => {
-    it('navigates to Dashboard with toast when phase is done', async () => {
+    it('resets to Dashboard with toast when phase is done', async () => {
       await renderScreen('done');
-      expect(navigation.navigate).toHaveBeenCalledWith('Dashboard', {
-        toast: 'Key pair has been added to Keycard',
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          {
+            name: 'Dashboard',
+            params: { toast: 'Key pair has been added to Keycard' },
+          },
+        ],
       });
     });
 
     it('does not navigate when phase is not done', async () => {
       await renderScreen('idle');
-      expect(navigation.navigate).not.toHaveBeenCalled();
+      expect(navigation.reset).not.toHaveBeenCalled();
     });
 
     it('calls cancel() and navigation.goBack() when NFCBottomSheet cancel is pressed', async () => {

--- a/__tests__/FactoryResetScreen.test.tsx
+++ b/__tests__/FactoryResetScreen.test.tsx
@@ -10,6 +10,10 @@ import NFCBottomSheet from '../src/components/NFCBottomSheet';
 // Mocks
 // ---------------------------------------------------------------------------
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -42,6 +46,7 @@ jest.mock('../src/hooks/keycard/useFactoryReset', () => ({
 // ---------------------------------------------------------------------------
 
 const navigation = {
+  addListener: jest.fn(() => jest.fn()),
   goBack: jest.fn(),
   reset: jest.fn(),
   setOptions: jest.fn(),

--- a/__tests__/MnemonicScreen.test.tsx
+++ b/__tests__/MnemonicScreen.test.tsx
@@ -9,6 +9,10 @@ import MnemonicScreen from '../src/screens/keypair/MnemonicScreen';
 // Mocks
 // ---------------------------------------------------------------------------
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -401,8 +405,14 @@ describe('MnemonicScreen', () => {
   describe('navigation', () => {
     it('navigates to Dashboard with toast when phase is done (import mode)', async () => {
       renderScreen('done');
-      expect(navigation.navigate).toHaveBeenCalledWith('Dashboard', {
-        toast: 'Key pair has been added to Keycard',
+      expect(navigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          {
+            name: 'Dashboard',
+            params: { toast: 'Key pair has been added to Keycard' },
+          },
+        ],
       });
     });
 

--- a/__tests__/SetCardNameScreen.test.tsx
+++ b/__tests__/SetCardNameScreen.test.tsx
@@ -10,6 +10,10 @@ let mockPhase = 'idle';
 let keyboardDidShow: ((event: any) => void) | null = null;
 let keyboardDidHide: (() => void) | null = null;
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
@@ -63,6 +67,7 @@ jest.mock('../src/hooks/keycard/useSetCardName', () => ({
 }));
 
 const navigation = {
+  addListener: jest.fn(() => jest.fn()),
   goBack: jest.fn(),
   reset: jest.fn(),
   setOptions: jest.fn(),

--- a/__tests__/Slip39Screen.test.tsx
+++ b/__tests__/Slip39Screen.test.tsx
@@ -30,6 +30,10 @@ const mockUseLoadKey = jest.fn();
 const mockUseVerifyFingerprint = jest.fn();
 const mockGenerateSlip39SharesFromKeycardEntropy = jest.fn();
 
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 jest.mock('../src/hooks/useSeedReviewTimer', () => ({
   useSeedReviewTimer: () => ({ timeLeft: 0, done: true, start: jest.fn() }),
 }));
@@ -71,6 +75,7 @@ jest.mock('../src/utils/slip39', () => {
 });
 
 const navigation = {
+  addListener: jest.fn(() => jest.fn()),
   navigate: jest.fn(),
   reset: jest.fn(),
   setOptions: jest.fn(),

--- a/__tests__/useKeycardScreen.test.ts
+++ b/__tests__/useKeycardScreen.test.ts
@@ -1,0 +1,329 @@
+import { renderHook } from '@testing-library/react-native';
+import { BackHandler } from 'react-native';
+
+import {
+  useKeycardScreen,
+  type UseKeycardScreenOptions,
+} from '../src/hooks/useKeycardScreen';
+
+jest.mock('@react-navigation/native', () => {
+  const { useEffect } = require('react');
+  return {
+    // Run the focus effect like a focused screen would.
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      useEffect(cb, [cb]);
+    },
+  };
+});
+
+function makeNavigation() {
+  return {
+    goBack: jest.fn(),
+    reset: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
+  };
+}
+
+function makeKeycard(phase: string, result: unknown = null) {
+  return { phase: phase as any, result, cancel: jest.fn() };
+}
+
+function renderScreenHook(options: UseKeycardScreenOptions) {
+  return renderHook(
+    (props: UseKeycardScreenOptions) => useKeycardScreen(props),
+    {
+      initialProps: options,
+    },
+  );
+}
+
+function capturedBackHandler(spy: jest.SpyInstance): () => boolean {
+  const call = spy.mock.calls.at(-1);
+  return call![1] as () => boolean;
+}
+
+function capturedBeforeRemove(navigation: ReturnType<typeof makeNavigation>) {
+  const call = navigation.addListener.mock.calls.at(-1) as unknown as [
+    string,
+    (e: { preventDefault: () => void }) => void,
+  ];
+  expect(call[0]).toBe('beforeRemove');
+  return call[1];
+}
+
+let backSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  backSpy = jest.spyOn(BackHandler, 'addEventListener');
+});
+
+afterEach(() => {
+  backSpy.mockRestore();
+});
+
+describe('done navigation', () => {
+  it('resets to Dashboard with the toast when phase is done', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('done', 'ok'),
+      navigation,
+      title: 'T',
+      done: { toast: 'All set' },
+    });
+    expect(navigation.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Dashboard', params: { toast: 'All set' } }],
+    });
+  });
+
+  it('computes the toast from the result', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('done', 'match'),
+      navigation,
+      title: 'T',
+      done: {
+        toast: r => (r === 'match' ? 'Matches' : 'Does not match'),
+      },
+    });
+    expect(navigation.reset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routes: [{ name: 'Dashboard', params: { toast: 'Matches' } }],
+      }),
+    );
+  });
+
+  it('requireResult blocks navigation while result is null', () => {
+    const navigation = makeNavigation();
+    const { rerender } = renderScreenHook({
+      keycard: makeKeycard('done', null),
+      navigation,
+      title: 'T',
+      done: { toast: 'Done', requireResult: true },
+    });
+    expect(navigation.reset).not.toHaveBeenCalled();
+
+    rerender({
+      keycard: makeKeycard('done', 'puk'),
+      navigation,
+      title: 'T',
+      done: { toast: 'Done', requireResult: true },
+    });
+    expect(navigation.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing on done without a done option', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('done', 'x'),
+      navigation,
+      title: 'T',
+    });
+    expect(navigation.reset).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate before done', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('nfc'),
+      navigation,
+      title: 'T',
+      done: { toast: 'Done' },
+    });
+    expect(navigation.reset).not.toHaveBeenCalled();
+  });
+});
+
+describe('header title', () => {
+  it('uses the base title outside PIN entry', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('idle'),
+      navigation,
+      title: 'Factory reset',
+    });
+    expect(navigation.setOptions).toHaveBeenCalledWith({
+      title: 'Factory reset',
+    });
+  });
+
+  it("defaults to 'Enter Keycard PIN' during PIN entry", () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('pin_entry'),
+      navigation,
+      title: 'Factory reset',
+    });
+    expect(navigation.setOptions).toHaveBeenCalledWith({
+      title: 'Enter Keycard PIN',
+    });
+  });
+
+  it('uses pinEntryTitle during PIN entry when provided', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('pin_entry'),
+      navigation,
+      title: 'Enter new PIN',
+      pinEntryTitle: 'Enter current PIN',
+    });
+    expect(navigation.setOptions).toHaveBeenCalledWith({
+      title: 'Enter current PIN',
+    });
+  });
+});
+
+describe('onCancel', () => {
+  it('cancels and goes back by default', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('nfc');
+    const { result } = renderScreenHook({
+      keycard,
+      navigation,
+      title: 'T',
+    });
+    result.current.onCancel();
+    expect(keycard.cancel).toHaveBeenCalled();
+    expect(navigation.goBack).toHaveBeenCalled();
+  });
+
+  it('only cancels with stayOnCancel', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('nfc');
+    const { result } = renderScreenHook({
+      keycard,
+      navigation,
+      title: 'T',
+      stayOnCancel: true,
+    });
+    result.current.onCancel();
+    expect(keycard.cancel).toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});
+
+describe('back guard', () => {
+  it('hardware back during an active tap cancels the session and pops', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('nfc');
+    renderScreenHook({ keycard, navigation, title: 'T' });
+
+    const handled = capturedBackHandler(backSpy)();
+
+    expect(handled).toBe(true);
+    expect(keycard.cancel).toHaveBeenCalled();
+    expect(navigation.goBack).toHaveBeenCalled();
+  });
+
+  it('hardware back during PIN entry cancels too', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('pin_entry');
+    renderScreenHook({ keycard, navigation, title: 'T' });
+
+    expect(capturedBackHandler(backSpy)()).toBe(true);
+    expect(keycard.cancel).toHaveBeenCalled();
+  });
+
+  it('hardware back when idle defers to the screen fallback', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('idle');
+    const onHardwareBack = jest.fn(() => true);
+    renderScreenHook({ keycard, navigation, title: 'T', onHardwareBack });
+
+    expect(capturedBackHandler(backSpy)()).toBe(true);
+    expect(onHardwareBack).toHaveBeenCalled();
+    expect(keycard.cancel).not.toHaveBeenCalled();
+  });
+
+  it('hardware back when idle without a fallback lets the system handle it', () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('idle'),
+      navigation,
+      title: 'T',
+    });
+    expect(capturedBackHandler(backSpy)()).toBe(false);
+  });
+
+  it('beforeRemove during an active tap cancels without preventing removal', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('nfc');
+    const onBeforeRemove = jest.fn();
+    renderScreenHook({ keycard, navigation, title: 'T', onBeforeRemove });
+
+    const e = { preventDefault: jest.fn() };
+    capturedBeforeRemove(navigation)(e);
+
+    expect(keycard.cancel).toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(onBeforeRemove).not.toHaveBeenCalled();
+  });
+
+  it('beforeRemove when idle defers to the screen fallback', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('idle');
+    const onBeforeRemove = jest.fn(e => e.preventDefault());
+    renderScreenHook({ keycard, navigation, title: 'T', onBeforeRemove });
+
+    const e = { preventDefault: jest.fn() };
+    capturedBeforeRemove(navigation)(e);
+
+    expect(onBeforeRemove).toHaveBeenCalledWith(e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(keycard.cancel).not.toHaveBeenCalled();
+  });
+});
+
+describe('activeKeycard override', () => {
+  it('guard, title, and cancel key on activeKeycard; done keys on keycard', () => {
+    const navigation = makeNavigation();
+    const keycard = makeKeycard('idle');
+    const activeKeycard = makeKeycard('nfc');
+    const { result } = renderScreenHook({
+      keycard,
+      navigation,
+      title: 'T',
+      done: { toast: 'Done' },
+      activeKeycard,
+    });
+
+    // Guard cancels the ACTIVE hook's tap.
+    expect(capturedBackHandler(backSpy)()).toBe(true);
+    expect(activeKeycard.cancel).toHaveBeenCalled();
+    expect(keycard.cancel).not.toHaveBeenCalled();
+
+    // onCancel also targets the active hook.
+    result.current.onCancel();
+    expect(activeKeycard.cancel).toHaveBeenCalledTimes(2);
+
+    // Done keyed on keycard (idle) — the active hook finishing must not navigate.
+    expect(navigation.reset).not.toHaveBeenCalled();
+  });
+
+  it("the active hook reaching 'done' does not trigger done-navigation", () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('idle'),
+      navigation,
+      title: 'T',
+      done: { toast: 'Done' },
+      activeKeycard: makeKeycard('done', 'shares'),
+    });
+    expect(navigation.reset).not.toHaveBeenCalled();
+  });
+
+  it("PIN-entry title keys on the active hook's phase", () => {
+    const navigation = makeNavigation();
+    renderScreenHook({
+      keycard: makeKeycard('idle'),
+      navigation,
+      title: 'Generate SLIP39 shares',
+      activeKeycard: makeKeycard('pin_entry'),
+    });
+    expect(navigation.setOptions).toHaveBeenCalledWith({
+      title: 'Enter Keycard PIN',
+    });
+  });
+});

--- a/src/hooks/useKeycardScreen.ts
+++ b/src/hooks/useKeycardScreen.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { BackHandler } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+
+import type { KeycardPhase } from './keycard/useKeycardOperation';
+
+type BeforeRemoveEvent = { preventDefault: () => void };
+
+export type KeycardScreenKeycard = {
+  phase: KeycardPhase;
+  result?: unknown;
+  cancel: () => void;
+};
+
+export type KeycardScreenNavigation = {
+  goBack(): void;
+  reset(state: {
+    index: number;
+    routes: { name: 'Dashboard'; params?: { toast?: string } }[];
+  }): void;
+  setOptions(options: { title: string }): void;
+  addListener(
+    type: 'beforeRemove',
+    callback: (e: BeforeRemoveEvent) => void,
+  ): () => void;
+};
+
+export type UseKeycardScreenOptions = {
+  /** Drives done-navigation (phase + result). */
+  keycard: KeycardScreenKeycard;
+  navigation: KeycardScreenNavigation;
+  /** Header title outside PIN entry. */
+  title: string;
+  /** Header title while the Keycard PIN pad is up. */
+  pinEntryTitle?: string;
+  /** When set, phase 'done' resets to Dashboard with this toast. */
+  done?: {
+    toast: string | ((result: unknown) => string);
+    /** Skip navigation while result is null/undefined (e.g. useInitCard). */
+    requireResult?: boolean;
+  };
+  /**
+   * Drives the back guard, the PIN-entry title, and onCancel when a screen
+   * runs more than one keycard hook (see Slip39Screen). Defaults to keycard.
+   */
+  activeKeycard?: KeycardScreenKeycard;
+  /** Hardware-back fallback once the keycard guard passes; BackHandler semantics. */
+  onHardwareBack?: () => boolean;
+  /** beforeRemove fallback once the keycard guard passes. */
+  onBeforeRemove?: (e: BeforeRemoveEvent) => void;
+  /** onCancel only cancels the tap instead of also leaving the screen. */
+  stayOnCancel?: boolean;
+};
+
+/**
+ * The shared phase-to-navigation adapter for screens that run a Keycard
+ * operation: done → reset to Dashboard with a toast, back-press during an
+ * active tap → cancel the NFC session first, PIN entry → header title.
+ * Screens keep only their entry UI and step machines.
+ */
+export function useKeycardScreen(options: UseKeycardScreenOptions): {
+  onCancel: () => void;
+} {
+  const { navigation } = options;
+  const { phase, result } = options.keycard;
+  const active = options.activeKeycard ?? options.keycard;
+
+  // Latest-value refs so the back listeners never go stale and never
+  // re-subscribe mid-gesture.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
+  useEffect(() => {
+    const done = optionsRef.current.done;
+    if (!done || phase !== 'done') {
+      return;
+    }
+    if (done.requireResult && result == null) {
+      return;
+    }
+    const toast =
+      typeof done.toast === 'function' ? done.toast(result) : done.toast;
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'Dashboard', params: { toast } }],
+    });
+  }, [phase, result, navigation]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title:
+        active.phase === 'pin_entry'
+          ? options.pinEntryTitle ?? 'Enter Keycard PIN'
+          : options.title,
+    });
+  }, [navigation, active.phase, options.pinEntryTitle, options.title]);
+
+  const keycardBusy = useCallback(() => {
+    const activePhase = activeRef.current.phase;
+    return activePhase === 'nfc' || activePhase === 'pin_entry';
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+        if (keycardBusy()) {
+          activeRef.current.cancel();
+          navigation.goBack();
+          return true;
+        }
+        return optionsRef.current.onHardwareBack?.() ?? false;
+      });
+      return () => sub.remove();
+    }, [keycardBusy, navigation]),
+  );
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', e => {
+      if (keycardBusy()) {
+        activeRef.current.cancel();
+        return;
+      }
+      optionsRef.current.onBeforeRemove?.(e);
+    });
+    return unsubscribe;
+  }, [navigation, keycardBusy]);
+
+  const onCancel = useCallback(() => {
+    activeRef.current.cancel();
+    if (!optionsRef.current.stayOnCancel) {
+      navigation.goBack();
+    }
+  }, [navigation]);
+
+  return { onCancel };
+}

--- a/src/screens/FactoryResetScreen.tsx
+++ b/src/screens/FactoryResetScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useLayoutEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import { DashboardAction, FactoryResetSreenProps } from '../navigation/types';
@@ -8,6 +8,7 @@ import NFCBottomSheet from '../components/NFCBottomSheet';
 import PrimaryButton from '../components/PrimaryButton';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFactoryReset } from '../hooks/keycard/useFactoryReset';
+import { useKeycardScreen } from '../hooks/useKeycardScreen';
 import { Icons } from '../assets/icons';
 
 export const dashboardEntry: DashboardAction = {
@@ -22,31 +23,18 @@ export default function FactoryResetScreen({
   const [checked, setChecked] = useState(false);
 
   const keycard = useFactoryReset();
-  const { phase, start, cancel } = keycard;
+  const { phase, start } = keycard;
 
-  useLayoutEffect(() => {
-    navigation.setOptions({ title: 'Factory reset' });
-  }, [navigation]);
-
-  useEffect(() => {
-    if (phase !== 'done') {
-      return;
-    }
-
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'Dashboard', params: { toast: 'Factory reset done' } }],
-    });
-  }, [phase, navigation]);
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: 'Factory reset',
+    done: { toast: 'Factory reset done' },
+  });
 
   const handleStart = useCallback(() => {
     start();
   }, [start]);
-
-  const handleCancel = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
@@ -85,7 +73,7 @@ export default function FactoryResetScreen({
         </View>
       )}
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} showOnDone />
     </View>
   );
 }

--- a/src/screens/InitCardScreen.tsx
+++ b/src/screens/InitCardScreen.tsx
@@ -1,18 +1,12 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-import { BackHandler, StyleSheet, View } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
+import React, { useCallback, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DashboardAction, InitCardScreenProps } from '../navigation/types';
 
 import { useInitCard } from '../hooks/keycard/useInitCard';
 import { useConfirmedEntry } from '../hooks/useConfirmedEntry';
+import { useKeycardScreen } from '../hooks/useKeycardScreen';
 
 import theme from '../theme';
 import ConfirmPrompt from '../components/ConfirmPropmpt';
@@ -32,7 +26,7 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
   const mainPinRef = useRef('');
 
   const keycard = useInitCard();
-  const { phase, result, start, cancel } = keycard;
+  const { phase, start } = keycard;
 
   const pinSetup = useConfirmedEntry(pin => {
     mainPinRef.current = pin;
@@ -44,22 +38,6 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
     mainPinRef.current = '';
   });
 
-  useEffect(() => {
-    if (phase !== 'done' || !result) {
-      return;
-    }
-
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'Dashboard', params: { toast: 'Card initialized' } }],
-    });
-  }, [phase, result, navigation]);
-
-  const handleCancel = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
-
   const handleDuressYes = useCallback(() => {
     setScreenStep('duress_setup');
   }, []);
@@ -69,13 +47,7 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
     mainPinRef.current = '';
   }, [start]);
 
-  const goBack = useCallback(() => {
-    if (phase === 'nfc') {
-      cancel();
-      navigation.goBack();
-      return true;
-    }
-
+  const onScreenBack = useCallback(() => {
     if (screenStep === 'pin_setup') {
       const handled = pinSetup.goBack();
       if (!handled) {
@@ -99,21 +71,27 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
     }
 
     return true;
-  }, [phase, screenStep, pinSetup, duressSetup, cancel, navigation]);
+  }, [screenStep, pinSetup, duressSetup, navigation]);
 
-  useFocusEffect(
-    useCallback(() => {
-      const sub = BackHandler.addEventListener('hardwareBackPress', goBack);
-      return () => sub.remove();
-    }, [goBack]),
-  );
+  const title = (() => {
+    if (screenStep === 'pin_setup') {
+      return pinSetup.step === 'entry' ? 'Create a PIN' : 'Confirm your PIN';
+    }
+    if (screenStep === 'duress_question') {
+      return 'Initialize Card';
+    }
+    return duressSetup.step === 'entry'
+      ? 'Create a duress PIN'
+      : 'Confirm duress PIN';
+  })();
 
-  useEffect(() => {
-    const unsubscribe = navigation.addListener('beforeRemove', e => {
-      if (phase === 'nfc') {
-        cancel();
-        return;
-      }
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title,
+    done: { toast: 'Card initialized', requireResult: true },
+    onHardwareBack: onScreenBack,
+    onBeforeRemove: e => {
       if (screenStep === 'pin_setup' && pinSetup.step === 'confirm') {
         e.preventDefault();
         pinSetup.goBack();
@@ -132,25 +110,8 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
           setScreenStep('duress_question');
         }
       }
-    });
-    return unsubscribe;
-  }, [navigation, phase, screenStep, pinSetup, duressSetup, cancel]);
-
-  const title = (() => {
-    if (screenStep === 'pin_setup') {
-      return pinSetup.step === 'entry' ? 'Create a PIN' : 'Confirm your PIN';
-    }
-    if (screenStep === 'duress_question') {
-      return 'Initialize Card';
-    }
-    return duressSetup.step === 'entry'
-      ? 'Create a duress PIN'
-      : 'Confirm duress PIN';
-  })();
-
-  useLayoutEffect(() => {
-    navigation.setOptions({ title });
-  }, [navigation, title]);
+    },
+  });
 
   const activePinSetup =
     screenStep === 'pin_setup'
@@ -185,7 +146,7 @@ export default function InitCardScreen({ navigation }: InitCardScreenProps) {
         />
       )}
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} showOnDone />
     </View>
   );
 }

--- a/src/screens/SetCardNameScreen.tsx
+++ b/src/screens/SetCardNameScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Keyboard, Platform, StyleSheet, TextInput, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,6 +10,7 @@ import { Icons } from '../assets/icons';
 import NFCBottomSheet from '../components/NFCBottomSheet';
 import PrimaryButton from '../components/PrimaryButton';
 import { useSetCardName } from '../hooks/keycard/useSetCardName';
+import { useKeycardScreen } from '../hooks/useKeycardScreen';
 import { MAX_KEYCARD_NAME_LENGTH } from '../utils/keycardName';
 
 export default function SetCardNameScreen({
@@ -20,11 +21,14 @@ export default function SetCardNameScreen({
   const [error, setError] = useState<string | null>(null);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const keycard = useSetCardName();
-  const { phase, start, cancel } = keycard;
+  const { phase, start } = keycard;
 
-  useLayoutEffect(() => {
-    navigation.setOptions({ title: 'Set card name' });
-  }, [navigation]);
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: 'Set card name',
+    done: { toast: 'Card name updated' },
+  });
 
   useEffect(() => {
     const show = Keyboard.addListener(
@@ -41,17 +45,6 @@ export default function SetCardNameScreen({
     };
   }, []);
 
-  useEffect(() => {
-    if (phase !== 'done') {
-      return;
-    }
-
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'Dashboard', params: { toast: 'Card name updated' } }],
-    });
-  }, [phase, navigation]);
-
   const handleSubmit = useCallback(() => {
     try {
       setError(null);
@@ -60,11 +53,6 @@ export default function SetCardNameScreen({
       setError(e.message);
     }
   }, [name, start]);
-
-  const handleCancel = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
 
   return (
     <View
@@ -112,7 +100,7 @@ export default function SetCardNameScreen({
         </View>
       )}
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} showOnDone />
     </View>
   );
 }

--- a/src/screens/address/AddressListScreen.tsx
+++ b/src/screens/address/AddressListScreen.tsx
@@ -1,12 +1,5 @@
 import { HDKey } from '@scure/bip32';
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -25,6 +18,7 @@ import AddressText from '../../components/AddressText';
 import NFCBottomSheet from '../../components/NFCBottomSheet';
 
 import { useAddresses } from '../../hooks/keycard/useAddresses';
+import { useKeycardScreen } from '../../hooks/useKeycardScreen';
 
 import { pubKeyToBtcAddress } from '../../utils/bitcoinAddress';
 import { pubKeyToEthAddress } from '../../utils/ethereumAddress';
@@ -63,14 +57,11 @@ export default function AddressListScreen({
   const externalRef = useRef<HDKey | null>(null);
   const nextIndexRef = useRef(0);
 
-  useLayoutEffect(() => {
-    if (phase === 'pin_entry') {
-      navigation.setOptions({ title: 'Enter Keycard PIN' });
-    } else {
-      const label = coin === 'eth' ? 'Ethereum' : 'Bitcoin';
-      navigation.setOptions({ title: `${label} Addresses` });
-    }
-  }, [navigation, coin, phase]);
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: `${coin === 'eth' ? 'Ethereum' : 'Bitcoin'} Addresses`,
+  });
 
   useEffect(() => {
     start();
@@ -103,11 +94,6 @@ export default function AddressListScreen({
     [coin, handleRowPress],
   );
 
-  const handleCancel = useCallback(() => {
-    keycard.cancel();
-    navigation.goBack();
-  }, [keycard, navigation]);
-
   const loadMore = useCallback(() => {
     if (!externalRef.current) return;
     const from = nextIndexRef.current;
@@ -139,7 +125,7 @@ export default function AddressListScreen({
         renderItem={renderItem}
       />
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} />
     </View>
   );
 }

--- a/src/screens/keypair/ConfirmKeyScreen.tsx
+++ b/src/screens/keypair/ConfirmKeyScreen.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -19,6 +13,7 @@ import {
   deriveMnemonicKeyPair,
   useLoadKey,
 } from '../../hooks/keycard/useLoadKey';
+import { useKeycardScreen } from '../../hooks/useKeycardScreen';
 
 export default function ConfirmKeyScreen({
   navigation,
@@ -32,26 +27,14 @@ export default function ConfirmKeyScreen({
   );
 
   const keycard = useLoadKey();
-  const { phase, start, cancel } = keycard;
+  const { start } = keycard;
 
-  const handleCancel = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
-
-  useEffect(() => {
-    if (phase === 'done') {
-      navigation.navigate('Dashboard', {
-        toast: 'Key pair has been added to Keycard',
-      });
-    }
-  }, [phase, navigation]);
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      title: phase === 'pin_entry' ? 'Enter Keycard PIN' : 'Check your backup',
-    });
-  }, [navigation, phase]);
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: 'Check your backup',
+    done: { toast: 'Key pair has been added to Keycard' },
+  });
 
   const [attemptKey, setAttemptKey] = useState(0);
 
@@ -61,10 +44,7 @@ export default function ConfirmKeyScreen({
     }, []),
   );
 
-  const handleFailure = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
+  const handleFailure = onCancel;
 
   return (
     <View
@@ -81,7 +61,7 @@ export default function ConfirmKeyScreen({
         onFailure={handleFailure}
       />
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} />
     </View>
   );
 }

--- a/src/screens/keypair/MnemonicScreen.tsx
+++ b/src/screens/keypair/MnemonicScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Keyboard,
   Platform,
@@ -29,6 +29,7 @@ import {
 } from '../../hooks/keycard/useLoadKey';
 import { useVerifyFingerprint } from '../../hooks/keycard/useVerifyFingerprint';
 import { deriveMnemonicFingerprint } from '../../hooks/keycard/useVerifyMnemonic';
+import { useKeycardScreen } from '../../hooks/useKeycardScreen';
 import { decodeSeedQr, isSeedQrPayload } from '../../utils/seedQr';
 
 export default function MnemonicScreen({
@@ -64,7 +65,6 @@ export default function MnemonicScreen({
   const loadKey = useLoadKey();
   const verifyFingerprint = useVerifyFingerprint();
   const keycard = mode === 'verify' ? verifyFingerprint : loadKey;
-  const { phase, result, cancel } = keycard;
 
   const handleTextChange = useCallback((text: string) => {
     setInput(text);
@@ -85,52 +85,29 @@ export default function MnemonicScreen({
     loadKey.start(deriveMnemonicKeyPair(words, passphrase || undefined));
   }, [loadKey, mode, passphrase, verifyFingerprint, words]);
 
-  const handleCancel = useCallback(() => {
-    cancel();
-  }, [cancel]);
-
   const handleScanPress = useCallback(() => {
     setScanError(null);
     setScanning(true);
   }, []);
 
-  useEffect(() => {
-    if (phase !== 'done') {
-      return;
-    }
-    if (mode === 'verify') {
-      navigation.reset({
-        index: 0,
-        routes: [
-          {
-            name: 'Dashboard',
-            params: {
-              toast:
-                result === 'match'
-                  ? 'Recovery phrase matches'
-                  : 'Recovery phrase does not match',
-            },
-          },
-        ],
-      });
-    } else {
-      navigation.navigate('Dashboard', {
-        toast: 'Key pair has been added to Keycard',
-      });
-    }
-  }, [phase, result, mode, navigation]);
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      title: scanning
-        ? 'Scan SeedQR'
-        : phase === 'pin_entry'
-        ? 'Enter Keycard PIN'
-        : mode === 'verify'
-        ? 'Verify recovery phrase'
-        : 'Import recovery phrase',
-    });
-  }, [navigation, phase, mode, scanning]);
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: scanning
+      ? 'Scan SeedQR'
+      : mode === 'verify'
+      ? 'Verify recovery phrase'
+      : 'Import recovery phrase',
+    done: {
+      toast: doneResult =>
+        mode === 'verify'
+          ? doneResult === 'match'
+            ? 'Recovery phrase matches'
+            : 'Recovery phrase does not match'
+          : 'Key pair has been added to Keycard',
+    },
+    stayOnCancel: true,
+  });
 
   useEffect(() => {
     if (!scanning) return;
@@ -212,7 +189,7 @@ export default function MnemonicScreen({
         />
       </View>
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} />
 
       {scanning && (
         <CameraView

--- a/src/screens/keypair/Slip39Screen.tsx
+++ b/src/screens/keypair/Slip39Screen.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Keyboard,
@@ -31,6 +25,7 @@ import { useGenerateSlip39Shares } from '../../hooks/keycard/useGenerateSlip39Sh
 import { useLoadKey } from '../../hooks/keycard/useLoadKey';
 import { useSeedReviewTimer } from '../../hooks/useSeedReviewTimer';
 import { useVerifyFingerprint } from '../../hooks/keycard/useVerifyFingerprint';
+import { useKeycardScreen } from '../../hooks/useKeycardScreen';
 import { pubKeyFingerprint } from '../../utils/cryptoAccount';
 import {
   SLIP39_MAX_SHARES,
@@ -112,8 +107,6 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
     mode === 'generate' && generatedShares.length === 0
       ? generateSlip39
       : keycard;
-  const { phase, result } = keycard;
-  const activePhase = activeKeycard.phase;
 
   const progress = useMemo(() => {
     if (operationShares.length === 0) {
@@ -254,10 +247,6 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
     }
   }, [generateSlip39]);
 
-  const handleCancel = useCallback(() => {
-    activeKeycard.cancel();
-  }, [activeKeycard]);
-
   useEffect(() => {
     if (
       mode !== 'generate' ||
@@ -292,50 +281,33 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
     return () => clearTimeout(timeout);
   }, [mode, generateSlip39, parsedShareCount, parsedThreshold]);
 
-  useEffect(() => {
-    if (phase !== 'done') {
-      return;
-    }
-
-    if (mode === 'verify') {
-      navigation.reset({
-        index: 0,
-        routes: [
-          {
-            name: 'Dashboard',
-            params: {
-              toast:
-                result === 'match'
-                  ? 'SLIP39 shares match'
-                  : 'SLIP39 shares do not match',
-            },
-          },
-        ],
-      });
-      return;
-    }
-
-    navigation.navigate('Dashboard', {
-      toast: 'Key pair has been added to Keycard',
-    });
-  }, [phase, result, mode, navigation]);
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      title:
-        activePhase === 'pin_entry'
-          ? 'Enter Keycard PIN'
-          : mode === 'generate' && backupStep === 'confirm'
-          ? 'Check SLIP39 share'
-          : mode === 'generate' && generatedSharesReady
-          ? 'Backup SLIP39 share'
-          : mode === 'generate'
-          ? 'Generate SLIP39 shares'
-          : mode === 'verify'
-          ? 'Verify SLIP39 shares'
-          : 'Import SLIP39 shares',
-    });
-  }, [navigation, activePhase, backupStep, generatedSharesReady, mode]);
+  // Done-navigation keys on the load/verify hook (`keycard`); the back guard,
+  // PIN-entry title, and cancel key on whichever hook is running the tap
+  // (`activeKeycard`, which is the generate hook during share generation).
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title:
+      mode === 'generate' && backupStep === 'confirm'
+        ? 'Check SLIP39 share'
+        : mode === 'generate' && generatedSharesReady
+        ? 'Backup SLIP39 share'
+        : mode === 'generate'
+        ? 'Generate SLIP39 shares'
+        : mode === 'verify'
+        ? 'Verify SLIP39 shares'
+        : 'Import SLIP39 shares',
+    done: {
+      toast: doneResult =>
+        mode === 'verify'
+          ? doneResult === 'match'
+            ? 'SLIP39 shares match'
+            : 'SLIP39 shares do not match'
+          : 'Key pair has been added to Keycard',
+    },
+    activeKeycard,
+    stayOnCancel: true,
+  });
 
   const isReady =
     mode === 'generate' ? generatedBackupComplete : progress?.complete ?? false;
@@ -377,7 +349,7 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
           />
         </View>
 
-        <NFCBottomSheet nfc={activeKeycard} onCancel={handleCancel} />
+        <NFCBottomSheet nfc={activeKeycard} onCancel={onCancel} />
       </View>
     );
   }
@@ -396,7 +368,7 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
           </View>
         </View>
 
-        <NFCBottomSheet nfc={activeKeycard} onCancel={handleCancel} />
+        <NFCBottomSheet nfc={activeKeycard} onCancel={onCancel} />
       </View>
     );
   }
@@ -609,7 +581,7 @@ export default function Slip39Screen({ navigation, route }: Slip39ScreenProps) {
         ) : null}
       </View>
 
-      <NFCBottomSheet nfc={activeKeycard} onCancel={handleCancel} />
+      <NFCBottomSheet nfc={activeKeycard} onCancel={onCancel} />
     </View>
   );
 }

--- a/src/screens/secrets/ChangeSecretScreen.tsx
+++ b/src/screens/secrets/ChangeSecretScreen.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useLayoutEffect } from 'react';
-import { BackHandler, StyleSheet, View } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type {
@@ -10,6 +9,7 @@ import type {
 
 import { useChangeSecret } from '../../hooks/keycard/useChangeSecret';
 import { useConfirmedEntry } from '../../hooks/useConfirmedEntry';
+import { useKeycardScreen } from '../../hooks/useKeycardScreen';
 
 import theme from '../../theme';
 import NFCBottomSheet from '../../components/NFCBottomSheet';
@@ -56,73 +56,34 @@ export default function ChangeSecretScreen({
   const insets = useSafeAreaInsets();
 
   const keycard = useChangeSecret(secretType);
-  const { phase, result, cancel } = keycard;
+  const { phase } = keycard;
 
   const entry = useConfirmedEntry(newSecret => keycard.start(newSecret), {
     length: config.length,
   });
 
-  useEffect(() => {
-    if (phase !== 'done') {
-      return;
-    }
-
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'Dashboard', params: { toast: config.toast } }],
-    });
-  }, [phase, result, navigation, config.toast]);
-
-  const handleCancel = useCallback(() => {
-    cancel();
-    navigation.goBack();
-  }, [cancel, navigation]);
-
-  const goBack = useCallback(() => {
-    if (phase === 'nfc' || phase === 'pin_entry') {
-      cancel();
-      navigation.goBack();
-      return true;
-    }
-
+  const onScreenBack = useCallback(() => {
     const handled = entry.goBack();
     if (!handled) {
       navigation.goBack();
     }
     return true;
-  }, [phase, entry, cancel, navigation]);
+  }, [entry, navigation]);
 
-  useFocusEffect(
-    useCallback(() => {
-      const sub = BackHandler.addEventListener('hardwareBackPress', goBack);
-      return () => sub.remove();
-    }, [goBack]),
-  );
-
-  useEffect(() => {
-    const unsubscribe = navigation.addListener('beforeRemove', e => {
-      if (phase === 'nfc' || phase === 'pin_entry') {
-        cancel();
-        return;
-      }
+  const { onCancel } = useKeycardScreen({
+    keycard,
+    navigation,
+    title: entry.step === 'entry' ? config.entryTitle : config.confirmTitle,
+    pinEntryTitle: 'Enter current PIN',
+    done: { toast: config.toast },
+    onHardwareBack: onScreenBack,
+    onBeforeRemove: e => {
       if (entry.step === 'confirm') {
         e.preventDefault();
         entry.goBack();
       }
-    });
-    return unsubscribe;
-  }, [navigation, phase, entry, cancel]);
-
-  const title =
-    phase === 'pin_entry'
-      ? 'Enter current PIN'
-      : entry.step === 'entry'
-      ? config.entryTitle
-      : config.confirmTitle;
-
-  useLayoutEffect(() => {
-    navigation.setOptions({ title });
-  }, [navigation, title]);
+    },
+  });
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom + 16 }]}>
@@ -149,7 +110,7 @@ export default function ChangeSecretScreen({
         />
       )}
 
-      <NFCBottomSheet nfc={keycard} onCancel={handleCancel} showOnDone />
+      <NFCBottomSheet nfc={keycard} onCancel={onCancel} showOnDone />
     </View>
   );
 }


### PR DESCRIPTION
Closes #237

## Summary

Eight screens re-implemented the same three-part lifecycle adapter with copy-paste variations: a `phase === 'done'` effect that navigates to Dashboard with a toast (some checking `result`, some not, two using `navigate` instead of `reset`), BackHandler + `beforeRemove` cancel wiring (~35 near-identical lines in InitCard and ChangeSecret, absent everywhere else), and a `pin_entry` header-title switch (four copies). The variations were undocumented; each screen test re-mocked the hook and re-covered a subset.

New `src/hooks/useKeycardScreen.ts` owns the adapter:

- **done**: `reset` to Dashboard with a toast (`string` or `result => string`); `requireResult` for InitCard
- **back guard**: hardware back and `beforeRemove` during `'nfc'`/`'pin_entry'` cancel the NFC session first, then defer to the screen's step machine via `onHardwareBack`/`onBeforeRemove`
- **title**: `pin_entry` swaps in `pinEntryTitle` (default "Enter Keycard PIN"; ChangeSecret keeps "Enter current PIN")
- returns `onCancel` for NFCBottomSheet; `stayOnCancel` for screens that keep the user in place (Mnemonic, Slip39)
- `activeKeycard` override for dual-hook screens: Slip39's guard, title, and cancel key on whichever hook is running the tap, while done-navigation stays keyed on the load/verify hook, so share generation completing can never trigger the Dashboard reset (regression-tested)

Adopted by InitCard, ChangeSecret, FactoryReset, SetCardName, Mnemonic, Slip39, ConfirmKey, and AddressList. Each screen keeps only its entry UI and step machine.

## Behavior changes (deliberate, discussed)

- **Import flows unified on reset**: Mnemonic import and ConfirmKey used `navigate`, leaving seed-entry screens (holding seed material in state) on the stack beneath Dashboard. All done-paths now `reset`.
- **Back-press session leak fixed**: previously only InitCard and ChangeSecret cancelled the NFC session on back; the other six screens popped with the session still running. The guard now covers all eight.

## Test plan

- New `__tests__/useKeycardScreen.test.ts`: 19 tests, 100% branch coverage; phase sequences asserted against navigation calls once, instead of via eight screen suites
- Screen suites updated: navigation mocks gained `addListener`, navigate-to-reset assertions for the unified import flows
- Full suite 1461 passed; ESLint and Prettier clean; no new tsc errors

## Notes

- Builds on #236's typed phase unions (the guard's phase set is compiler-checked)
- Leverage for PLAN_NFC_RECONNECT: phase-machine changes now audit one module instead of eight screens
