### PR TITLE
refactor: ExportTarget table, remove bitget sentinel and path-regex routing in wallet export

### DIFF
--- a/__tests__/ExportKeyScreen.test.tsx
+++ b/__tests__/ExportKeyScreen.test.tsx
@@ -142,64 +142,61 @@ describe('ExportKeyScreen', () => {
       fireEvent.press(screen.getByText('Ethereum'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/44'/60'/0'",
-        source: 'account.standard',
+        target: 'ethereum',
       });
     });
 
-    it('navigates to Keycard with Bitcoin export path when Bitcoin is pressed', async () => {
+    it('navigates to Keycard with the bitcoin target when Bitcoin is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/84'/0'/0'",
+        target: 'bitcoin',
       });
     });
 
-    it('navigates to Keycard with multisig export path when Bitcoin Multisig is pressed', async () => {
+    it('navigates to Keycard with the bitcoin-multisig target when Bitcoin Multisig is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin Multisig'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/48'/0'/0'/2'",
+        target: 'bitcoin-multisig',
       });
     });
 
-    it('navigates to Keycard with testnet export path when Bitcoin Testnet is pressed', async () => {
+    it('navigates to Keycard with the bitcoin-testnet target when Bitcoin Testnet is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Bitcoin Testnet'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/84'/1'/0'",
+        target: 'bitcoin-testnet',
       });
     });
 
-    it('navigates to Keycard with source "account.ledger_live" when Ledger Live is pressed', async () => {
+    it('navigates to Keycard with the ledger-live target when Ledger Live is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Ledger Live'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/44'/60'/0'",
-        source: 'account.ledger_live',
+        target: 'ledger-live',
       });
     });
 
-    it('navigates to Keycard with source "account.ledger_legacy" when Ledger Legacy is pressed', async () => {
+    it('navigates to Keycard with the ledger-legacy target when Ledger Legacy is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Ledger Legacy'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: "m/44'/60'/0'",
-        source: 'account.ledger_legacy',
+        target: 'ledger-legacy',
       });
     });
 
-    it('navigates to Keycard with derivationPath "bitget" when Bitget is pressed', async () => {
+    it('navigates to Keycard with the bitget target when Bitget is pressed', async () => {
       await renderScreen();
       fireEvent.press(screen.getByText('Bitget'));
       expect(navigation.navigate).toHaveBeenCalledWith('Keycard', {
         operation: 'export_key',
-        derivationPath: 'bitget',
+        target: 'bitget',
       });
     });
   });

--- a/__tests__/KeycardScreen.test.tsx
+++ b/__tests__/KeycardScreen.test.tsx
@@ -35,7 +35,6 @@ jest.mock('../src/utils/cryptoHdKey', () => ({
 
 jest.mock('../src/utils/cryptoMultiAccounts', () => ({
   buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
-  exportKeysForBitget: jest.fn(),
 }));
 
 jest.mock('../src/utils/btcPsbt', () => ({
@@ -64,7 +63,7 @@ jest.mock('../src/utils/keycardExport', () => {
   const actual = jest.requireActual('../src/utils/keycardExport');
   return {
     ...actual,
-    exportKeyForWallet: jest.fn(),
+    exportKeysForTarget: jest.fn(),
   };
 });
 
@@ -135,7 +134,7 @@ const btcMessageSignRoute = {
 const btcExportRoute = {
   params: {
     operation: 'export_key',
-    derivationPath: "m/84'/0'/0'",
+    target: 'bitcoin',
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -144,8 +143,7 @@ const btcExportRoute = {
 const ethExportRoute = {
   params: {
     operation: 'export_key',
-    derivationPath: "m/44'/60'/0'",
-    source: 'account.standard',
+    target: 'ethereum',
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -154,7 +152,7 @@ const ethExportRoute = {
 const bitgetExportRoute = {
   params: {
     operation: 'export_key',
-    derivationPath: 'bitget',
+    target: 'bitget',
   },
   key: 'Keycard',
   name: 'Keycard',
@@ -293,7 +291,7 @@ describe('KeycardScreen', () => {
 
       mockUseKeycardOperation.mockReturnValue({
         ...hookMock('done'),
-        result: { masterFingerprint: 1, descriptors: [] },
+        result: { masterFingerprint: 1, keys: [] },
       });
       await renderWithMockedHook(btcExportRoute);
       await act(async () => {
@@ -316,9 +314,17 @@ describe('KeycardScreen', () => {
       mockUseKeycardOperation.mockReturnValue({
         ...hookMock('done'),
         result: {
-          exportRespData: new Uint8Array([1, 2, 3]),
-          sourceFingerprint: 0xdeadbeef,
-          parentFingerprint: 0xaabbccdd,
+          masterFingerprint: 0xdeadbeef,
+          keys: [
+            {
+              entry: {
+                derivationPath: "m/44'/60'/0'",
+                parentPath: "m/44'/60'",
+              },
+              exportRespData: new Uint8Array([1, 2, 3]),
+              parentFingerprint: 0xaabbccdd,
+            },
+          ],
         },
       });
       await renderWithMockedHook(ethExportRoute);
@@ -554,13 +560,14 @@ describe('KeycardScreen', () => {
   });
 
   describe('export execute callback', () => {
-    it('calls exportKeyForWallet with derivationPath and setStatus', async () => {
-      const { exportKeyForWallet } = require('../src/utils/keycardExport') as {
-        exportKeyForWallet: jest.Mock;
+    it("calls exportKeysForTarget with the target's plan and setStatus", async () => {
+      const { exportKeysForTarget } = require('../src/utils/keycardExport') as {
+        exportKeysForTarget: jest.Mock;
       };
-      exportKeyForWallet.mockResolvedValue({
-        exportRespData: new Uint8Array([1]),
-      });
+      exportKeysForTarget.mockResolvedValue({ masterFingerprint: 1, keys: [] });
+      const { getExportTarget } = jest.requireActual(
+        '../src/utils/exportTargets',
+      );
 
       await renderScreen('pin_entry', ethExportRoute);
 
@@ -569,9 +576,9 @@ describe('KeycardScreen', () => {
       const setStatus = jest.fn();
       await exportOp(cmdSet, { setStatus });
 
-      expect(exportKeyForWallet).toHaveBeenCalledWith(
+      expect(exportKeysForTarget).toHaveBeenCalledWith(
         cmdSet,
-        ethExportRoute.params.derivationPath,
+        getExportTarget('ethereum').keys,
         setStatus,
       );
     });

--- a/__tests__/cryptoMultiAccounts.test.ts
+++ b/__tests__/cryptoMultiAccounts.test.ts
@@ -2,8 +2,7 @@ import { CryptoMultiAccounts } from '@keystonehq/bc-ur-registry';
 import { URDecoder } from '@ngraveio/bc-ur';
 import {
   buildCryptoMultiAccountsUR,
-  exportKeysForBitget,
-  type BitgetExportResult,
+  type MultiAccountKey,
 } from '../src/utils/cryptoMultiAccounts';
 
 /* eslint-disable no-bitwise */
@@ -69,31 +68,6 @@ function buildExtendedKeyTLV(
   return tlvEncode(0xa1, inner);
 }
 
-function makeMockCmdSet() {
-  let exportKeyCall = 0;
-  let exportExtendedKeyCall = 0;
-
-  return {
-    exportKey: jest.fn().mockImplementation(() => {
-      const seed = ++exportKeyCall;
-      const pub = new Uint8Array(65);
-      pub[0] = 0x04;
-      pub[1] = seed;
-      const data = tlvEncode(0xa1, concat(tlvEncode(0x80, pub)));
-      return Promise.resolve({ checkOK: jest.fn(), data });
-    }),
-    exportExtendedKey: jest.fn().mockImplementation(() => {
-      const seed = ++exportExtendedKeyCall;
-      const pub = new Uint8Array(65);
-      pub[0] = 0x04;
-      pub[1] = seed + 100;
-      const cc = new Uint8Array(32).fill(seed);
-      const data = buildExtendedKeyTLV(pub, cc);
-      return Promise.resolve({ checkOK: jest.fn(), data });
-    }),
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -106,21 +80,22 @@ const DERIVATION_PATHS = [
   "m/44'/60'/0'",
 ];
 
-function buildFixture(): BitgetExportResult {
-  return {
-    masterFingerprint: MASTER_FINGERPRINT,
-    keys: DERIVATION_PATHS.map((derivationPath, i) => {
-      const pub = new Uint8Array(65);
-      pub[0] = 0x04;
-      pub[1] = i + 1; // distinguishable per key
-      const cc = new Uint8Array(32).fill(i + 1);
-      return {
-        derivationPath,
-        exportRespData: buildExtendedKeyTLV(pub, cc),
-        parentFingerprint: 0x11000000 + i,
-      };
-    }),
-  };
+function buildFixture(): MultiAccountKey[] {
+  return DERIVATION_PATHS.map((derivationPath, i) => {
+    const pub = new Uint8Array(65);
+    pub[0] = 0x04;
+    pub[1] = i + 1; // distinguishable per key
+    const cc = new Uint8Array(32).fill(i + 1);
+    return {
+      derivationPath,
+      exportRespData: buildExtendedKeyTLV(pub, cc),
+      parentFingerprint: 0x11000000 + i,
+      // Keys 0-2 are BTC (coin type 0), key 3 is ETH with the EIP-4527 source
+      coinType: i === 3 ? 60 : 0,
+      network: 0,
+      ...(i === 3 ? { source: 'account.standard' } : {}),
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -138,50 +113,6 @@ function decodeMultiAccounts(urString: string): CryptoMultiAccounts {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// exportKeysForBitget
-// ---------------------------------------------------------------------------
-
-describe('exportKeysForBitget', () => {
-  it('calls setStatus with progress messages', async () => {
-    const cmdSet = makeMockCmdSet() as any;
-    const setStatus = jest.fn();
-    await exportKeysForBitget(cmdSet, setStatus);
-
-    expect(setStatus).toHaveBeenCalledWith('Reading master key...');
-    expect(setStatus).toHaveBeenCalledWith('Exporting key 1 of 4...');
-    expect(setStatus).toHaveBeenCalledWith('Exporting key 2 of 4...');
-    expect(setStatus).toHaveBeenCalledWith('Exporting key 3 of 4...');
-    expect(setStatus).toHaveBeenCalledWith('Exporting key 4 of 4...');
-  });
-
-  it('returns 4 keys and a masterFingerprint', async () => {
-    const cmdSet = makeMockCmdSet() as any;
-    const result = await exportKeysForBitget(cmdSet, jest.fn());
-    expect(result.keys).toHaveLength(4);
-    expect(typeof result.masterFingerprint).toBe('number');
-  });
-
-  it('each key has a parentFingerprint', async () => {
-    const cmdSet = makeMockCmdSet() as any;
-    const result = await exportKeysForBitget(cmdSet, jest.fn());
-    for (const key of result.keys) {
-      expect(typeof key.parentFingerprint).toBe('number');
-    }
-  });
-
-  it('keys have the correct derivation paths', async () => {
-    const cmdSet = makeMockCmdSet() as any;
-    const result = await exportKeysForBitget(cmdSet, jest.fn());
-    expect(result.keys.map(k => k.derivationPath)).toEqual([
-      "m/84'/0'/0'",
-      "m/49'/0'/0'",
-      "m/44'/0'/0'",
-      "m/44'/60'/0'",
-    ]);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // buildCryptoMultiAccountsUR
 // ---------------------------------------------------------------------------
 
@@ -190,7 +121,7 @@ describe('buildCryptoMultiAccountsUR', () => {
   let multiAccounts: CryptoMultiAccounts;
 
   beforeAll(() => {
-    urString = buildCryptoMultiAccountsUR(buildFixture());
+    urString = buildCryptoMultiAccountsUR(MASTER_FINGERPRINT, buildFixture());
     multiAccounts = decodeMultiAccounts(urString);
   });
 

--- a/__tests__/exportTargets.test.ts
+++ b/__tests__/exportTargets.test.ts
@@ -1,0 +1,155 @@
+import type { ExportedKey } from '../src/utils/keycardExport';
+import { EXPORT_TARGETS, getExportTarget } from '../src/utils/exportTargets';
+
+jest.mock('../src/utils/cryptoHdKey', () => ({
+  buildCryptoHdKeyUR: jest.fn(() => 'ur:crypto-hdkey/mock'),
+}));
+jest.mock('../src/utils/cryptoAccount', () => ({
+  buildCryptoAccountUR: jest.fn(() => 'ur:crypto-account/mock'),
+}));
+jest.mock('../src/utils/cryptoMultiAccounts', () => ({
+  buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
+}));
+
+const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey');
+const { buildCryptoAccountUR } = require('../src/utils/cryptoAccount');
+const {
+  buildCryptoMultiAccountsUR,
+} = require('../src/utils/cryptoMultiAccounts');
+
+function exportedKeys(target: { keys: readonly any[] }): ExportedKey<any>[] {
+  return target.keys.map((entry, i) => ({
+    entry,
+    exportRespData: new Uint8Array([i]),
+    parentFingerprint: 0x1000 + i,
+  }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('export plans', () => {
+  it('declares seven targets in menu order', () => {
+    expect(EXPORT_TARGETS.map(t => t.id)).toEqual([
+      'ethereum',
+      'bitcoin',
+      'bitcoin-multisig',
+      'bitcoin-testnet',
+      'bitget',
+      'ledger-live',
+      'ledger-legacy',
+    ]);
+  });
+
+  it('every plan entry pairs a derivation path with its parent path', () => {
+    for (const target of EXPORT_TARGETS) {
+      for (const entry of target.keys) {
+        expect(entry.derivationPath.startsWith('m/')).toBe(true);
+        expect(
+          entry.parentPath === 'm' ||
+            entry.derivationPath.startsWith(entry.parentPath + '/'),
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('bitcoin single-sig plans export wpkh, sh-wpkh, and pkh accounts', () => {
+    const paths = getExportTarget('bitcoin').keys.map(k => k.derivationPath);
+    expect(paths).toEqual(["m/84'/0'/0'", "m/49'/0'/0'", "m/44'/0'/0'"]);
+    const testnetPaths = getExportTarget('bitcoin-testnet').keys.map(
+      k => k.derivationPath,
+    );
+    expect(testnetPaths).toEqual(["m/84'/1'/0'", "m/49'/1'/0'", "m/44'/1'/0'"]);
+  });
+
+  it('bitcoin multisig plan includes the m/45 fallback with the master as parent', () => {
+    const keys = getExportTarget('bitcoin-multisig').keys;
+    expect(keys.map(k => k.derivationPath)).toEqual([
+      "m/48'/0'/0'/2'",
+      "m/48'/0'/0'/1'",
+      "m/45'",
+    ]);
+    expect(keys[2].parentPath).toBe('m');
+  });
+
+  it('getExportTarget throws on unknown ids', () => {
+    expect(() => getExportTarget('nope' as any)).toThrow(
+      'Unknown export target',
+    );
+  });
+});
+
+describe('buildUr wiring', () => {
+  it('ethereum targets build a crypto-hdkey with the master and parent fingerprints and their source', () => {
+    for (const [id, source] of [
+      ['ethereum', 'account.standard'],
+      ['ledger-live', 'account.ledger_live'],
+      ['ledger-legacy', 'account.ledger_legacy'],
+    ] as const) {
+      const target = getExportTarget(id);
+      const keys = exportedKeys(target);
+      const ur = target.buildUr({ masterFingerprint: 0xaa, keys });
+
+      expect(buildCryptoHdKeyUR).toHaveBeenCalledWith(
+        keys[0].exportRespData,
+        "m/44'/60'/0'",
+        0xaa,
+        keys[0].parentFingerprint,
+        source,
+      );
+      expect(ur).toBe('ur:crypto-hdkey/mock');
+    }
+  });
+
+  it('bitcoin targets build a crypto-account whose descriptors carry each key script type', () => {
+    const target = getExportTarget('bitcoin');
+    const keys = exportedKeys(target);
+    target.buildUr({ masterFingerprint: 0xbb, keys });
+
+    expect(buildCryptoAccountUR).toHaveBeenCalledWith({
+      masterFingerprint: 0xbb,
+      descriptors: [
+        {
+          derivationPath: "m/84'/0'/0'",
+          exportRespData: keys[0].exportRespData,
+          parentFingerprint: keys[0].parentFingerprint,
+          scriptType: 'wpkh',
+        },
+        {
+          derivationPath: "m/49'/0'/0'",
+          exportRespData: keys[1].exportRespData,
+          parentFingerprint: keys[1].parentFingerprint,
+          scriptType: 'sh-wpkh',
+        },
+        {
+          derivationPath: "m/44'/0'/0'",
+          exportRespData: keys[2].exportRespData,
+          parentFingerprint: keys[2].parentFingerprint,
+          scriptType: 'pkh',
+        },
+      ],
+    });
+  });
+
+  it('bitget builds a crypto-multi-accounts where every key carries its own coin metadata', () => {
+    const target = getExportTarget('bitget');
+    const keys = exportedKeys(target);
+    target.buildUr({ masterFingerprint: 0xcc, keys });
+
+    expect(buildCryptoMultiAccountsUR).toHaveBeenCalledWith(0xcc, [
+      expect.objectContaining({
+        derivationPath: "m/84'/0'/0'",
+        coinType: 0,
+        source: undefined,
+      }),
+      expect.objectContaining({ derivationPath: "m/49'/0'/0'", coinType: 0 }),
+      expect.objectContaining({ derivationPath: "m/44'/0'/0'", coinType: 0 }),
+      expect.objectContaining({
+        derivationPath: "m/44'/60'/0'",
+        coinType: 60,
+        source: 'account.standard',
+      }),
+    ]);
+  });
+});

--- a/__tests__/keycardExport.test.ts
+++ b/__tests__/keycardExport.test.ts
@@ -1,190 +1,140 @@
-import { buildExportUr, exportKeyForWallet } from '../src/utils/keycardExport';
+import { exportKeysForTarget } from '../src/utils/keycardExport';
 
 jest.mock('keycard-sdk', () => ({
   __esModule: true,
   default: {
     BIP32KeyPair: {
-      fromTLV: jest.fn(() => ({ publicKey: new Uint8Array([9, 9, 9]) })),
+      fromTLV: jest.fn((data: Uint8Array) => ({ publicKey: data })),
     },
   },
 }));
 
-jest.mock('../src/utils/cryptoHdKey', () => ({
-  buildCryptoHdKeyUR: jest.fn(() => 'ur:crypto-hdkey/mock'),
-}));
 jest.mock('../src/utils/cryptoAccount', () => ({
-  buildCryptoAccountUR: jest.fn(() => 'ur:crypto-account/mock'),
-  pubKeyFingerprint: jest.fn(() => 0xdeadbeef),
-}));
-jest.mock('../src/utils/cryptoMultiAccounts', () => ({
-  buildCryptoMultiAccountsUR: jest.fn(() => 'ur:crypto-multi-accounts/mock'),
-  exportKeysForBitget: jest.fn(),
+  pubKeyFingerprint: jest.fn(
+    (pub: Uint8Array) => 0xf0000000 + pub[0], // distinct per response
+  ),
 }));
 
-describe('buildExportUr', () => {
-  const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey');
-  const { buildCryptoAccountUR } = require('../src/utils/cryptoAccount');
-  const {
-    buildCryptoMultiAccountsUR,
-  } = require('../src/utils/cryptoMultiAccounts');
+// exportKey responses carry a tag byte the fingerprint mock keys off.
+function response(tag: number) {
+  return { checkOK: jest.fn(), data: new Uint8Array([tag]) };
+}
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    buildCryptoHdKeyUR.mockReturnValue('ur:crypto-hdkey/mock');
-    buildCryptoAccountUR.mockReturnValue('ur:crypto-account/mock');
-    buildCryptoMultiAccountsUR.mockReturnValue('ur:crypto-multi-accounts/mock');
+function makeCmdSet(parentTagsByPath: Record<string, number>) {
+  return {
+    exportKey: jest.fn((_p1: number, _p2: boolean, path: string) => {
+      const tag = path === 'm' ? 1 : parentTagsByPath[path];
+      if (tag === undefined) {
+        throw new Error(`Unexpected exportKey path: ${path}`);
+      }
+      return Promise.resolve(response(tag));
+    }),
+    exportExtendedKey: jest.fn((_p1: number, path: string) =>
+      Promise.resolve({
+        checkOK: jest.fn(),
+        data: new Uint8Array([0x50, path.length]),
+      }),
+    ),
+  } as any;
+}
+
+describe('exportKeysForTarget', () => {
+  it('exports the master key once and derives its fingerprint', async () => {
+    const cmdSet = makeCmdSet({ "m/44'/60'": 2 });
+    const result = await exportKeysForTarget(cmdSet, [
+      { derivationPath: "m/44'/60'/0'", parentPath: "m/44'/60'" },
+    ]);
+
+    expect(cmdSet.exportKey).toHaveBeenCalledWith(0, true, 'm', false);
+    expect(result.masterFingerprint).toBe(0xf0000000 + 1);
   });
 
-  it('calls buildCryptoHdKeyUR when result has exportRespData', () => {
-    const result = buildExportUr(
-      {
-        exportRespData: new Uint8Array([1, 2, 3]),
-        sourceFingerprint: 0xdeadbeef,
-        parentFingerprint: 0xaabbccdd,
-      },
-      "m/44'/60'/0'",
-      'MetaMask',
+  it('exports each planned key with its parent fingerprint and embeds the entry', async () => {
+    const cmdSet = makeCmdSet({ "m/84'/0'": 2, "m/49'/0'": 3 });
+    const entries = [
+      { derivationPath: "m/84'/0'/0'", parentPath: "m/84'/0'", meta: 'a' },
+      { derivationPath: "m/49'/0'/0'", parentPath: "m/49'/0'", meta: 'b' },
+    ];
+
+    const result = await exportKeysForTarget(cmdSet, entries);
+
+    expect(cmdSet.exportExtendedKey).toHaveBeenNthCalledWith(
+      1,
+      0,
+      "m/84'/0'/0'",
+      false,
     );
-    expect(buildCryptoHdKeyUR).toHaveBeenCalledWith(
-      new Uint8Array([1, 2, 3]),
-      "m/44'/60'/0'",
-      0xdeadbeef,
-      0xaabbccdd,
-      'MetaMask',
-    );
-    expect(result).toBe('ur:crypto-hdkey/mock');
-  });
-
-  it('calls buildCryptoMultiAccountsUR when result has keys', () => {
-    const multiResult = { keys: [] } as any;
-    const result = buildExportUr(multiResult, 'bitget');
-    expect(buildCryptoMultiAccountsUR).toHaveBeenCalledWith(multiResult);
-    expect(result).toBe('ur:crypto-multi-accounts/mock');
-  });
-
-  it('calls buildCryptoAccountUR for Bitcoin crypto-account result', () => {
-    const btcResult = { masterFingerprint: 0xdeadbeef, descriptors: [] } as any;
-    const result = buildExportUr(btcResult, "m/84'/0'/0'");
-    expect(buildCryptoAccountUR).toHaveBeenCalledWith(btcResult);
-    expect(result).toBe('ur:crypto-account/mock');
-  });
-});
-
-describe('exportKeyForWallet', () => {
-  const { pubKeyFingerprint } = require('../src/utils/cryptoAccount');
-  const { exportKeysForBitget } = require('../src/utils/cryptoMultiAccounts');
-
-  const response = (data: number[]) => ({
-    checkOK: jest.fn(),
-    data: new Uint8Array(data),
-  });
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    pubKeyFingerprint.mockReturnValue(0xdeadbeef);
-  });
-
-  it('delegates Bitget exports to exportKeysForBitget', async () => {
-    const bitgetResult = { keys: [{ path: "m/44'/60'/0'/0/0" }] };
-    exportKeysForBitget.mockResolvedValue(bitgetResult);
-    const cmdSet = {} as any;
-    const setStatus = jest.fn();
-
-    await expect(exportKeyForWallet(cmdSet, 'bitget', setStatus)).resolves.toBe(
-      bitgetResult,
-    );
-    expect(exportKeysForBitget).toHaveBeenCalledWith(cmdSet, setStatus);
-  });
-
-  it('exports an Ethereum hdkey with master and parent fingerprints', async () => {
-    const masterResp = response([0, 1, 2]);
-    const parentResp = response([1, 2, 3]);
-    const extendedResp = response([4, 5, 6]);
-    pubKeyFingerprint.mockReturnValueOnce(0xaaaa).mockReturnValueOnce(0xbbbb);
-    const cmdSet = {
-      exportKey: jest
-        .fn()
-        .mockResolvedValueOnce(masterResp)
-        .mockResolvedValueOnce(parentResp),
-      exportExtendedKey: jest.fn().mockResolvedValue(extendedResp),
-    } as any;
-
-    const result = await exportKeyForWallet(cmdSet, "m/44'/60'/0'/0/0");
-
-    expect(cmdSet.exportKey).toHaveBeenNthCalledWith(1, 0, true, 'm', false);
-    expect(cmdSet.exportKey).toHaveBeenNthCalledWith(
+    expect(cmdSet.exportExtendedKey).toHaveBeenNthCalledWith(
       2,
       0,
-      true,
-      "m/44'/60'/0'/0",
+      "m/49'/0'/0'",
       false,
     );
-    expect(cmdSet.exportExtendedKey).toHaveBeenCalledWith(
-      0,
-      "m/44'/60'/0'/0/0",
-      false,
+    expect(result.keys).toHaveLength(2);
+    expect(result.keys[0].entry).toBe(entries[0]);
+    expect(result.keys[0].entry.meta).toBe('a');
+    expect(result.keys[0].parentFingerprint).toBe(0xf0000000 + 2);
+    expect(result.keys[1].parentFingerprint).toBe(0xf0000000 + 3);
+  });
+
+  it('fetches each distinct parent path once', async () => {
+    const cmdSet = makeCmdSet({ "m/48'/0'/0'": 2 });
+    await exportKeysForTarget(cmdSet, [
+      { derivationPath: "m/48'/0'/0'/2'", parentPath: "m/48'/0'/0'" },
+      { derivationPath: "m/48'/0'/0'/1'", parentPath: "m/48'/0'/0'" },
+    ]);
+
+    const parentCalls = cmdSet.exportKey.mock.calls.filter(
+      (c: unknown[]) => c[2] === "m/48'/0'/0'",
     );
-    expect(masterResp.checkOK).toHaveBeenCalled();
-    expect(parentResp.checkOK).toHaveBeenCalled();
-    expect(extendedResp.checkOK).toHaveBeenCalled();
-    expect(result).toEqual({
-      exportRespData: new Uint8Array([4, 5, 6]),
-      sourceFingerprint: 0xaaaa,
-      parentFingerprint: 0xbbbb,
-    });
+    expect(parentCalls).toHaveLength(1);
   });
 
-  it('builds Bitcoin descriptor exports for single-sig paths', async () => {
-    const cmdSet = {
-      exportKey: jest
-        .fn()
-        .mockResolvedValueOnce(response([0]))
-        .mockResolvedValueOnce(response([1]))
-        .mockResolvedValueOnce(response([2]))
-        .mockResolvedValueOnce(response([3])),
-      exportExtendedKey: jest
-        .fn()
-        .mockResolvedValueOnce(response([10]))
-        .mockResolvedValueOnce(response([20]))
-        .mockResolvedValueOnce(response([30])),
-    } as any;
+  it("reuses the master fingerprint for parentPath 'm' without re-exporting", async () => {
+    const cmdSet = makeCmdSet({});
+    const result = await exportKeysForTarget(cmdSet, [
+      { derivationPath: "m/45'", parentPath: 'm' },
+    ]);
 
-    const result = await exportKeyForWallet(cmdSet, "m/84'/0'/0'");
-
-    expect(result).toMatchObject({
-      masterFingerprint: 0xdeadbeef,
-      descriptors: [
-        { derivationPath: "m/84'/0'/0'", scriptType: 'wpkh' },
-        { derivationPath: "m/49'/0'/0'", scriptType: 'sh-wpkh' },
-        { derivationPath: "m/44'/0'/0'", scriptType: 'pkh' },
-      ],
-    });
-    expect(cmdSet.exportExtendedKey).toHaveBeenCalledTimes(3);
+    // exportKey called exactly once — for the master read.
+    expect(cmdSet.exportKey).toHaveBeenCalledTimes(1);
+    expect(result.keys[0].parentFingerprint).toBe(result.masterFingerprint);
   });
 
-  it('builds Bitcoin descriptor exports for multisig paths', async () => {
+  it('reports progress statuses', async () => {
+    const cmdSet = makeCmdSet({ "m/84'/0'": 2, "m/49'/0'": 3 });
+    const setStatus = jest.fn();
+    await exportKeysForTarget(
+      cmdSet,
+      [
+        { derivationPath: "m/84'/0'/0'", parentPath: "m/84'/0'" },
+        { derivationPath: "m/49'/0'/0'", parentPath: "m/49'/0'" },
+      ],
+      setStatus,
+    );
+
+    expect(setStatus).toHaveBeenCalledWith('Reading master key...');
+    expect(setStatus).toHaveBeenCalledWith('Exporting key 1 of 2...');
+    expect(setStatus).toHaveBeenCalledWith('Exporting key 2 of 2...');
+  });
+
+  it('checks every card response', async () => {
+    const bad = {
+      checkOK: jest.fn(() => {
+        throw new Error('SW error');
+      }),
+      data: new Uint8Array([1]),
+    };
     const cmdSet = {
-      exportKey: jest
-        .fn()
-        .mockResolvedValueOnce(response([0]))
-        .mockResolvedValueOnce(response([1]))
-        .mockResolvedValueOnce(response([2]))
-        .mockResolvedValueOnce(response([3])),
-      exportExtendedKey: jest
-        .fn()
-        .mockResolvedValueOnce(response([10]))
-        .mockResolvedValueOnce(response([20]))
-        .mockResolvedValueOnce(response([30])),
+      exportKey: jest.fn().mockResolvedValue(bad),
+      exportExtendedKey: jest.fn(),
     } as any;
 
-    const result = await exportKeyForWallet(cmdSet, "m/48'/0'/0'/2'");
-
-    expect(result).toMatchObject({
-      descriptors: [
-        { derivationPath: "m/48'/0'/0'/2'", scriptType: 'wsh' },
-        { derivationPath: "m/48'/0'/0'/1'", scriptType: 'sh-wsh' },
-        { derivationPath: "m/45'", scriptType: 'sh' },
-      ],
-    });
+    await expect(
+      exportKeysForTarget(cmdSet, [
+        { derivationPath: "m/44'/60'/0'", parentPath: "m/44'/60'" },
+      ]),
+    ).rejects.toThrow('SW error');
+    expect(cmdSet.exportExtendedKey).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/keycardFlows.test.ts
+++ b/__tests__/keycardFlows.test.ts
@@ -22,8 +22,11 @@ jest.mock('../src/utils/btcMessage', () => ({
 }));
 
 jest.mock('../src/utils/keycardExport', () => ({
-  buildExportUr: jest.fn(() => 'ur:crypto-hdkey/mock'),
-  exportKeyForWallet: jest.fn(),
+  exportKeysForTarget: jest.fn(),
+}));
+
+jest.mock('../src/utils/cryptoHdKey', () => ({
+  buildCryptoHdKeyUR: jest.fn(() => 'ur:crypto-hdkey/mock'),
 }));
 
 const {
@@ -39,10 +42,7 @@ const {
   parseKeycardBtcMessageSignature,
   buildBtcSignatureUR,
 } = require('../src/utils/btcMessage');
-const {
-  buildExportUr,
-  exportKeyForWallet,
-} = require('../src/utils/keycardExport');
+const { exportKeysForTarget } = require('../src/utils/keycardExport');
 
 const DIGEST_HEX = 'ab'.repeat(32);
 
@@ -63,7 +63,6 @@ beforeEach(() => {
   buildCryptoPsbtUR.mockReturnValue('ur:crypto-psbt/mock');
   hashBitcoinMessage.mockReturnValue(new Uint8Array(32).fill(0x77));
   buildBtcSignatureUR.mockReturnValue('ur:btc-signature/mock');
-  buildExportUr.mockReturnValue('ur:crypto-hdkey/mock');
 });
 
 describe('eth sign flow', () => {
@@ -236,38 +235,48 @@ describe('btc message flow', () => {
 });
 
 describe('export key flow', () => {
-  const params = {
-    operation: 'export_key',
-    derivationPath: "m/44'/60'/0'",
-    source: 'MetaMask',
-  } as any;
+  const params = { operation: 'export_key', target: 'ethereum' } as any;
+  const { getExportTarget } = jest.requireActual('../src/utils/exportTargets');
 
-  it('cardOp delegates to exportKeyForWallet with the derivation path', async () => {
-    const exportResult = { exportRespData: new Uint8Array([1]) };
-    exportKeyForWallet.mockResolvedValue(exportResult);
+  it("cardOp delegates to exportKeysForTarget with the target's plan", async () => {
+    const exportResult = { masterFingerprint: 1, keys: [] };
+    exportKeysForTarget.mockResolvedValue(exportResult);
 
     const flowRun = prepareKeycardFlow(params);
     const setStatus = jest.fn();
     const cmdSet = {} as any;
 
     await expect(flowRun.cardOp(cmdSet, setStatus)).resolves.toBe(exportResult);
-    expect(exportKeyForWallet).toHaveBeenCalledWith(
+    expect(exportKeysForTarget).toHaveBeenCalledWith(
       cmdSet,
-      params.derivationPath,
+      getExportTarget('ethereum').keys,
       setStatus,
     );
   });
 
-  it('buildOutput builds the export UR with the xpub explainer and export navigation', () => {
+  it("buildOutput builds the target's UR with the xpub explainer and export navigation", () => {
     const flowRun = prepareKeycardFlow(params);
-    const exportResult = { exportRespData: new Uint8Array([1]) };
+    const exportResult = {
+      masterFingerprint: 0xaa,
+      keys: [
+        {
+          entry: { derivationPath: "m/44'/60'/0'", parentPath: "m/44'/60'" },
+          exportRespData: new Uint8Array([1]),
+          parentFingerprint: 0xbb,
+        },
+      ],
+    };
 
     const outcome = flowRun.buildOutput(exportResult);
 
-    expect(buildExportUr).toHaveBeenCalledWith(
-      exportResult,
-      params.derivationPath,
-      params.source,
+    // The ethereum target's buildUr feeds the mocked crypto-hdkey builder.
+    const { buildCryptoHdKeyUR } = require('../src/utils/cryptoHdKey');
+    expect(buildCryptoHdKeyUR).toHaveBeenCalledWith(
+      new Uint8Array([1]),
+      "m/44'/60'/0'",
+      0xaa,
+      0xbb,
+      'account.standard',
     );
     expect(outcome).toEqual({
       kind: 'ur',

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -3,6 +3,7 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import type { WCContext } from '../constants/walletConnect';
 import type { ScanResult } from '../types';
+import type { ExportTargetId } from '../utils/exportTargets';
 
 export type KeycardParams =
   | {
@@ -31,8 +32,7 @@ export type KeycardParams =
     }
   | {
       operation: 'export_key';
-      derivationPath: string;
-      source?: string;
+      target: ExportTargetId;
     };
 // Future: | { operation: 'change_pin' } | { operation: 'generate_key' }
 

--- a/src/screens/ExportKeyScreen.tsx
+++ b/src/screens/ExportKeyScreen.tsx
@@ -13,6 +13,7 @@ import {
   loadXpubNoticeDismissed,
   saveXpubNoticeDismissed,
 } from '../storage/preferencesStorage';
+import { EXPORT_TARGETS } from '../utils/exportTargets';
 
 export const dashboardEntry: DashboardAction = {
   label: 'Connect software wallet',
@@ -44,74 +45,15 @@ export default function ExportKeyScreen({ navigation }: ExportKeyScreenProps) {
     saveXpubNoticeDismissed(true).catch(() => {});
   }, []);
 
-  const entries = [
-    {
-      label: 'Ethereum',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/44'/60'/0'",
-          source: 'account.standard',
-        }),
-    },
-    {
-      label: 'Bitcoin',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/84'/0'/0'",
-        }),
-    },
-    {
-      label: 'Bitcoin Multisig',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/48'/0'/0'/2'",
-        }),
-    },
-    {
-      label: 'Bitcoin Testnet',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/84'/1'/0'",
-        }),
-    },
-    {
-      label: 'Bitget',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: 'bitget',
-        }),
-    },
-    {
-      label: 'Ledger Live',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/44'/60'/0'",
-          source: 'account.ledger_live',
-        }),
-    },
-    {
-      label: 'Ledger Legacy',
-      requiresNfc: true,
-      onPress: () =>
-        navigation.navigate('Keycard', {
-          operation: 'export_key',
-          derivationPath: "m/44'/60'/0'",
-          source: 'account.ledger_legacy',
-        }),
-    },
-  ];
+  const entries = EXPORT_TARGETS.map(target => ({
+    label: target.label,
+    requiresNfc: true,
+    onPress: () =>
+      navigation.navigate('Keycard', {
+        operation: 'export_key',
+        target: target.id,
+      }),
+  }));
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom }]}>

--- a/src/utils/cryptoMultiAccounts.ts
+++ b/src/utils/cryptoMultiAccounts.ts
@@ -1,114 +1,33 @@
 import {
   CryptoCoinInfo,
-  CryptoCoinInfoNetwork,
-  CryptoCoinInfoType,
   CryptoHDKey,
   CryptoMultiAccounts,
 } from '@keystonehq/bc-ur-registry';
 import { encodeToUR } from './ur';
 import Keycard from 'keycard-sdk';
-import type { Commandset } from 'keycard-sdk/dist/commandset';
 
 import { APP_NAME } from '@/constants/app';
-import { pubKeyFingerprint } from './cryptoAccount';
-import { TLV_KEY_TEMPLATE, TLV_PUB_KEY } from './keycardTlv';
 import {
   derivationPathToKeypath,
   numberToFingerprintBuffer,
 } from './hdKeyUtils';
 
-// Coin type 60 for Ethereum — not exported by bc-ur-registry's CryptoCoinInfoType
-const COIN_TYPE_ETHEREUM = 60;
-
-// EIP-4527 source field — used by Bitget to distinguish account types
-const EIP4527_STANDARD = 'account.standard';
-
-type MultiAccountKey = {
+/** One key of a crypto-multi-accounts export, carrying its own coin metadata. */
+export type MultiAccountKey = {
   derivationPath: string;
-  parentPath: string;
+  exportRespData: Uint8Array;
+  parentFingerprint: number;
   coinType: number;
   network: number;
   source?: string;
 };
 
-const BITGET_KEYS: MultiAccountKey[] = [
-  {
-    derivationPath: "m/84'/0'/0'",
-    parentPath: "m/84'/0'",
-    coinType: CryptoCoinInfoType.bitcoin,
-    network: CryptoCoinInfoNetwork.mainnet,
-  },
-  {
-    derivationPath: "m/49'/0'/0'",
-    parentPath: "m/49'/0'",
-    coinType: CryptoCoinInfoType.bitcoin,
-    network: CryptoCoinInfoNetwork.mainnet,
-  },
-  {
-    derivationPath: "m/44'/0'/0'",
-    parentPath: "m/44'/0'",
-    coinType: CryptoCoinInfoType.bitcoin,
-    network: CryptoCoinInfoNetwork.mainnet,
-  },
-  {
-    derivationPath: "m/44'/60'/0'",
-    parentPath: "m/44'/60'",
-    coinType: COIN_TYPE_ETHEREUM,
-    network: CryptoCoinInfoNetwork.mainnet,
-    source: EIP4527_STANDARD,
-  },
-];
-
-export type BitgetExportResult = {
-  masterFingerprint: number;
-  keys: {
-    derivationPath: string;
-    exportRespData: Uint8Array;
-    parentFingerprint: number;
-  }[];
-};
-
-export async function exportKeysForBitget(
-  cmdSet: Commandset,
-  setStatus: (s: string) => void,
-): Promise<BitgetExportResult> {
-  setStatus('Reading master key...');
-  const rootResp = await cmdSet.exportKey(0, true, 'm', false);
-  rootResp.checkOK();
-
-  const tlv = new Keycard.BERTLV(rootResp.data);
-  tlv.enterConstructed(TLV_KEY_TEMPLATE);
-  const rootPubKey = tlv.readPrimitive(TLV_PUB_KEY);
-  const masterFingerprint = pubKeyFingerprint(rootPubKey);
-
-  const keys: BitgetExportResult['keys'] = [];
-  for (let i = 0; i < BITGET_KEYS.length; i++) {
-    const key = BITGET_KEYS[i];
-    setStatus(`Exporting key ${i + 1} of ${BITGET_KEYS.length}...`);
-
-    const parentResp = await cmdSet.exportKey(0, true, key.parentPath, false);
-    parentResp.checkOK();
-    const parentTlv = new Keycard.BERTLV(parentResp.data);
-    parentTlv.enterConstructed(TLV_KEY_TEMPLATE);
-    const parentPubKey = parentTlv.readPrimitive(TLV_PUB_KEY);
-    const parentFingerprint = pubKeyFingerprint(parentPubKey);
-
-    const resp = await cmdSet.exportExtendedKey(0, key.derivationPath, false);
-    resp.checkOK();
-    keys.push({
-      derivationPath: key.derivationPath,
-      exportRespData: resp.data,
-      parentFingerprint,
-    });
-  }
-
-  return { masterFingerprint, keys };
-}
-
-export function buildCryptoMultiAccountsUR(result: BitgetExportResult): string {
-  const hdKeys = result.keys.map((keyData, i) => {
+export function buildCryptoMultiAccountsUR(
+  masterFingerprint: number,
+  keys: MultiAccountKey[],
+): string {
+  const hdKeys = keys.map(keyData => {
     const parsed = Keycard.BIP32KeyPair.fromTLV(keyData.exportRespData);
-    const keySpec = BITGET_KEYS[i];
 
     return new CryptoHDKey({
       isMaster: false,
@@ -116,23 +35,23 @@ export function buildCryptoMultiAccountsUR(result: BitgetExportResult): string {
       chainCode: Buffer.from(parsed.chainCode),
       origin: derivationPathToKeypath(
         keyData.derivationPath,
-        result.masterFingerprint,
+        masterFingerprint,
       ),
-      useInfo: keySpec.source
-        ? new CryptoCoinInfo(keySpec.coinType, keySpec.network)
+      useInfo: keyData.source
+        ? new CryptoCoinInfo(keyData.coinType, keyData.network)
         : undefined,
       parentFingerprint: numberToFingerprintBuffer(keyData.parentFingerprint),
       name: APP_NAME,
-      note: keySpec.source,
+      note: keyData.source,
     });
   });
 
-  const deviceId = numberToFingerprintBuffer(result.masterFingerprint)
+  const deviceId = numberToFingerprintBuffer(masterFingerprint)
     .toString('hex')
     .toUpperCase();
 
   const cryptoMultiAccounts = new CryptoMultiAccounts(
-    numberToFingerprintBuffer(result.masterFingerprint),
+    numberToFingerprintBuffer(masterFingerprint),
     hdKeys,
     APP_NAME,
     deviceId,

--- a/src/utils/exportTargets.ts
+++ b/src/utils/exportTargets.ts
@@ -1,0 +1,209 @@
+import {
+  CryptoCoinInfoNetwork,
+  CryptoCoinInfoType,
+} from '@keystonehq/bc-ur-registry';
+
+import {
+  buildCryptoAccountUR,
+  type BitcoinAccountDescriptor,
+} from './cryptoAccount';
+import { buildCryptoHdKeyUR } from './cryptoHdKey';
+import { buildCryptoMultiAccountsUR } from './cryptoMultiAccounts';
+import type {
+  ExportedKey,
+  ExportKeysResult,
+  ExportPlanEntry,
+} from './keycardExport';
+
+// Coin type 60 for Ethereum — not exported by bc-ur-registry's CryptoCoinInfoType
+const COIN_TYPE_ETHEREUM = 60;
+
+export type ExportTargetId =
+  | 'ethereum'
+  | 'bitcoin'
+  | 'bitcoin-multisig'
+  | 'bitcoin-testnet'
+  | 'bitget'
+  | 'ledger-live'
+  | 'ledger-legacy';
+
+/**
+ * One wallet a key can be exported to: the menu label, the exact BIP32 paths
+ * to export (with the parent paths their fingerprints come from), and the
+ * pure UR builder for the exported keys. Adding a wallet target is one entry
+ * here — the card-session executor (exportKeysForTarget) and the Keycard
+ * screen are generic.
+ *
+ * The plan entries drive both the export order and the build: the executor
+ * embeds each entry in its ExportedKey, so per-key metadata (script type,
+ * coin info, EIP-4527 source) travels with the key instead of being matched
+ * up by array position.
+ */
+export type ExportTarget = {
+  id: ExportTargetId;
+  label: string;
+  keys: readonly ExportPlanEntry[];
+  buildUr: (result: ExportKeysResult) => string;
+};
+
+function ethereumTarget(
+  id: ExportTargetId,
+  label: string,
+  source: string,
+): ExportTarget {
+  return {
+    id,
+    label,
+    keys: [{ derivationPath: "m/44'/60'/0'", parentPath: "m/44'/60'" }],
+    buildUr: ({ masterFingerprint, keys: [key] }) =>
+      buildCryptoHdKeyUR(
+        key.exportRespData,
+        key.entry.derivationPath,
+        masterFingerprint,
+        key.parentFingerprint,
+        source,
+      ),
+  };
+}
+
+type BitcoinEntry = ExportPlanEntry & {
+  scriptType: BitcoinAccountDescriptor['scriptType'];
+};
+
+function bitcoinTarget(
+  id: ExportTargetId,
+  label: string,
+  keys: readonly BitcoinEntry[],
+): ExportTarget {
+  return {
+    id,
+    label,
+    keys,
+    buildUr: result =>
+      buildCryptoAccountUR({
+        masterFingerprint: result.masterFingerprint,
+        // The executor exported this target's own entries, so each key
+        // carries a BitcoinEntry.
+        descriptors: (result.keys as ExportedKey<BitcoinEntry>[]).map(key => ({
+          derivationPath: key.entry.derivationPath,
+          exportRespData: key.exportRespData,
+          parentFingerprint: key.parentFingerprint,
+          scriptType: key.entry.scriptType,
+        })),
+      }),
+  };
+}
+
+type BitgetEntry = ExportPlanEntry & {
+  coinType: number;
+  network: number;
+  source?: string;
+};
+
+const BITGET_KEYS: readonly BitgetEntry[] = [
+  {
+    derivationPath: "m/84'/0'/0'",
+    parentPath: "m/84'/0'",
+    coinType: CryptoCoinInfoType.bitcoin,
+    network: CryptoCoinInfoNetwork.mainnet,
+  },
+  {
+    derivationPath: "m/49'/0'/0'",
+    parentPath: "m/49'/0'",
+    coinType: CryptoCoinInfoType.bitcoin,
+    network: CryptoCoinInfoNetwork.mainnet,
+  },
+  {
+    derivationPath: "m/44'/0'/0'",
+    parentPath: "m/44'/0'",
+    coinType: CryptoCoinInfoType.bitcoin,
+    network: CryptoCoinInfoNetwork.mainnet,
+  },
+  {
+    derivationPath: "m/44'/60'/0'",
+    parentPath: "m/44'/60'",
+    coinType: COIN_TYPE_ETHEREUM,
+    network: CryptoCoinInfoNetwork.mainnet,
+    source: 'account.standard',
+  },
+];
+
+const BITGET_TARGET: ExportTarget = {
+  id: 'bitget',
+  label: 'Bitget',
+  keys: BITGET_KEYS,
+  buildUr: result =>
+    buildCryptoMultiAccountsUR(
+      result.masterFingerprint,
+      (result.keys as ExportedKey<BitgetEntry>[]).map(key => ({
+        derivationPath: key.entry.derivationPath,
+        exportRespData: key.exportRespData,
+        parentFingerprint: key.parentFingerprint,
+        coinType: key.entry.coinType,
+        network: key.entry.network,
+        source: key.entry.source,
+      })),
+    ),
+};
+
+export const EXPORT_TARGETS: readonly ExportTarget[] = [
+  ethereumTarget('ethereum', 'Ethereum', 'account.standard'),
+  bitcoinTarget('bitcoin', 'Bitcoin', [
+    {
+      derivationPath: "m/84'/0'/0'",
+      parentPath: "m/84'/0'",
+      scriptType: 'wpkh',
+    },
+    {
+      derivationPath: "m/49'/0'/0'",
+      parentPath: "m/49'/0'",
+      scriptType: 'sh-wpkh',
+    },
+    {
+      derivationPath: "m/44'/0'/0'",
+      parentPath: "m/44'/0'",
+      scriptType: 'pkh',
+    },
+  ]),
+  bitcoinTarget('bitcoin-multisig', 'Bitcoin Multisig', [
+    {
+      derivationPath: "m/48'/0'/0'/2'",
+      parentPath: "m/48'/0'/0'",
+      scriptType: 'wsh',
+    },
+    {
+      derivationPath: "m/48'/0'/0'/1'",
+      parentPath: "m/48'/0'/0'",
+      scriptType: 'sh-wsh',
+    },
+    { derivationPath: "m/45'", parentPath: 'm', scriptType: 'sh' },
+  ]),
+  bitcoinTarget('bitcoin-testnet', 'Bitcoin Testnet', [
+    {
+      derivationPath: "m/84'/1'/0'",
+      parentPath: "m/84'/1'",
+      scriptType: 'wpkh',
+    },
+    {
+      derivationPath: "m/49'/1'/0'",
+      parentPath: "m/49'/1'",
+      scriptType: 'sh-wpkh',
+    },
+    {
+      derivationPath: "m/44'/1'/0'",
+      parentPath: "m/44'/1'",
+      scriptType: 'pkh',
+    },
+  ]),
+  BITGET_TARGET,
+  ethereumTarget('ledger-live', 'Ledger Live', 'account.ledger_live'),
+  ethereumTarget('ledger-legacy', 'Ledger Legacy', 'account.ledger_legacy'),
+];
+
+export function getExportTarget(id: ExportTargetId): ExportTarget {
+  const target = EXPORT_TARGETS.find(t => t.id === id);
+  if (!target) {
+    throw new Error(`Unknown export target: ${id}`);
+  }
+  return target;
+}

--- a/src/utils/keycardExport.ts
+++ b/src/utils/keycardExport.ts
@@ -1,193 +1,72 @@
-/* eslint-disable no-bitwise */
 import Keycard from 'keycard-sdk';
 import type { Commandset } from 'keycard-sdk/dist/commandset';
 
-import {
-  buildCryptoAccountUR,
-  pubKeyFingerprint,
-  type BitcoinCryptoAccount,
-} from './cryptoAccount';
-import { buildCryptoHdKeyUR } from './cryptoHdKey';
-import {
-  buildCryptoMultiAccountsUR,
-  exportKeysForBitget,
-  type BitgetExportResult,
-} from './cryptoMultiAccounts';
+import { pubKeyFingerprint } from './cryptoAccount';
 
-export type ExportKeyResult =
-  | {
-      exportRespData: Uint8Array;
-      sourceFingerprint: number;
-      parentFingerprint: number;
-    }
-  | BitcoinCryptoAccount
-  | BitgetExportResult;
-
-type BitcoinDescriptorPlan = {
+/** One key an export target wants: the path to export and the parent path its fingerprint comes from. */
+export type ExportPlanEntry = {
   derivationPath: string;
   parentPath: string;
-  scriptType: BitcoinCryptoAccount['descriptors'][number]['scriptType'];
 };
 
-export function buildExportUr(
-  result: ExportKeyResult,
-  derivationPath: string,
-  source?: string,
-): string {
-  if ('exportRespData' in result) {
-    return buildCryptoHdKeyUR(
-      result.exportRespData,
-      derivationPath,
-      result.sourceFingerprint,
-      result.parentFingerprint,
-      source,
-    );
-  }
-  if ('keys' in result) {
-    return buildCryptoMultiAccountsUR(result);
-  }
-  return buildCryptoAccountUR(result);
+/** An exported key carrying the plan entry it was exported for, so per-key metadata travels with the key. */
+export type ExportedKey<E extends ExportPlanEntry = ExportPlanEntry> = {
+  entry: E;
+  exportRespData: Uint8Array;
+  parentFingerprint: number;
+};
+
+export type ExportKeysResult<E extends ExportPlanEntry = ExportPlanEntry> = {
+  masterFingerprint: number;
+  keys: ExportedKey<E>[];
+};
+
+function fingerprintFromExportResponse(data: Uint8Array): number {
+  return pubKeyFingerprint(Keycard.BIP32KeyPair.fromTLV(data).publicKey);
 }
 
-export async function exportKeyForWallet(
+/**
+ * The generic card-session executor for wallet exports: reads the master
+ * fingerprint once, then exports every planned key with its parent
+ * fingerprint (parents are fetched once per distinct path). Which keys to
+ * export and what UR to build from them is declared by an ExportTarget
+ * (see exportTargets.ts).
+ */
+export async function exportKeysForTarget<E extends ExportPlanEntry>(
   cmdSet: Commandset,
-  derivationPath: string,
+  entries: readonly E[],
   setStatus: (s: string) => void = () => {},
-): Promise<ExportKeyResult> {
-  if (derivationPath === 'bitget') {
-    return exportKeysForBitget(cmdSet, setStatus);
-  }
+): Promise<ExportKeysResult<E>> {
+  setStatus('Reading master key...');
+  const masterResp = await cmdSet.exportKey(0, true, 'm', false);
+  masterResp.checkOK();
+  const masterFingerprint = fingerprintFromExportResponse(masterResp.data);
 
-  if (!isBitcoinPath(derivationPath)) {
-    const masterResp = await cmdSet.exportKey(0, true, 'm', false);
-    masterResp.checkOK();
+  const parentFingerprints = new Map<string, number>([
+    ['m', masterFingerprint],
+  ]);
 
-    const parentPath = derivationPath.split('/').slice(0, -1).join('/') || 'm';
-    const parentResp = await cmdSet.exportKey(0, true, parentPath, false);
-    parentResp.checkOK();
+  const keys: ExportedKey<E>[] = [];
+  for (const [index, entry] of entries.entries()) {
+    setStatus(`Exporting key ${index + 1} of ${entries.length}...`);
 
-    const resp = await cmdSet.exportExtendedKey(0, derivationPath, false);
+    let parentFingerprint = parentFingerprints.get(entry.parentPath);
+    if (parentFingerprint === undefined) {
+      const parentResp = await cmdSet.exportKey(
+        0,
+        true,
+        entry.parentPath,
+        false,
+      );
+      parentResp.checkOK();
+      parentFingerprint = fingerprintFromExportResponse(parentResp.data);
+      parentFingerprints.set(entry.parentPath, parentFingerprint);
+    }
+
+    const resp = await cmdSet.exportExtendedKey(0, entry.derivationPath, false);
     resp.checkOK();
-    return {
-      exportRespData: resp.data,
-      sourceFingerprint: pubKeyFingerprint(
-        Keycard.BIP32KeyPair.fromTLV(masterResp.data).publicKey,
-      ),
-      parentFingerprint: pubKeyFingerprint(
-        Keycard.BIP32KeyPair.fromTLV(parentResp.data).publicKey,
-      ),
-    };
+    keys.push({ entry, exportRespData: resp.data, parentFingerprint });
   }
 
-  const rootResp = await cmdSet.exportKey(0, true, 'm', false);
-  rootResp.checkOK();
-  const masterFingerprint = pubKeyFingerprint(
-    Keycard.BIP32KeyPair.fromTLV(rootResp.data).publicKey,
-  );
-
-  const descriptors: BitcoinCryptoAccount['descriptors'] = [];
-  for (const descriptor of bitcoinDescriptorPlan(derivationPath)) {
-    const keyResp = await cmdSet.exportExtendedKey(
-      0,
-      descriptor.derivationPath,
-      false,
-    );
-    keyResp.checkOK();
-
-    const parentResp = await cmdSet.exportKey(
-      0,
-      true,
-      descriptor.parentPath,
-      false,
-    );
-    parentResp.checkOK();
-
-    descriptors.push({
-      derivationPath: descriptor.derivationPath,
-      exportRespData: keyResp.data,
-      parentFingerprint: pubKeyFingerprint(
-        Keycard.BIP32KeyPair.fromTLV(parentResp.data).publicKey,
-      ),
-      scriptType: descriptor.scriptType,
-    });
-  }
-
-  return {
-    masterFingerprint,
-    descriptors,
-  };
-}
-
-function isBitcoinMultisigPath(path: string) {
-  return /^m\/48'\/0'\/\d+'\/2'$/.test(path);
-}
-
-function isBitcoinPath(path: string) {
-  return /^m\/(44'|49'|84'|48')\/(0'|1')\//.test(path);
-}
-
-function parsePath(path: string): number[] {
-  const parts = path.split('/').slice(1);
-  return parts.map(part => {
-    const hardened = part.endsWith("'");
-    const value = parseInt(hardened ? part.slice(0, -1) : part, 10);
-    return hardened ? value | 0x80000000 : value;
-  });
-}
-
-function formatPath(parts: number[]): string {
-  return (
-    'm/' +
-    parts
-      .map(part => {
-        const hardened = (part & 0x80000000) !== 0;
-        const value = part & 0x7fffffff;
-        return `${value}${hardened ? "'" : ''}`;
-      })
-      .join('/')
-  );
-}
-
-function bitcoinDescriptorPlan(path: string): BitcoinDescriptorPlan[] {
-  const parts = parsePath(path);
-
-  if (isBitcoinMultisigPath(path)) {
-    const [purpose, coin, account] = parts;
-    return [
-      {
-        derivationPath: formatPath([purpose, coin, account, 0x80000002]),
-        parentPath: formatPath([purpose, coin, account]),
-        scriptType: 'wsh',
-      },
-      {
-        derivationPath: formatPath([purpose, coin, account, 0x80000001]),
-        parentPath: formatPath([purpose, coin, account]),
-        scriptType: 'sh-wsh',
-      },
-      {
-        derivationPath: "m/45'",
-        parentPath: 'm',
-        scriptType: 'sh',
-      },
-    ];
-  }
-
-  const [, coin, account] = parts;
-  return [
-    {
-      derivationPath: formatPath([0x80000054, coin, account]),
-      parentPath: formatPath([0x80000054, coin]),
-      scriptType: 'wpkh',
-    },
-    {
-      derivationPath: formatPath([0x80000031, coin, account]),
-      parentPath: formatPath([0x80000031, coin]),
-      scriptType: 'sh-wpkh',
-    },
-    {
-      derivationPath: formatPath([0x8000002c, coin, account]),
-      parentPath: formatPath([0x8000002c, coin]),
-      scriptType: 'pkh',
-    },
-  ];
+  return { masterFingerprint, keys };
 }

--- a/src/utils/keycardFlows.ts
+++ b/src/utils/keycardFlows.ts
@@ -14,7 +14,8 @@ import {
   buildEthSignatureURFromResult,
   buildRawEthHexSignature,
 } from './ethSignature';
-import { buildExportUr, exportKeyForWallet } from './keycardExport';
+import { getExportTarget } from './exportTargets';
+import { exportKeysForTarget, type ExportKeysResult } from './keycardExport';
 
 /**
  * What happens after the card operation succeeds. 'ur' outcomes navigate to
@@ -164,12 +165,13 @@ function prepareBtcMessageSign(params: BtcMessageParams): KeycardFlowRun {
 }
 
 function prepareExportKey(params: ExportKeyParams): KeycardFlowRun {
-  return flow<Awaited<ReturnType<typeof exportKeyForWallet>>>({
+  const target = getExportTarget(params.target);
+  return flow<ExportKeysResult>({
     cardOp: (cmdSet, setStatus) =>
-      exportKeyForWallet(cmdSet, params.derivationPath, setStatus),
+      exportKeysForTarget(cmdSet, target.keys, setStatus),
     buildOutput: result => ({
       kind: 'ur',
-      urString: buildExportUr(result, params.derivationPath, params.source),
+      urString: target.buildUr(result),
       title: 'Show key to the wallet',
       description: XPUB_EXPLAINER,
       doneNavigation: 'export',


### PR DESCRIPTION
Closes #238

## Summary

"Wallet export target" had no module. A parameter named `derivationPath` sometimes carried the sentinel string `'bitget'`, routing regex-sniffed path shapes (`isBitcoinPath`), Bitget's card I/O lived inside the crypto-multi-accounts UR builder, fingerprints were derived by two different mechanisms (`BIP32KeyPair.fromTLV` vs manual BERTLV walking), and `BITGET_KEYS[i]` coupled export order to builder metadata by array position, so a reorder would silently mis-tag coin types. `buildExportUr` duck-typed a three-way result union that its caller re-discriminated.

Now:

- **`src/utils/exportTargets.ts`** declares each of the seven wallet targets as data: id, menu label, the exact BIP32 paths to export (each with the parent path its fingerprint comes from, plus per-key metadata: script types for Bitcoin, coin info and EIP-4527 source for Bitget), and a pure `buildUr`. The ExportKey menu is a `map` over the table; adding a wallet target is one entry.
- **`exportKeysForTarget`** in `keycardExport.ts` is the one generic card-session executor: master fingerprint read once, each distinct parent path fetched once (multisig's `m/45'` reuses the master read, so Bitcoin and multisig taps issue fewer card commands), one fingerprint mechanism. Each exported key embeds its plan entry, so metadata travels with the key instead of being matched up by position.
- **`cryptoMultiAccounts.ts`** is now a pure builder like its two siblings: exported-key data in, UR out, no card I/O.
- **Keycard route params are honest**: `{ operation: 'export_key', target: ExportTargetId }` instead of a path-as-selector plus magic source strings spelled across three files.

Deleted: the `'bitget'` sentinel, `isBitcoinPath`/`bitcoinDescriptorPlan`/`parsePath`/`formatPath`, `exportKeyForWallet`, `buildExportUr` and its `ExportKeyResult` union, `exportKeysForBitget`, and the BERTLV fingerprint path.

## Test plan

- New `__tests__/exportTargets.test.ts`: plans asserted as data (paths, parents, script types per target) plus buildUr wiring for all three builder families
- `__tests__/keycardExport.test.ts` rewritten for the executor: parent-fingerprint caching, master reuse for `parentPath 'm'`, progress statuses, plan-entry embedding, response checking
- Both new modules at 100% branch coverage; cryptoMultiAccounts, KeycardScreen, keycardFlows, and ExportKeyScreen suites updated
- Full suite 1464 passed; ESLint, Prettier, and tsc clean

## Notes

- Builds on #235: this swaps only the export flow entry's internals, exactly as planned there
- Exported URs are byte-identical for all seven targets: same paths, same fingerprint sources, same builder arguments (pinned by the wiring tests)
