### PR TITLE
refactor: extract WalletConnect proposal validation into a pure shared module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Ethereum signature `v` is now derived from the classified payload kind instead of sniffing the first byte of the payload: a personal-sign message or EIP-712 digest that happened to start with `0x01`/`0x02` no longer produces an invalid signature (`v = recId` instead of `27 + recId`)
 - Signing a malformed PSBT or failing to encode the result QR now shows an error screen instead of crashing or doing nothing
 - Navigating back during an active Keycard tap now cancels the NFC session on every Keycard screen; previously only Initialize Card and Change PIN/PUK did this, leaving the session running elsewhere
+- The WalletConnect pairing screen's unsupported-proposal banner and the rejection reason sent to the dApp now come from one shared check with identical wording; previously the two could disagree about the same proposal
 - Generated recovery-phrase list: two-digit word numbers (`10.`, `11.`, `12.`) no longer wrap onto a second line on iOS; the number column is now auto-width
 
 ## [1.8.0] - 2026-06-30

--- a/__tests__/proposalPolicy.test.ts
+++ b/__tests__/proposalPolicy.test.ts
@@ -1,0 +1,146 @@
+import type { SessionProposalEvent } from '../src/providers/walletConnect/context';
+import {
+  resolveNamespaces,
+  validateProposal,
+} from '../src/utils/walletConnect/proposalPolicy';
+
+function proposal(params: {
+  required?: Record<string, { chains?: string[]; methods: string[] }>;
+  optional?: Record<string, { chains?: string[]; methods: string[] }>;
+}): SessionProposalEvent {
+  return {
+    id: 1,
+    params: {
+      id: 1,
+      expiryTimestamp: 0,
+      proposer: { metadata: { name: 'App', url: '', icons: [] } },
+      requiredNamespaces: params.required ?? {},
+      optionalNamespaces: params.optional ?? {},
+    },
+  } as SessionProposalEvent;
+}
+
+describe('validateProposal', () => {
+  it('accepts a proposal with supported required chains and methods', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+      }),
+    );
+    expect(verdict).toEqual({ ok: true });
+  });
+
+  it('accepts a proposal with no required namespaces', () => {
+    expect(validateProposal(proposal({}))).toEqual({ ok: true });
+  });
+
+  it('rejects non-eip155 required namespaces, naming them', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          eip155: { chains: ['eip155:1'], methods: [] },
+          cosmos: { chains: ['cosmos:cosmoshub-4'], methods: [] },
+        },
+      }),
+    );
+    expect(verdict).toEqual({
+      ok: false,
+      reason: 'Required namespaces not supported: cosmos',
+    });
+  });
+
+  it('rejects unsupported required chains, naming them', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          eip155: { chains: ['eip155:1', 'eip155:56'], methods: [] },
+        },
+      }),
+    );
+    expect(verdict).toEqual({
+      ok: false,
+      reason: 'Required chains not supported: eip155:56',
+    });
+  });
+
+  it('rejects unsupported required methods, naming them', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          eip155: {
+            chains: ['eip155:1'],
+            methods: ['personal_sign', 'eth_sendTransaction'],
+          },
+        },
+      }),
+    );
+    expect(verdict).toEqual({
+      ok: false,
+      reason: 'Required methods not supported: eth_sendTransaction',
+    });
+  });
+
+  it('unsupported optional chains and methods do not reject', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optional: {
+          eip155: { chains: ['eip155:56'], methods: ['eth_sendTransaction'] },
+        },
+      }),
+    );
+    expect(verdict).toEqual({ ok: true });
+  });
+
+  it('namespace problems take precedence over chain and method problems', () => {
+    const verdict = validateProposal(
+      proposal({
+        required: {
+          cosmos: { chains: [], methods: [] },
+          eip155: { chains: ['eip155:56'], methods: ['eth_sendTransaction'] },
+        },
+      }),
+    );
+    expect(verdict).toEqual({
+      ok: false,
+      reason: 'Required namespaces not supported: cosmos',
+    });
+  });
+});
+
+describe('resolveNamespaces', () => {
+  it('approves the intersection of requested and supported chains and methods', () => {
+    const resolved = resolveNamespaces(
+      proposal({
+        required: {
+          eip155: { chains: ['eip155:1'], methods: ['personal_sign'] },
+        },
+        optional: {
+          eip155: {
+            chains: ['eip155:137', 'eip155:56'],
+            methods: ['eth_signTypedData_v4', 'eth_sendTransaction'],
+          },
+        },
+      }),
+    );
+    expect(resolved.approvedChains).toEqual(['eip155:1', 'eip155:137']);
+    expect(resolved.approvedMethods).toEqual([
+      'personal_sign',
+      'eth_signTypedData_v4',
+    ]);
+  });
+
+  it('falls back to every supported chain and method when none are requested', () => {
+    const resolved = resolveNamespaces(proposal({}));
+    expect(resolved.approvedChains).toContain('eip155:1');
+    expect(resolved.approvedChains.length).toBeGreaterThan(1);
+    expect(resolved.approvedMethods).toContain('personal_sign');
+    expect(resolved.unsupportedNamespaces).toEqual([]);
+    expect(resolved.unsupportedRequired).toEqual([]);
+    expect(resolved.unsupportedRequiredChains).toEqual([]);
+  });
+});

--- a/src/providers/walletConnect/Provider.online.tsx
+++ b/src/providers/walletConnect/Provider.online.tsx
@@ -7,13 +7,13 @@ import React, {
 } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 
-import {
-  SUPPORTED_WC_EIP155_CHAIN_IDS,
-  SUPPORTED_WC_METHODS,
-  WCContext,
-} from '@/constants/walletConnect';
+import { SUPPORTED_WC_METHODS, WCContext } from '@/constants/walletConnect';
 import { navigationRef } from '@/navigation/navigationRef';
 import { wcClient } from '@/utils/walletConnect/client.online';
+import {
+  resolveNamespaces,
+  validateProposal,
+} from '@/utils/walletConnect/proposalPolicy';
 import { wcRequestToScanResult } from '@/utils/walletConnect/requestAdapter';
 
 import {
@@ -25,60 +25,9 @@ import {
   WCRequest,
 } from './context';
 
+// Incoming session_request method gate — proposal-time policy lives in
+// utils/walletConnect/proposalPolicy.ts.
 const SUPPORTED_METHODS: string[] = [...SUPPORTED_WC_METHODS];
-
-type ResolvedNamespaces = {
-  approvedChains: string[];
-  approvedMethods: string[];
-  unsupportedNamespaces: string[];
-  unsupportedRequired: string[];
-  unsupportedRequiredChains: string[];
-};
-
-function resolveNamespaces(proposal: SessionProposalEvent): ResolvedNamespaces {
-  const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
-  const unsupportedNamespaces = Object.keys(
-    proposal.params.requiredNamespaces,
-  ).filter(ns => ns !== 'eip155');
-
-  const requiredChains =
-    proposal.params.requiredNamespaces.eip155?.chains ?? [];
-  const optionalChains =
-    proposal.params.optionalNamespaces?.eip155?.chains ?? [];
-  const requestedChains = [...new Set([...requiredChains, ...optionalChains])];
-  const approvedChains =
-    requestedChains.length > 0
-      ? requestedChains.filter(c => supported.includes(c))
-      : supported;
-
-  const requiredMethods =
-    proposal.params.requiredNamespaces.eip155?.methods ?? [];
-  const optionalMethods =
-    proposal.params.optionalNamespaces?.eip155?.methods ?? [];
-  const requestedMethods = [
-    ...new Set([...requiredMethods, ...optionalMethods]),
-  ];
-  const approvedMethods =
-    requestedMethods.length > 0
-      ? requestedMethods.filter(m => SUPPORTED_METHODS.includes(m))
-      : SUPPORTED_METHODS;
-
-  const unsupportedRequired = requiredMethods.filter(
-    m => !SUPPORTED_METHODS.includes(m),
-  );
-
-  const unsupportedRequiredChains = requiredChains.filter(
-    c => !supported.includes(c),
-  );
-
-  return {
-    approvedChains,
-    approvedMethods,
-    unsupportedNamespaces,
-    unsupportedRequired,
-    unsupportedRequiredChains,
-  };
-}
 
 export function WalletConnectProvider({
   children,
@@ -260,34 +209,12 @@ export function WalletConnectProvider({
         return;
       }
       const { proposal } = currentPhase;
-      const {
-        approvedChains,
-        approvedMethods,
-        unsupportedNamespaces,
-        unsupportedRequired,
-        unsupportedRequiredChains,
-      } = resolveNamespaces(proposal);
-
-      if (
-        unsupportedNamespaces.length > 0 ||
-        unsupportedRequiredChains.length > 0 ||
-        unsupportedRequired.length > 0
-      ) {
-        const reason =
-          unsupportedNamespaces.length > 0
-            ? `Required namespaces not supported: ${unsupportedNamespaces.join(
-                ', ',
-              )}`
-            : unsupportedRequiredChains.length > 0
-            ? `Required chains not supported: ${unsupportedRequiredChains.join(
-                ', ',
-              )}`
-            : `Required methods not supported: ${unsupportedRequired.join(
-                ', ',
-              )}`;
-        await rejectProposal(proposal, reason);
+      const verdict = validateProposal(proposal);
+      if (!verdict.ok) {
+        await rejectProposal(proposal, verdict.reason);
         return;
       }
+      const { approvedChains, approvedMethods } = resolveNamespaces(proposal);
 
       addressPathRef.current.set(address.toLowerCase(), derivationPath);
       setPhase('approving');

--- a/src/screens/WalletConnectPairingScreen/index.tsx
+++ b/src/screens/WalletConnectPairingScreen/index.tsx
@@ -4,16 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { WalletConnectPairingScreenProps } from '@/navigation/types';
-import {
-  SUPPORTED_WC_EIP155_CHAIN_IDS,
-  SUPPORTED_WC_METHODS,
-} from '@/constants/walletConnect';
 import { useKeycardOp } from '@/hooks/keycard/useKeycardOperation';
 import { useWalletConnectSession } from '@/hooks/useWalletConnectSession.online';
 import type { SessionProposalEvent } from '@/providers/walletConnect/context';
 import { getChainName } from '@/utils/chainMetadata';
 import { pubKeyToEthAddress } from '@/utils/ethereumAddress';
 import { deriveAddresses } from '@/utils/hdAddress';
+import { validateProposal } from '@/utils/walletConnect/proposalPolicy';
 
 import AddressSelectionPhase from './AddressSelectionPhase';
 import ApprovingPhase from './ApprovingPhase';
@@ -206,34 +203,10 @@ export default function WalletConnectPairingScreen({
 
   const proposalError = useMemo(() => {
     if (!proposal) return null;
-    const requiredNamespaces = proposal.params.requiredNamespaces ?? {};
-    const unsupportedNamespaces = Object.keys(requiredNamespaces).filter(
-      ns => ns !== 'eip155',
-    );
-    if (unsupportedNamespaces.length > 0) {
-      return `Required namespaces not supported: ${unsupportedNamespaces.join(
-        ', ',
-      )}`;
-    }
-
-    const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
-    const requiredChains = requiredNamespaces.eip155?.chains ?? [];
-    const unsupportedChains = requiredChains.filter(
-      c => !supported.includes(c),
-    );
-    if (unsupportedChains.length > 0) {
-      return `Required chains not supported: ${unsupportedChains
-        .map(c => c.replace('eip155:', ''))
-        .join(', ')}`;
-    }
-    const requiredMethods = requiredNamespaces.eip155?.methods ?? [];
-    const unsupported = requiredMethods.filter(
-      m => !(SUPPORTED_WC_METHODS as readonly string[]).includes(m),
-    );
-    if (unsupported.length > 0) {
-      return `Required methods not supported: ${unsupported.join(', ')}`;
-    }
-    return null;
+    // Same policy the provider rejects with — banner and rejection reason
+    // are composed from one verdict and cannot drift.
+    const verdict = validateProposal(proposal);
+    return verdict.ok ? null : verdict.reason;
   }, [proposal]);
 
   if (localPhase === 'pairing') {

--- a/src/utils/walletConnect/proposalPolicy.ts
+++ b/src/utils/walletConnect/proposalPolicy.ts
@@ -1,0 +1,107 @@
+import {
+  SUPPORTED_WC_EIP155_CHAIN_IDS,
+  SUPPORTED_WC_METHODS,
+} from '@/constants/walletConnect';
+import type { SessionProposalEvent } from '@/providers/walletConnect/context';
+
+const SUPPORTED_METHODS: string[] = [...SUPPORTED_WC_METHODS];
+
+export type ResolvedNamespaces = {
+  approvedChains: string[];
+  approvedMethods: string[];
+  unsupportedNamespaces: string[];
+  unsupportedRequired: string[];
+  unsupportedRequiredChains: string[];
+};
+
+/**
+ * The WalletConnect allowlist policy: which of a proposal's namespaces,
+ * chains, and methods this wallet supports. The provider (session rejection)
+ * and the pairing screen (pre-NFC banner) both consume this module, so the
+ * reason sent to the dApp and the banner shown to the user can never drift.
+ */
+export function resolveNamespaces(
+  proposal: SessionProposalEvent,
+): ResolvedNamespaces {
+  const supported = SUPPORTED_WC_EIP155_CHAIN_IDS.map(id => `eip155:${id}`);
+  const unsupportedNamespaces = Object.keys(
+    proposal.params.requiredNamespaces,
+  ).filter(ns => ns !== 'eip155');
+
+  const requiredChains =
+    proposal.params.requiredNamespaces.eip155?.chains ?? [];
+  const optionalChains =
+    proposal.params.optionalNamespaces?.eip155?.chains ?? [];
+  const requestedChains = [...new Set([...requiredChains, ...optionalChains])];
+  const approvedChains =
+    requestedChains.length > 0
+      ? requestedChains.filter(c => supported.includes(c))
+      : supported;
+
+  const requiredMethods =
+    proposal.params.requiredNamespaces.eip155?.methods ?? [];
+  const optionalMethods =
+    proposal.params.optionalNamespaces?.eip155?.methods ?? [];
+  const requestedMethods = [
+    ...new Set([...requiredMethods, ...optionalMethods]),
+  ];
+  const approvedMethods =
+    requestedMethods.length > 0
+      ? requestedMethods.filter(m => SUPPORTED_METHODS.includes(m))
+      : SUPPORTED_METHODS;
+
+  const unsupportedRequired = requiredMethods.filter(
+    m => !SUPPORTED_METHODS.includes(m),
+  );
+
+  const unsupportedRequiredChains = requiredChains.filter(
+    c => !supported.includes(c),
+  );
+
+  return {
+    approvedChains,
+    approvedMethods,
+    unsupportedNamespaces,
+    unsupportedRequired,
+    unsupportedRequiredChains,
+  };
+}
+
+export type ProposalVerdict = { ok: true } | { ok: false; reason: string };
+
+/** One verdict for both surfaces: the dApp rejection reason and the user-facing banner. */
+export function validateProposal(
+  proposal: SessionProposalEvent,
+): ProposalVerdict {
+  const {
+    unsupportedNamespaces,
+    unsupportedRequired,
+    unsupportedRequiredChains,
+  } = resolveNamespaces(proposal);
+
+  if (unsupportedNamespaces.length > 0) {
+    return {
+      ok: false,
+      reason: `Required namespaces not supported: ${unsupportedNamespaces.join(
+        ', ',
+      )}`,
+    };
+  }
+  if (unsupportedRequiredChains.length > 0) {
+    return {
+      ok: false,
+      reason: `Required chains not supported: ${unsupportedRequiredChains.join(
+        ', ',
+      )}`,
+    };
+  }
+  if (unsupportedRequired.length > 0) {
+    return {
+      ok: false,
+      reason: `Required methods not supported: ${unsupportedRequired.join(
+        ', ',
+      )}`,
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Closes #239

## Summary

The WalletConnect allowlist policy (which namespaces, chains, and methods a proposal may require, and how to word the rejection) was computed twice: `resolveNamespaces`, module-private inside the provider, and a 30-line `proposalError` memo re-implementing the same checks in the pairing screen. Because the policy was private, both copies were only testable through render harnesses, and they had already drifted: the screen stripped the `eip155:` prefix from unsupported chain ids while the provider sent it raw, so the user's banner and the dApp's rejection reason disagreed about the same proposal.

Now `src/utils/walletConnect/proposalPolicy.ts` owns the policy (a sibling of `requestAdapter.ts`, same shape: pure, exhaustively unit-tested):

- `resolveNamespaces(proposal)` moved verbatim from the provider
- `validateProposal(proposal)` returns `{ ok: true }` or `{ ok: false, reason }` with one wording

The provider's approve guard collapses to `validateProposal` + `rejectProposal(proposal, verdict.reason)`; the screen's banner renders the same `verdict.reason`. The session_request method gate stays in the provider (a different concern, request-time rather than proposal-time).

## Behavior change

The banner and the dApp rejection now carry identical wording, unified on the raw namespace-qualified form (`eip155:56`). Previously the banner showed stripped ids while the dApp got the raw ones.

## Test plan

- New `__tests__/proposalPolicy.test.ts`: 9 table tests at 100% branch coverage — accept paths, all three reject reasons with exact wording, optional-vs-required distinction, namespace > chains > methods precedence, and `resolveNamespaces` intersection/fallback behavior
- Provider and pairing-screen suites unchanged and green; they now pin the wiring rather than re-covering policy permutations
- Full suite 1473 passed; ESLint, Prettier, tsc, and the offline bundle guard clean

## Notes

- The module is shared-safe like `requestAdapter.ts`: type-only import of `SessionProposalEvent`, no online-only packages; it is only reachable from `.online` modules anyway
- Closes the second of the two duplicated-policy findings from the architecture review; #240 (address enumeration) is the remaining WalletConnect-adjacent one
